### PR TITLE
fix: use full clone in CI and guard diff tests against shallow repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         neovim_version: ['stable', 'nightly']
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -30,6 +30,8 @@ describe("raccoon.git commit operations", function()
   -- Detect whether origin/main is reachable (may be absent in CI shallow clones,
   -- repos with master default branch, or repos without an origin remote)
   local has_origin_main = vim.fn.system("git rev-parse --verify origin/main 2>/dev/null"):match("^%x+") ~= nil
+  local is_shallow = vim.fn.system("git rev-parse --is-shallow-repository"):match("true") ~= nil
+  local can_diff = has_origin_main and not is_shallow
 
   describe("new functions exist", function()
     it("has unshallow_if_needed function", function()
@@ -124,7 +126,7 @@ describe("raccoon.git commit operations", function()
 
   describe("show_commit on current repo", function()
     it("returns file diffs for a commit", function()
-      if not has_origin_main then return end
+      if not can_diff then return end
 
       local done = false
       local sha = nil
@@ -158,7 +160,7 @@ describe("raccoon.git commit operations", function()
     end)
 
     it("never returns dev/null as filename", function()
-      if not has_origin_main then return end
+      if not can_diff then return end
 
       local done = false
       local sha = nil
@@ -193,7 +195,7 @@ describe("raccoon.git commit operations", function()
 
   describe("show_commit_file on current repo", function()
     it("returns full-context patch for a file", function()
-      if not has_origin_main then return end
+      if not can_diff then return end
 
       local done = false
       local sha = nil


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to the test job's `actions/checkout@v4` step so git history is available for `diff-tree` operations
- Add `is_shallow` / `can_diff` guards to `show_commit` and `show_commit_file` tests as defense-in-depth against shallow clone environments

The CI failure (run #21783999876) was caused by GitHub Actions defaulting to a shallow clone (depth=1). The `show_commit_file` test calls `git diff-tree` which needs a parent commit to compute diffs — in a shallow clone the root commit has no parent, producing empty output and failing the assertion at `commits_spec.lua:221`.

## Test plan
- [x] `make lint` passes (0 warnings / 0 errors)
- [x] `make test` passes locally (63 success, 0 failed)
- [ ] CI passes on both stable and nightly Neovim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed CI test failures caused by shallow git clones (depth=1) by adding `fetch-depth: 0` to the checkout step and adding defensive guards in tests.

- Added `fetch-depth: 0` to `actions/checkout@v4` in the test job so full git history is available for `git diff-tree` operations
- Added `is_shallow` detection using `git rev-parse --is-shallow-repository` 
- Created combined `can_diff` guard that checks both `has_origin_main` and `not is_shallow` to skip tests that require parent commits
- Updated 3 test cases to use `can_diff` instead of just `has_origin_main`

The fix addresses the root cause (shallow clone in CI) while also adding defense-in-depth to prevent similar failures in other shallow repo environments.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues
- The changes correctly address the CI failure with a proper fix (full clone) and appropriate defensive guards. The implementation is clean, follows existing patterns in the test file, and the logic for detecting shallow repos and skipping tests is sound.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Added `fetch-depth: 0` to enable full git history for diff operations in tests |
| tests/commits_spec.lua | Added shallow repo detection and guard to skip diff tests when git history unavailable |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->