### PR TITLE
feat: add COMBINED DIFF entry to commit viewer sidebar

### DIFF
--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -508,9 +508,14 @@ end
 function M.open_maximize(opts)
   local git = require("raccoon.git")
 
-  local fetch_patch = opts.is_working_dir
-    and function(cb) git.diff_working_dir_file(opts.repo_path, opts.filename, cb) end
-    or function(cb) git.show_commit_file(opts.repo_path, opts.sha, opts.filename, cb) end
+  local fetch_patch
+  if opts.is_working_dir then
+    fetch_patch = function(cb) git.diff_working_dir_file(opts.repo_path, opts.filename, cb) end
+  elseif opts.is_combined_diff then
+    fetch_patch = function(cb) git.diff_combined_file(opts.repo_path, opts.base_ref, opts.filename, cb) end
+  else
+    fetch_patch = function(cb) git.show_commit_file(opts.repo_path, opts.sha, opts.filename, cb) end
+  end
 
   fetch_patch(function(patch, err)
     if opts.get_generation() ~= opts.generation then return end
@@ -1113,6 +1118,9 @@ function M.setup_filetree_nav(s, opts)
     if not repo_path then return end
     local is_changed = s.commit_files and s.commit_files[path]
     local commit_msg = opts.get_commit_message and opts.get_commit_message() or ""
+    local git = require("raccoon.git")
+    local is_combined = sha == git.COMBINED_DIFF_SHA
+    local base_ref = opts.get_base_ref and opts.get_base_ref()
     if is_changed then
       M.open_maximize({
         ns_id = opts.ns_id,
@@ -1124,11 +1132,13 @@ function M.setup_filetree_nav(s, opts)
         get_generation = function() return s.select_generation end,
         state = s,
         is_working_dir = sha == nil,
+        is_combined_diff = is_combined,
+        base_ref = base_ref,
       })
     else
       M.open_file_content({
         repo_path = repo_path,
-        sha = sha,
+        sha = is_combined and "HEAD" or sha,
         filename = path,
         generation = s.select_generation,
         get_generation = function() return s.select_generation end,

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -11,6 +11,8 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
+local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
+
 --- Namespace for commit viewer highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_commits")
 
@@ -151,6 +153,9 @@ local function maximize_cell(cell_num)
   local clone_path = state.get_clone_path()
   if not commit or not clone_path then return end
 
+  local pr = state.get_pr()
+  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
+
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = clone_path,
@@ -160,6 +165,8 @@ local function maximize_cell(cell_num)
     generation = commit_state.select_generation,
     get_generation = function() return commit_state.select_generation end,
     state = commit_state,
+    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    base_ref = base_ref,
   })
 end
 
@@ -183,7 +190,14 @@ local function select_commit(index)
   if not clone_path then return end
 
   local context = ui.compute_grid_context(commit_state.grid_rows)
-  git.show_commit(clone_path, commit.sha, context, function(files, err)
+  local pr = state.get_pr()
+  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
+
+  local fetch_diff = commit.sha == COMBINED_DIFF_SHA
+    and function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
+    or function(cb) git.show_commit(clone_path, commit.sha, context, cb) end
+
+  fetch_diff(function(files, err)
     if generation ~= commit_state.select_generation then return end
 
     if err then
@@ -254,6 +268,9 @@ local function render_sidebar()
     section1_commits = commit_state.pr_commits,
     section2_header = "── Base Branch ──",
     section2_commits = commit_state.base_commits,
+    commit_hl_fn = function(commit)
+      if commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
+    end,
   })
   ui.update_sidebar_winbar(commit_state, total_commits())
   update_sidebar_selection()
@@ -310,6 +327,8 @@ build_filetree_cache = function()
   if not clone_path then return end
   local commit = get_commit(commit_state.selected_index)
   local sha = commit and commit.sha or "HEAD"
+  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
+  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(commit_state, clone_path, sha)
 end
 
@@ -392,6 +411,10 @@ local function setup_keymaps()
       local c = get_commit(commit_state.selected_index)
       return c and c.message or ""
     end,
+    get_base_ref = function()
+      local pr = state.get_pr()
+      return pr and ("origin/" .. pr.base.ref) or "origin/main"
+    end,
   })
 
   -- Focus lock autocmd
@@ -462,6 +485,12 @@ local function enter_commit_mode()
           vim.notify("No commits found on PR branch", vim.log.levels.WARN)
           M.toggle()
           return
+        end
+
+        -- Add combined diff entry at the top when there are multiple PR commits
+        if #commit_state.pr_commits > 1 then
+          table.insert(commit_state.pr_commits, 1,
+            { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
         end
 
         ui.create_grid_layout(commit_state, rows, cols)

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -964,4 +964,60 @@ function M.find_repo_root(path, callback)
   })
 end
 
+--- Sentinel SHA used for the "combined diff" synthetic commit entry.
+--- Must not collide with real SHAs or nil (which means working directory).
+M.COMBINED_DIFF_SHA = "__combined_diff__"
+
+--- Get the combined diff of all branch changes vs a base ref.
+--- Uses three-dot diff (merge-base to HEAD), matching what GitHub shows in "Files changed".
+---@param path string Repository path
+---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
+---@param context number|nil Lines of surrounding context
+---@param callback fun(files: table[]|nil, err: string|nil)
+function M.diff_combined(path, base_ref, context, callback)
+  local args = { "diff" }
+  if context and context > 0 then
+    table.insert(args, "-U" .. tostring(math.floor(context)))
+  end
+  table.insert(args, base_ref .. "...HEAD")
+  run_git(args, {
+    cwd = path,
+    on_exit = function(code, stdout, stderr)
+      if code ~= 0 then
+        callback(nil, table.concat(stderr, "\n"))
+        return
+      end
+      callback(parse_diff_output(stdout), nil)
+    end,
+  })
+end
+
+--- Get the combined diff for a single file (full context, for maximize view).
+---@param path string Repository path
+---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
+---@param filename string File path within the repo
+---@param callback fun(patch: string|nil, err: string|nil)
+function M.diff_combined_file(path, base_ref, filename, callback)
+  run_git({ "diff", "-U99999", base_ref .. "...HEAD", "--", filename }, {
+    cwd = path,
+    on_exit = function(code, stdout, stderr)
+      if code ~= 0 then
+        callback(nil, table.concat(stderr, "\n"))
+        return
+      end
+      local lines = {}
+      local in_patch = false
+      for _, line in ipairs(stdout) do
+        if line:match("^@@") then
+          in_patch = true
+        end
+        if in_patch then
+          table.insert(lines, line)
+        end
+      end
+      callback(table.concat(lines, "\n"), nil)
+    end,
+  })
+end
+
 return M

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -11,6 +11,8 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
+local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
+
 local ns_id = vim.api.nvim_create_namespace("raccoon_local_commits")
 
 local BATCH_SIZE = 100
@@ -127,6 +129,8 @@ local function maximize_cell(cell_num)
   local commit = get_commit(local_state.selected_index)
   if not commit or not local_state.repo_path then return end
 
+  local base_ref = local_state.merge_base_sha or local_state.base_branch
+
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = local_state.repo_path,
@@ -137,6 +141,8 @@ local function maximize_cell(cell_num)
     get_generation = function() return local_state.select_generation end,
     state = local_state,
     is_working_dir = commit.sha == nil,
+    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    base_ref = base_ref,
   })
 end
 
@@ -153,9 +159,16 @@ local function select_commit(index)
   if not local_state.repo_path then return end
 
   local context = ui.compute_grid_context(local_state.grid_rows)
-  local fetch_diff = commit.sha
-    and function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end
-    or function(cb) git.diff_working_dir(local_state.repo_path, context, cb) end
+  local base_ref = local_state.merge_base_sha or local_state.base_branch
+
+  local fetch_diff
+  if commit.sha == COMBINED_DIFF_SHA then
+    fetch_diff = function(cb) git.diff_combined(local_state.repo_path, base_ref, context, cb) end
+  elseif commit.sha then
+    fetch_diff = function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end
+  else
+    fetch_diff = function(cb) git.diff_working_dir(local_state.repo_path, context, cb) end
+  end
 
   fetch_diff(function(files, err)
     if generation ~= local_state.select_generation then return end
@@ -252,7 +265,7 @@ local function render_sidebar()
       section2_header = "── " .. local_state.base_branch .. " ──",
       section2_commits = local_state.base_commits,
       commit_hl_fn = function(commit)
-        if commit.sha == nil then return "DiagnosticInfo" end
+        if commit.sha == nil or commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
       end,
       loading = local_state.loading_more,
     })
@@ -358,6 +371,8 @@ build_filetree_cache = function()
   if not local_state.repo_path then return end
   local commit = get_commit(local_state.selected_index)
   local sha = (commit and commit.sha) or nil
+  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
+  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(local_state, local_state.repo_path, sha)
 end
 
@@ -494,6 +509,9 @@ local function setup_keymaps()
       local c = get_commit(local_state.selected_index)
       return c and c.message or ""
     end,
+    get_base_ref = function()
+      return local_state.merge_base_sha or local_state.base_branch
+    end,
   })
 
   -- Focus lock autocmd
@@ -585,7 +603,10 @@ local function refresh_commits()
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
       if err or not new_branch then return end
-      table.insert(new_branch, 1, { sha = nil, message = "Current changes" })
+      table.insert(new_branch, 1, { sha = nil, message = "CURRENT CHANGES" })
+      if #new_branch > 2 then
+        table.insert(new_branch, 2, { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+      end
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -596,7 +617,7 @@ local function refresh_commits()
     local count = math.max(total_commits() - 1, BATCH_SIZE)
     git.log_all_commits(local_state.repo_path, count, 0, function(new_commits, err)
       if err or not new_commits then return end
-      table.insert(new_commits, 1, { sha = nil, message = "Current changes" })
+      table.insert(new_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
       local_state.branch_commits = new_commits
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -719,7 +740,7 @@ local function enter_local_mode()
             vim.notify("No commits found", vim.log.levels.WARN)
             return
           end
-          table.insert(commits, 1, { sha = nil, message = "Current changes" })
+          table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
           local_state.branch_commits = commits
           activate_mode(repo_root, rows, cols,
             string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -737,7 +758,7 @@ local function enter_local_mode()
               return
             end
             local_state.current_branch = current_branch
-            table.insert(commits, 1, { sha = nil, message = "Current changes" })
+            table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
             local_state.branch_commits = commits
             activate_mode(repo_root, rows, cols,
               string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -755,7 +776,7 @@ local function enter_local_mode()
                 return
               end
               local_state.current_branch = current_branch
-              table.insert(commits, 1, { sha = nil, message = "Current changes" })
+              table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
               local_state.branch_commits = commits
               activate_mode(repo_root, rows, cols,
                 string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -770,7 +791,12 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
-            table.insert(branch_commits, 1, { sha = nil, message = "Current changes" })
+            table.insert(branch_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+            -- Add combined diff entry when there are multiple branch commits
+            if #branch_commits > 2 then -- >2 because index 1 is CURRENT CHANGES
+              table.insert(branch_commits, 2,
+                { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+            end
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch
             local_state.merge_base_sha = merge_sha


### PR DESCRIPTION
## Summary
- When a PR or local branch has more than 1 commit, adds a **COMBINED DIFF** entry at the top of the commit list in the sidebar
- Selecting it shows the full branch diff against the base branch (all changes merged into one view), equivalent to GitHub's "Files changed" tab
- Uses `DiagnosticInfo` highlight (same as CURRENT CHANGES) for visual distinction
- Renames "Current changes" to "CURRENT CHANGES" for consistency

## Changes
- **git.lua**: Added `diff_combined()` and `diff_combined_file()` using three-dot diff (`base...HEAD`) plus `COMBINED_DIFF_SHA` sentinel
- **commits.lua**: Prepends combined diff entry when PR has >1 commits, routes selection/maximize through combined diff git commands
- **localcommits.lua**: Same treatment for local branch mode (when >1 branch commits), also uppercases CURRENT CHANGES
- **commit_ui.lua**: `open_maximize()` and `setup_filetree_nav()` handle the combined diff case for full-file views

## Test plan
- [x] All 124 existing tests pass
- [ ] Open a PR with multiple commits → verify COMBINED DIFF appears at top of sidebar
- [ ] Select COMBINED DIFF → verify grid shows all branch changes combined
- [ ] Maximize a cell from COMBINED DIFF → verify full file diff works
- [ ] Open a PR with exactly 1 commit → verify no COMBINED DIFF entry appears
- [ ] Local branch mode with multiple commits → verify COMBINED DIFF and CURRENT CHANGES entries
- [ ] Navigate filetree while COMBINED DIFF is selected → verify file opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)