### PR TITLE
fix: use portable ~ path for clone_root in default config

### DIFF
--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -130,6 +130,8 @@ vim.api.nvim_create_user_command("Raccoon", function(opts)
     -- Create default config if file doesn't exist
     if vim.fn.filereadable(config_path) == 0 then
       local clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos")
+      local home = vim.fn.expand("~")
+      clone_root = clone_root:gsub("^" .. vim.pesc(home), "~")
       local default_config = string.format([[{
   "github_username": "your-username",
   "github_host": "github.com",


### PR DESCRIPTION
## Summary
- When `:Raccoon config` creates a new config file, `clone_root` was resolved to an absolute path (e.g., `/home/m/.local/share/nvim/raccoon/repos`), leaking the user's home directory
- Now replaces the home directory prefix with `~` before writing the template, producing `~/.local/share/nvim/raccoon/repos`

## Test plan
- [ ] Delete `~/.config/raccoon/config.json`, run `:Raccoon config`, verify `clone_root` uses `~` prefix
- [ ] `make test` passes (100 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed privacy issue where `:Raccoon config` was writing absolute paths (e.g., `/home/m/.local/share/nvim/raccoon/repos`) to the config file template, exposing the user's home directory. Now replaces the home directory prefix with `~` before writing, producing portable paths like `~/.local/share/nvim/raccoon/repos`.

**Key changes:**
- Uses `vim.fn.expand("~")` to get the home directory
- Uses `vim.pesc()` to properly escape Lua pattern metacharacters before pattern matching
- Replaces home prefix with `~` using `gsub` before string interpolation into the config template

**Compatibility:**
- Works seamlessly with existing `expand_path()` function in `lua/raccoon/config.lua:73-78` that expands `~` back to absolute paths when loading configs
- Maintains backward compatibility - configs with absolute paths continue to work
- Test suite confirms functionality with 100 tests passing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (2 lines), solves a clear privacy issue, uses proper Lua pattern escaping with `vim.pesc()`, integrates seamlessly with existing path expansion logic, and all 100 tests pass
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| plugin/raccoon.lua | Added home directory replacement with `~` prefix for `clone_root` in default config template to prevent leaking absolute paths |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->