### PR TITLE
ci: add auto-tag workflow on VERSION bump

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,28 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths: [VERSION]
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version and create tag
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+          fi


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically creates a `v{version}` git tag whenever the `VERSION` file changes on main
- Idempotent — skips if tag already exists
- No third-party actions — just `actions/checkout` and git commands

## How it works
1. Workflow triggers on push to `main` only when `VERSION` file changes (`paths: [VERSION]`)
2. Reads version from `VERSION` file
3. Checks if `v{version}` tag exists
4. Creates and pushes tag if it doesn't

## Test plan
- [ ] Merge this PR, then bump VERSION in a follow-up — verify tag is auto-created in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a GitHub Actions workflow (`.github/workflows/auto-tag.yml`) that triggers on pushes to `main` when the `VERSION` file changes, reads the version, and creates/pushes a corresponding `v{version}` git tag if it doesn’t already exist.

The overall approach matches the repository’s release/versioning mechanism (VERSION bump), and uses only `actions/checkout` plus git commands with `contents: write` permissions.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; one small logic fix is needed to ensure tags are created reliably.
- Workflow is minimal and correctly scoped to VERSION changes on main with proper permissions and full fetch. The remaining concern is the tag existence check: using `git rev-parse` without tag scoping can falsely detect non-tag refs and skip creating the tag.
- .github/workflows/auto-tag.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/auto-tag.yml | Adds a workflow to tag pushes to main when VERSION changes; core flow is correct, but tag existence check uses `git rev-parse` without `--verify`, which can mis-detect if a branch/remote with the same name exists. |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->