### PR TITLE
feat: add COMBINED DIFF entry and background sync for PR commit viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.11] - 2026-03-12
+## [0.11] - 2026-03-13
 
 ### Added
 - **Combined diff entry** in commit viewer sidebar — a synthetic "COMBINED DIFF" row at the top showing the three-dot diff (`base...HEAD`) of the entire PR, matching GitHub's "Files changed" view
-- **Background sync for PR commit viewer** — automatically fetches new commits from origin at a configurable interval and refreshes the sidebar and grid when changes are detected
+- **Background sync for PR commit viewer** — automatically fetches new commits from origin at a configurable interval and refreshes the sidebar and grid when changes are detected; selection is preserved across refreshes
 - `commit_viewer.sync_interval` config option (default 60 seconds, range 10–3600) to control background sync frequency
 - `git.ref_sha()`, `git.reset_hard()`, `git.diff_combined()`, `git.diff_combined_file()` helpers for combined diff and remote sync operations
 - PR list popup now opens correctly from within commit viewer mode without being blocked by focus lock (`global_popup_win`)
 - PR list floating window title now shows a close-key hint derived from config
+- Tests for combined diff helpers, `status_porcelain`, and `apply_diff_result` stale-callback handling
 
 ### Changed
+- Extracted `commit_ui.apply_diff_result()` shared helper — diff result processing (error handling, state updates, cache building, grid rendering) is now shared between PR and local commit viewers
+- Extracted combined-diff helpers (`make_combined_diff_entry`, `is_combined_diff`, `maybe_prepend_combined_diff`) into `git.lua`
+- Extracted shared exit teardown into `commit_ui.teardown_viewer()` to prevent ghost windows on exit
 - Extracted `strip_to_patch()` helper in `git.lua`, removing duplicated patch-extraction logic from `show_commit_file` and `diff_working_dir_file`
 - "Current changes" label in local mode normalized to `CURRENT_CHANGES_MSG` constant
 - Combined diff entry appears in both PR commit mode and local commit mode when there are multiple branch commits
 - Error messages in commit/diff operations now include the actual error string
+
+### Fixed
+- Commit viewer exit now switches to sidebar before `:only` so file tree doesn't survive teardown
+- Header window is closed on commit mode exit to prevent ghost UI
+- Poll timer seeded inside SHA callback to prevent race condition on first tick
+- `on_complete` threaded through `refresh_commits` to prevent `sync_in_flight` deadlock
+- Error handling added for silent failures across commit modules (diff, commit, and file operations)
 
 ## [0.10.3] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - PR list popup now opens correctly from within commit viewer mode without being blocked by focus lock (`global_popup_win`)
 - PR list floating window title now shows a close-key hint derived from config
 - Tests for combined diff helpers, `status_porcelain`, and `apply_diff_result` stale-callback handling
+- Tests for `teardown_viewer` cleanup, `apply_diff_result` error/empty-diff paths, `safe_close_timer`, `parse_viewer_config`, `make_base_state`, and session generation guard
 
 ### Changed
 - Extracted `commit_ui.apply_diff_result()` shared helper — diff result processing (error handling, state updates, cache building, grid rendering) is now shared between PR and local commit viewers
@@ -24,6 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - "Current changes" label in local mode normalized to `CURRENT_CHANGES_MSG` constant
 - Combined diff entry appears in both PR commit mode and local commit mode when there are multiple branch commits
 - Error messages in commit/diff operations now include the actual error string
+- Extracted `commit_ui.safe_close_timer()` — shared libuv timer cleanup with pcall and DEBUG-level failure logging, replacing 3 duplicated stop/close blocks
+- Extracted `commit_ui.parse_viewer_config()` — shared config parsing with default values and clamping, replacing duplicated config blocks in `commits.lua` and `localcommits.lua`
+- Extracted `commit_ui.make_base_state()` — shared base state table with ~25 UI fields, extended by each viewer module with mode-specific fields
+- Extracted `enter_flat_mode()` in `localcommits.lua` — replaces 3 copy-pasted fallback blocks in `enter_local_mode()`
+- Renamed `localcommits.get_base_ref()` to `get_local_base_ref()` to distinguish it from `commits.get_base_ref()` (different semantics: no "origin/" prefix, uses merge_base_sha)
+- Sync failure logging now escalates from DEBUG to WARN after 3 consecutive failures via `sync_fail_count` counter
+- Partial refresh failures in `commits.refresh_commits()` now log at WARN level identifying which section is stale
 
 ### Fixed
 - **Opening a new PR now properly exits any active viewer mode first** — selecting a PR from the picker while in commit viewer or local commit mode no longer opens the new PR inside the grid/filetree windows; the viewer is fully torn down before the new session starts
@@ -34,6 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Poll timer seeded inside SHA callback to prevent race condition on first tick
 - `on_complete` threaded through `refresh_commits` to prevent `sync_in_flight` deadlock
 - Error handling added for silent failures across commit modules (diff, commit, and file operations)
+- **Commit count display** in local mode now correctly excludes synthetic entries (COMBINED DIFF, CURRENT CHANGES) when both are prepended
+- **Session generation guard** in PR commit viewer — monotonic counter prevents stale async callbacks from corrupting a new session's state on rapid exit/re-enter
+- **Workdir poll failure tracking** in local commit viewer — consecutive failures are counted and polling stops after 5 failures with a WARN notification, preventing infinite silent retries
+- Timer creation failures in `localcommits.lua` now notify at WARN level instead of silently continuing
+- Added nil guard for `base_ref` in `commits.select_commit()` combined diff path, matching the existing `localcommits.lua` pattern
 
 ## [0.10.3] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - `github_host` configuration option for GitHub Enterprise support — set to your GHE hostname instead of the default `github.com`
-- `pull_changes_interval` configuration option to control how often the auto-sync timer checks for new commits (default: 300 seconds, minimum: 10 seconds)
+- `poll_interval_seconds` configuration option to control how often the auto-sync timer checks for new commits (default: 300 seconds, minimum: 10 seconds)
 - Comprehensive configuration reference documentation (`config_docs.md`)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11] - 2026-03-12
+
+### Added
+- **Combined diff entry** in commit viewer sidebar — a synthetic "COMBINED DIFF" row at the top showing the three-dot diff (`base...HEAD`) of the entire PR, matching GitHub's "Files changed" view
+- **Background sync for PR commit viewer** — automatically fetches new commits from origin at a configurable interval and refreshes the sidebar and grid when changes are detected
+- `commit_viewer.sync_interval` config option (default 60 seconds, range 10–3600) to control background sync frequency
+- `git.ref_sha()`, `git.reset_hard()`, `git.diff_combined()`, `git.diff_combined_file()` helpers for combined diff and remote sync operations
+- PR list popup now opens correctly from within commit viewer mode without being blocked by focus lock (`global_popup_win`)
+- PR list floating window title now shows a close-key hint derived from config
+
+### Changed
+- Extracted `strip_to_patch()` helper in `git.lua`, removing duplicated patch-extraction logic from `show_commit_file` and `diff_working_dir_file`
+- "Current changes" label in local mode normalized to `CURRENT_CHANGES_MSG` constant
+- Combined diff entry appears in both PR commit mode and local commit mode when there are multiple branch commits
+- Error messages in commit/diff operations now include the actual error string
+
 ## [0.10.3] - 2026-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Extracted `commit_ui.apply_diff_result()` shared helper — diff result processing (error handling, state updates, cache building, grid rendering) is now shared between PR and local commit viewers
 - Extracted combined-diff helpers (`make_combined_diff_entry`, `is_combined_diff`, `maybe_prepend_combined_diff`) into `git.lua`
 - Extracted shared exit teardown into `commit_ui.teardown_viewer()` to prevent ghost windows on exit
+- Added `state.set_mode_exit()` / `state.exit_active_mode()` callback mechanism so viewer modes register their cleanup with central state, avoiding circular dependencies between `open.lua` and viewer modules
 - Extracted `strip_to_patch()` helper in `git.lua`, removing duplicated patch-extraction logic from `show_commit_file` and `diff_working_dir_file`
 - "Current changes" label in local mode normalized to `CURRENT_CHANGES_MSG` constant
 - Combined diff entry appears in both PR commit mode and local commit mode when there are multiple branch commits
 - Error messages in commit/diff operations now include the actual error string
 
 ### Fixed
+- **Opening a new PR now properly exits any active viewer mode first** — selecting a PR from the picker while in commit viewer or local commit mode no longer opens the new PR inside the grid/filetree windows; the viewer is fully torn down before the new session starts
+- Closing a PR session (`:Raccoon close` / `<leader>q`) now exits commit viewer or local commit mode first, preventing orphaned viewer windows
+- **Maximize window blinking** — the focus-lock autocmd and fs_event file watcher now use debounce timers (50ms / 150ms) to prevent rapid screen redraws that caused the floating window to flicker, especially on macOS where libuv fires multiple callbacks per file change
 - Commit viewer exit now switches to sidebar before `:only` so file tree doesn't survive teardown
 - Header window is closed on commit mode exit to prevent ghost UI
 - Poll timer seeded inside SHA callback to prevent race condition on first tick

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
 - Create and view inline comments on specific lines
 - Jump between diff hunks and comment threads
 - Step through individual commits in a grid layout (commit viewer mode)
+- Combined diff view showing the full PR diff (`base...HEAD`), matching GitHub's "Files changed" tab
 - View PR descriptions and metadata
 - Merge, squash, or rebase PRs
-- Auto-sync to detect new commits pushed to the branch
+- Auto-sync to detect new commits pushed to the branch (both in review mode and commit viewer mode)
 - Local commit viewer (`:Raccoon local`) for browsing any git repo's history with live "Current changes" view
 - Dispatch CLI agents (claude, amp, aider) from commit viewer diffs with context injection
 - Statusline integration showing file position and sync status
@@ -94,6 +95,7 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `commit_viewer.grid.cols` | number | `2` | Columns in the commit viewer diff grid |
 | `commit_viewer.base_commits_count` | number | `20` | Number of recent base branch commits shown in the sidebar |
 | `commit_viewer.sidebar_width` | number | `50` | Width of commit list and file tree sidebars (20–120) |
+| `commit_viewer.sync_interval` | number | `60` | Background sync frequency in seconds for PR commit viewer (10–3600) |
 | `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized diff view (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
 
 Each key in `tokens` is the **owner or org name from the repo URL** — the first path segment after the host. To find it, open any repo you want to review and copy the name between the host and the repo name:
@@ -150,7 +152,8 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 co
   "pull_changes_interval": 120,
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
-    "base_commits_count": 30
+    "base_commits_count": 30,
+    "sync_interval": 60
   },
   "parallel_agents": {
     "enabled": true,
@@ -265,6 +268,10 @@ All keymaps are configurable via the `shortcuts` field in `config.json`. The val
 Inspired by chess game review, where you step through moves to understand the sequence that led to the final position. Instead of seeing the PR as a flat diff, commit viewer lets you replay the author's thought process one commit at a time — understanding *how* the code got to where it is, not just *what* changed.
 
 Press `<leader>cm` during a PR review to enter commit viewer mode. A file tree on the left shows all PR files with three-level highlighting: files in the current commit are brighter, and files currently visible in the grid are highlighted the strongest. The main area displays a configurable grid of diff hunks. A sidebar on the right lists all commits from the PR branch and recent base branch commits.
+
+When the PR has multiple commits, a **COMBINED DIFF** entry appears at the top of the sidebar showing the three-dot diff (`base...HEAD`) of the entire PR — matching GitHub's "Files changed" view. This gives you the full picture alongside individual commit diffs.
+
+**Background sync** automatically fetches new commits from origin and refreshes the sidebar and grid when changes are detected. The sync interval is configurable via `commit_viewer.sync_interval` (default 60 seconds). Your selection is preserved across refreshes.
 
 ### Commit viewer keymaps
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `tokens` | object | `{}` | Token per owner/org — string or `{"token": "...", "host": "..."}` for multi-host |
 | `repos` | array | `[]` | Limit PR list to specific repos, e.g. `["my-org/backend"]`. Only PRs involving you are shown. |
 | `clone_root` | string | `<nvim data dir>/raccoon/repos` | Where PR branches are cloned for review |
-| `pull_changes_interval` | number | `300` | How often (in seconds) to auto-sync with remote |
+| `poll_interval_seconds` | number | `300` | How often (in seconds) to auto-sync with remote |
 | `shortcuts` | object | see below | Custom keyboard shortcuts (partial overrides merged with defaults) |
 | `commit_viewer.grid.rows` | number | `2` | Rows in the commit viewer diff grid |
 | `commit_viewer.grid.cols` | number | `2` | Columns in the commit viewer diff grid |
@@ -149,7 +149,7 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 co
   },
   "repos": ["your-username/project", "work-org/api"],
   "clone_root": "~/code/pr-reviews",
-  "pull_changes_interval": 120,
+  "poll_interval_seconds": 120,
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
     "base_commits_count": 30,

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ When you open a PR, raccoon shallow-clones the PR branch into a local directory 
 
 The per-PR directory means previous clones stay on disk — reopening a PR is fast because it fetches updates instead of cloning from scratch. Neovim's working directory changes to the clone path during a review session, so LSP, treesitter, and other tools work on the actual source code.
 
-One review session is active at a time. Opening a second PR closes the first.
+One review session is active at a time. Opening a second PR closes the first — this works seamlessly from any mode, including commit viewer and local commit viewer.
 
 ## Commands
 

--- a/config_docs.md
+++ b/config_docs.md
@@ -153,7 +153,7 @@ The sync check compares the HEAD SHA — if nothing changed, no further API call
 
 ### `commit_viewer`
 
-Nested object controlling the commit viewer grid layout.
+Nested object controlling the commit viewer grid layout and background sync.
 
 #### `commit_viewer.grid.rows`
 
@@ -207,6 +207,24 @@ Width in columns of the commit list sidebar (right) and file tree panel (left). 
 {
   "commit_viewer": {
     "sidebar_width": 40
+  }
+}
+```
+
+#### `commit_viewer.sync_interval`
+
+| Type | Default |
+|------|---------|
+| number | `60` |
+
+How often (in seconds) the PR commit viewer checks for new commits pushed to the PR branch while commit viewer mode is active. On each tick, the plugin fetches the PR and base branches from origin, compares SHAs, and refreshes the sidebar and grid if changes are detected. Your selection is preserved across refreshes.
+
+Set lower for faster detection, higher to reduce network traffic. Clamped to 10–3600. This is separate from `pull_changes_interval`, which controls auto-sync during normal review mode.
+
+```json
+{
+  "commit_viewer": {
+    "sync_interval": 30
   }
 }
 ```
@@ -273,7 +291,8 @@ Partial overrides are merged with defaults — you only need to specify keys you
   "pull_changes_interval": 120,
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
-    "base_commits_count": 30
+    "base_commits_count": 30,
+    "sync_interval": 60
   },
   "parallel_agents": {
     "enabled": true,

--- a/config_docs.md
+++ b/config_docs.md
@@ -10,7 +10,8 @@ The merge uses a deep merge strategy, so nested objects like `shortcuts` and `co
 
 Validation rules:
 - **`tokens`** is required and must contain at least one entry
-- Unknown fields are silently ignored (including legacy `github_username`)
+- Unknown fields are silently ignored
+- Deprecated fields (`github_token`, `pull_changes_interval`, `github_username`) trigger a warning with the replacement
 
 ## Minimal config
 
@@ -135,7 +136,7 @@ Supports tilde expansion (`~/...`).
 
 Clones persist on disk, so reopening a PR is fast — it fetches updates instead of cloning from scratch. Delete the directory to free disk space when you no longer need old review clones.
 
-### `pull_changes_interval`
+### `poll_interval_seconds`
 
 | Type | Default |
 |------|---------|
@@ -145,7 +146,7 @@ How often (in seconds) the plugin checks for new commits pushed to the PR branch
 
 ```json
 {
-  "pull_changes_interval": 120
+  "poll_interval_seconds": 120
 }
 ```
 
@@ -219,7 +220,7 @@ Width in columns of the commit list sidebar (right) and file tree panel (left). 
 
 How often (in seconds) the PR commit viewer checks for new commits pushed to the PR branch while commit viewer mode is active. On each tick, the plugin fetches the PR and base branches from origin, compares SHAs, and refreshes the sidebar and grid if changes are detected. Your selection is preserved across refreshes.
 
-Set lower for faster detection, higher to reduce network traffic. Clamped to 10–3600. This is separate from `pull_changes_interval`, which controls auto-sync during normal review mode.
+Set lower for faster detection, higher to reduce network traffic. Clamped to 10–3600. This is separate from `poll_interval_seconds`, which controls auto-sync during normal review mode.
 
 ```json
 {
@@ -288,7 +289,7 @@ Partial overrides are merged with defaults — you only need to specify keys you
   },
   "repos": ["your-username/project", "work-org/api"],
   "clone_root": "~/code/pr-reviews",
-  "pull_changes_interval": 120,
+  "poll_interval_seconds": 120,
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
     "base_commits_count": 30,

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -49,7 +49,9 @@ function M.make_base_state()
     grid_cols = 2,
     maximize_win = nil,
     maximize_buf = nil,
+    maximize_debounce_timer = nil,
     focus_augroup = nil,
+    focus_redirect_timer = nil,
     header_win = nil,
     header_buf = nil,
     filetree_win = nil,
@@ -745,9 +747,11 @@ function M.open_maximize(opts)
   end)
 end
 
---- Stop the file watcher for the maximize window
+--- Stop the file watcher (and its debounce timer) for the maximize window
 ---@param s table State table
 function M.stop_maximize_watcher(s)
+  M.safe_close_timer(s.maximize_debounce_timer)
+  s.maximize_debounce_timer = nil
   if s.maximize_fs_event then
     local handle = s.maximize_fs_event
     s.maximize_fs_event = nil
@@ -760,7 +764,11 @@ function M.stop_maximize_watcher(s)
   end
 end
 
---- Start a file watcher that refreshes the maximize window on file changes
+local FS_EVENT_DEBOUNCE_MS = 150
+
+--- Start a file watcher that refreshes the maximize window on file changes.
+--- Debounced: rapid fs_event fires (common on macOS FSEvents) collapse into
+--- a single refresh after FS_EVENT_DEBOUNCE_MS of quiet.
 ---@param s table State table (must have maximize_workdir_opts set)
 function M.start_maximize_watcher(s)
   local mopts = s.maximize_workdir_opts
@@ -771,13 +779,29 @@ function M.start_maximize_watcher(s)
   if not handle then return end
 
   s.maximize_fs_event = handle
+  s.maximize_debounce_timer = nil
+
   handle:start(filepath, {}, vim.schedule_wrap(function(err)
     if err then
       vim.notify("File watcher error: " .. tostring(err), vim.log.levels.DEBUG)
       return
     end
     if not s.maximize_workdir_opts then return end
-    M.refresh_maximize(s)
+
+    -- Cancel any pending debounce and restart the delay
+    if s.maximize_debounce_timer then
+      s.maximize_debounce_timer:stop()
+    else
+      s.maximize_debounce_timer = vim.uv.new_timer()
+      if not s.maximize_debounce_timer then
+        M.refresh_maximize(s) -- fallback: refresh immediately
+        return
+      end
+    end
+    s.maximize_debounce_timer:start(FS_EVENT_DEBOUNCE_MS, 0, vim.schedule_wrap(function()
+      if not s.maximize_workdir_opts then return end
+      M.refresh_maximize(s)
+    end))
   end))
 end
 
@@ -1132,13 +1156,18 @@ function M.setup_sidebar_nav(buf, callbacks)
   M.lock_buf(buf)
 end
 
+local FOCUS_LOCK_DEBOUNCE_MS = 50
+
 --- Setup the focus-lock autocmd that keeps cursor in the active panel (or maximize window).
+--- Debounced to prevent rapid focus-fight with external plugins.
 --- Respects s.focus_target: "sidebar" (default) or "filetree".
 ---@param s table State table (needs active, maximize_win, sidebar_win, filetree_win, focus_target)
 ---@param augroup_name string Name for the augroup
 ---@return number augroup_id
 function M.setup_focus_lock(s, augroup_name)
   local augroup = vim.api.nvim_create_augroup(augroup_name, { clear = true })
+  s.focus_redirect_timer = nil
+
   vim.api.nvim_create_autocmd("WinEnter", {
     group = augroup,
     callback = function()
@@ -1154,28 +1183,44 @@ function M.setup_focus_lock(s, augroup_name)
           return
         end
       end
+
+      -- Determine where focus should go
+      local target
       if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
-        vim.schedule(function()
-          local has_popup = s.popup_win
-            or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win))
-          if has_popup then return end
-          if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
-            vim.api.nvim_set_current_win(s.maximize_win)
-          end
-        end)
-        return
+        target = s.maximize_win
+      else
+        target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
       end
-      local target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
-      if cur_win ~= target then
-        vim.schedule(function()
-          local has_popup = s.popup_win
-            or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win))
-          if has_popup then return end
-          if target and vim.api.nvim_win_is_valid(target) then
-            vim.api.nvim_set_current_win(target)
-          end
-        end)
+
+      if not target or cur_win == target then return end
+
+      -- Debounce: cancel any pending redirect, wait FOCUS_LOCK_DEBOUNCE_MS before acting.
+      -- This prevents a rapid focus-fight with external plugins that also redirect on WinEnter.
+      if s.focus_redirect_timer then
+        s.focus_redirect_timer:stop()
+      else
+        s.focus_redirect_timer = vim.uv.new_timer()
+        if not s.focus_redirect_timer then
+          -- Fallback: redirect immediately (old behaviour)
+          vim.schedule(function()
+            if target and vim.api.nvim_win_is_valid(target) then
+              vim.api.nvim_set_current_win(target)
+            end
+          end)
+          return
+        end
       end
+      s.focus_redirect_timer:start(FOCUS_LOCK_DEBOUNCE_MS, 0, vim.schedule_wrap(function()
+        if not s.active then return end
+        local has_popup = s.popup_win
+          or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win))
+        if has_popup then return end
+        -- Re-check: focus may already be correct by the time the debounce fires
+        if vim.api.nvim_get_current_win() == target then return end
+        if target and vim.api.nvim_win_is_valid(target) then
+          vim.api.nvim_set_current_win(target)
+        end
+      end))
     end,
   })
   return augroup
@@ -1467,6 +1512,8 @@ end
 ---@param s table State table
 ---@param opts table {on_before_only: fun()|nil, on_after: fun()|nil}
 function M.teardown_viewer(s, opts)
+  M.safe_close_timer(s.focus_redirect_timer)
+  s.focus_redirect_timer = nil
   if s.focus_augroup then
     pcall(vim.api.nvim_del_augroup_by_id, s.focus_augroup)
   end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -9,6 +9,10 @@ local diff = require("raccoon.diff")
 M.SIDEBAR_WIDTH = 50
 M.STAT_BAR_MAX_WIDTH = 20
 
+--- Shared popup window handle. When set, all focus locks allow this window.
+---@type number|nil
+M.global_popup_win = nil
+
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
 
@@ -520,10 +524,11 @@ function M.open_maximize(opts)
   fetch_patch(function(patch, err)
     if opts.get_generation() ~= opts.generation then return end
 
-    if err or not patch or patch == "" then
-      vim.notify("Failed to get full file diff", vim.log.levels.ERROR)
+    if err then
+      vim.notify("Failed to get full file diff: " .. err, vim.log.levels.ERROR)
       return
     end
+    if not patch or patch == "" then return end
 
     local hunks = diff.parse_patch(patch)
     if #hunks == 0 then return end
@@ -1034,10 +1039,18 @@ function M.setup_focus_lock(s, augroup_name)
       if not s.active then return end
       local cur_win = vim.api.nvim_get_current_win()
       if cur_win == s.maximize_win then return end
+      -- Allow focus on per-state or global popups (e.g. PR picker)
       if s.popup_win and cur_win == s.popup_win then return end
+      if M.global_popup_win then
+        if not vim.api.nvim_win_is_valid(M.global_popup_win) then
+          M.global_popup_win = nil
+        elseif cur_win == M.global_popup_win then
+          return
+        end
+      end
       if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
         vim.schedule(function()
-          if s.popup_win then return end
+          if s.popup_win or (M.global_popup_win and vim.api.nvim_win_is_valid(M.global_popup_win)) then return end
           if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
             vim.api.nvim_set_current_win(s.maximize_win)
           end
@@ -1047,7 +1060,7 @@ function M.setup_focus_lock(s, augroup_name)
       local target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
       if cur_win ~= target then
         vim.schedule(function()
-          if s.popup_win then return end
+          if s.popup_win or (M.global_popup_win and vim.api.nvim_win_is_valid(M.global_popup_win)) then return end
           if target and vim.api.nvim_win_is_valid(target) then
             vim.api.nvim_set_current_win(target)
           end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -10,7 +10,7 @@ local state = require("raccoon.state")
 M.SIDEBAR_WIDTH = 50
 M.STAT_BAR_MAX_WIDTH = 20
 
-local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
+local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header window (1-line split)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
 
 --- Approximate usable editor height for grid layout.
@@ -1228,7 +1228,6 @@ end
 --- Works for both PR viewer ("PR Branch"/"Base Branch") and local viewer ("feat-xyz"/"main").
 ---@param buf number Buffer ID
 ---@param opts table {section1_header, section1_commits, section2_header, section2_commits, commit_hl_fn?, loading?}
----@return table highlights Array of {line, hl} used for highlight application
 function M.render_split_sidebar(buf, opts)
   if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1385,4 +1385,30 @@ function M.apply_diff_result(s, opts)
   opts.render_grid_fn()
 end
 
+--- Shared exit teardown for commit viewer modes.
+--- Deletes augroup, closes maximize window, runs :only, restores saved buf/laststatus.
+---@param s table State table
+---@param opts table {on_before_only: fun()|nil, on_after: fun()|nil}
+function M.teardown_viewer(s, opts)
+  if s.focus_augroup then
+    pcall(vim.api.nvim_del_augroup_by_id, s.focus_augroup)
+  end
+
+  M.close_win_pair(s, "maximize_win", "maximize_buf")
+
+  if opts.on_before_only then opts.on_before_only() end
+
+  vim.cmd("only")
+
+  if s.saved_buf and vim.api.nvim_buf_is_valid(s.saved_buf) then
+    vim.api.nvim_set_current_buf(s.saved_buf)
+  end
+
+  if s.saved_laststatus then
+    vim.o.laststatus = s.saved_laststatus
+  end
+
+  if opts.on_after then opts.on_after() end
+end
+
 return M

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1050,7 +1050,9 @@ function M.setup_focus_lock(s, augroup_name)
       end
       if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
         vim.schedule(function()
-          if s.popup_win or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win)) then return end
+          local has_popup = s.popup_win
+            or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win))
+          if has_popup then return end
           if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
             vim.api.nvim_set_current_win(s.maximize_win)
           end
@@ -1060,7 +1062,9 @@ function M.setup_focus_lock(s, augroup_name)
       local target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
       if cur_win ~= target then
         vim.schedule(function()
-          if s.popup_win or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win)) then return end
+          local has_popup = s.popup_win
+            or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win))
+          if has_popup then return end
           if target and vim.api.nvim_win_is_valid(target) then
             vim.api.nvim_set_current_win(target)
           end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -69,7 +69,10 @@ end
 --- Parse and clamp commit viewer config values from user config.
 ---@return table {rows: number, cols: number, base_count: number, sidebar_width: number, sync_interval: number}
 function M.parse_viewer_config()
-  local cfg = config.load()
+  local cfg, cfg_err = config.load()
+  if cfg_err then
+    vim.notify("Commit viewer: using defaults (config error: " .. cfg_err .. ")", vim.log.levels.DEBUG)
+  end
   local rows = 2
   local cols = 2
   local base_count = 20
@@ -94,7 +97,7 @@ function M.parse_viewer_config()
 end
 
 --- Approximate usable editor height for grid layout.
---- Subtracts cmdheight and global chrome (statusline + header separator); intentionally omits
+--- Subtracts cmdheight and global chrome (statusline + header window); intentionally omits
 --- header content height and inter-row separators since this feeds a heuristic, not exact layout.
 ---@return number
 function M.grid_total_height()
@@ -632,7 +635,10 @@ function M.open_maximize(opts)
     end
 
     local hunks = diff.parse_patch(patch)
-    if #hunks == 0 then return end
+    if #hunks == 0 then
+      vim.notify("No diff hunks to display for " .. opts.filename, vim.log.levels.INFO)
+      return
+    end
 
     local lines = {}
     local hl_lines = {}
@@ -755,12 +761,18 @@ function M.stop_maximize_watcher(s)
   if s.maximize_fs_event then
     local handle = s.maximize_fs_event
     s.maximize_fs_event = nil
-    pcall(handle.stop, handle)
-    pcall(function()
+    local ok1, err1 = pcall(handle.stop, handle)
+    if not ok1 then
+      vim.notify("fs_event stop failed: " .. tostring(err1), vim.log.levels.DEBUG)
+    end
+    local ok2, err2 = pcall(function()
       if not handle:is_closing() then
         handle:close()
       end
     end)
+    if not ok2 then
+      vim.notify("fs_event close failed: " .. tostring(err2), vim.log.levels.DEBUG)
+    end
   end
 end
 
@@ -776,7 +788,10 @@ function M.start_maximize_watcher(s)
 
   local filepath = vim.fs.joinpath(mopts.repo_path, mopts.filename)
   local handle = vim.uv.new_fs_event()
-  if not handle then return end
+  if not handle then
+    vim.notify("Failed to create file watcher for " .. mopts.filename, vim.log.levels.DEBUG)
+    return
+  end
 
   s.maximize_fs_event = handle
   s.maximize_debounce_timer = nil
@@ -865,7 +880,7 @@ function M.open_file_content(opts)
   git.show_file_content(opts.repo_path, opts.sha, opts.filename, function(lines, err)
     if opts.get_generation() ~= opts.generation then return end
     if err or not lines then
-      vim.notify("Failed to get file content", vim.log.levels.ERROR)
+      vim.notify("Failed to get file content: " .. (err or opts.filename), vim.log.levels.ERROR)
       return
     end
 
@@ -1508,17 +1523,23 @@ function M.apply_diff_result(s, opts)
 end
 
 --- Shared exit teardown for commit viewer modes.
---- Deletes augroup, closes maximize window, switches to sidebar, runs :only, restores saved buf/laststatus.
+--- Closes timers, deletes augroup, closes all viewer windows/buffers, runs :only, restores editor state.
+--- Calls on_before_only before closing windows and on_after after restoring state.
 ---@param s table State table
 ---@param opts table {on_before_only: fun()|nil, on_after: fun()|nil}
 function M.teardown_viewer(s, opts)
   M.safe_close_timer(s.focus_redirect_timer)
   s.focus_redirect_timer = nil
   if s.focus_augroup then
-    pcall(vim.api.nvim_del_augroup_by_id, s.focus_augroup)
+    local ok, del_err = pcall(vim.api.nvim_del_augroup_by_id, s.focus_augroup)
+    if not ok then
+      vim.notify("Failed to delete focus augroup: " .. tostring(del_err), vim.log.levels.DEBUG)
+    end
   end
 
   M.close_win_pair(s, "maximize_win", "maximize_buf")
+  if s.grid_wins then M.close_grid(s) end
+  M.close_win_pair(s, "filetree_win", "filetree_buf")
 
   if opts.on_before_only then opts.on_before_only() end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1385,7 +1385,7 @@ function M.apply_diff_result(s, opts)
 end
 
 --- Shared exit teardown for commit viewer modes.
---- Deletes augroup, closes maximize window, runs :only, restores saved buf/laststatus.
+--- Deletes augroup, closes maximize window, switches to sidebar, runs :only, restores saved buf/laststatus.
 ---@param s table State table
 ---@param opts table {on_before_only: fun()|nil, on_after: fun()|nil}
 function M.teardown_viewer(s, opts)

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -5,13 +5,10 @@ local M = {}
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local diff = require("raccoon.diff")
+local state = require("raccoon.state")
 
 M.SIDEBAR_WIDTH = 50
 M.STAT_BAR_MAX_WIDTH = 20
-
---- Shared popup window handle. When set, all focus locks allow this window.
----@type number|nil
-M.global_popup_win = nil
 
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
@@ -1044,16 +1041,16 @@ function M.setup_focus_lock(s, augroup_name)
       if cur_win == s.maximize_win then return end
       -- Allow focus on per-state or global popups (e.g. PR picker)
       if s.popup_win and cur_win == s.popup_win then return end
-      if M.global_popup_win then
-        if not vim.api.nvim_win_is_valid(M.global_popup_win) then
-          M.global_popup_win = nil
-        elseif cur_win == M.global_popup_win then
+      if state.global_popup_win then
+        if not vim.api.nvim_win_is_valid(state.global_popup_win) then
+          state.global_popup_win = nil
+        elseif cur_win == state.global_popup_win then
           return
         end
       end
       if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
         vim.schedule(function()
-          if s.popup_win or (M.global_popup_win and vim.api.nvim_win_is_valid(M.global_popup_win)) then return end
+          if s.popup_win or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win)) then return end
           if s.maximize_win and vim.api.nvim_win_is_valid(s.maximize_win) then
             vim.api.nvim_set_current_win(s.maximize_win)
           end
@@ -1063,7 +1060,7 @@ function M.setup_focus_lock(s, augroup_name)
       local target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
       if cur_win ~= target then
         vim.schedule(function()
-          if s.popup_win or (M.global_popup_win and vim.api.nvim_win_is_valid(M.global_popup_win)) then return end
+          if s.popup_win or (state.global_popup_win and vim.api.nvim_win_is_valid(state.global_popup_win)) then return end
           if target and vim.api.nvim_win_is_valid(target) then
             vim.api.nvim_set_current_win(target)
           end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -32,6 +32,27 @@ function M.compute_grid_context(rows)
   return math.max(MIN_DIFF_CONTEXT, math.floor(row_height / 2))
 end
 
+--- Preserve selected commit across a refresh by searching for a matching SHA.
+--- Falls back to clamping the index when the SHA is not found (e.g., after force-push).
+---@param s table State table (must have selected_index field)
+---@param selected_sha string|nil SHA to search for
+---@param total_fn fun(): number Returns total navigable commits
+---@param get_fn fun(i: number): table|nil Returns commit at index i
+function M.restore_selection_by_sha(s, selected_sha, total_fn, get_fn)
+  if selected_sha then
+    for i = 1, total_fn() do
+      local c = get_fn(i)
+      if c and c.sha == selected_sha then
+        s.selected_index = i
+        return
+      end
+    end
+  end
+  if s.selected_index > total_fn() then
+    s.selected_index = math.max(1, total_fn())
+  end
+end
+
 --- Compute per-file addition/deletion counts from diff patches
 ---@param files table[] Array of {filename, patch}
 ---@return table<string, {additions: number, deletions: number}>
@@ -505,7 +526,7 @@ function M.close_grid(s)
 end
 
 --- Open a maximize floating window for a full-file diff
----@param opts table {ns_id, repo_path, sha, filename, commit_message, generation, ...}
+---@param opts table {ns_id, repo_path, sha, filename, commit_message, generation, get_generation, state, is_working_dir?, is_combined_diff?, base_ref?}
 function M.open_maximize(opts)
   local git = require("raccoon.git")
 
@@ -1078,7 +1099,7 @@ end
 --- Setup filetree browsing keymaps. j/k navigate all files, Enter shows file diff.
 --- The diff grid stays intact while browsing.
 ---@param s table State table
----@param opts table {get_repo_path, get_sha, ns_id}
+---@param opts table {ns_id, get_repo_path, get_sha, get_commit_message, get_base_ref}
 function M.setup_filetree_nav(s, opts)
   if not s.filetree_buf or not vim.api.nvim_buf_is_valid(s.filetree_buf) then return end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -13,6 +13,21 @@ M.STAT_BAR_MAX_WIDTH = 20
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header window (1-line split)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
 
+--- Safely stop and close a libuv timer handle (idempotent).
+--- Logs failures at DEBUG level to avoid silently swallowing errors.
+---@param handle userdata|nil Timer handle from vim.uv.new_timer()
+function M.safe_close_timer(handle)
+  if not handle then return end
+  local ok1, err1 = pcall(handle.stop, handle)
+  if not ok1 then
+    vim.notify("Timer stop failed: " .. tostring(err1), vim.log.levels.DEBUG)
+  end
+  local ok2, err2 = pcall(handle.close, handle)
+  if not ok2 then
+    vim.notify("Timer close failed: " .. tostring(err2), vim.log.levels.DEBUG)
+  end
+end
+
 --- Approximate usable editor height for grid layout.
 --- Subtracts cmdheight and global chrome (statusline + header separator); intentionally omits
 --- header content height and inter-row separators since this feeds a heuristic, not exact layout.

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -609,7 +609,7 @@ function M.close_grid(s)
 end
 
 --- Open a maximize floating window for a full-file diff
----@param opts table {ns_id, repo_path, sha, filename, commit_message, generation, get_generation, state, is_working_dir?, is_combined_diff?, base_ref?}
+---@param opts table {ns_id, repo_path, sha, filename, commit_message, generation, get_generation, state, is_working_dir?, is_combined_diff?, base_ref (required if is_combined_diff)}
 function M.open_maximize(opts)
   local git = require("raccoon.git")
 
@@ -796,7 +796,7 @@ function M.start_maximize_watcher(s)
   s.maximize_fs_event = handle
   s.maximize_debounce_timer = nil
 
-  handle:start(filepath, {}, vim.schedule_wrap(function(err)
+  local start_ok, start_err = pcall(handle.start, handle, filepath, {}, vim.schedule_wrap(function(err)
     if err then
       vim.notify("File watcher error: " .. tostring(err), vim.log.levels.DEBUG)
       return
@@ -818,6 +818,12 @@ function M.start_maximize_watcher(s)
       M.refresh_maximize(s)
     end))
   end))
+  if not start_ok then
+    vim.notify("File watcher start failed: " .. tostring(start_err), vim.log.levels.DEBUG)
+    pcall(handle.close, handle)
+    s.maximize_fs_event = nil
+    return
+  end
 end
 
 --- Refresh the maximize window in-place for working directory changes
@@ -837,9 +843,15 @@ function M.refresh_maximize(s)
     if not s.maximize_workdir_opts then return end
     if not vim.api.nvim_buf_is_valid(buf) then return end
 
-    if err or not patch or patch == "" then
+    if err then
       vim.bo[buf].modifiable = true
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", "  Error refreshing diff: " .. tostring(err) })
+      vim.bo[buf].modifiable = false
+      return
+    end
+    if not patch or patch == "" then
+      vim.bo[buf].modifiable = true
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", "  No diff content (file may be unchanged)" })
       vim.bo[buf].modifiable = false
       return
     end
@@ -1523,8 +1535,8 @@ function M.apply_diff_result(s, opts)
 end
 
 --- Shared exit teardown for commit viewer modes.
---- Closes timers, deletes augroup, closes all viewer windows/buffers, runs :only, restores editor state.
---- Calls on_before_only before closing windows and on_after after restoring state.
+--- Closes timers, deletes augroup, closes maximize/grid/filetree windows, then runs :only to close remaining splits.
+--- Calls on_before_only after closing viewer panels but before :only, and on_after after restoring editor state.
 ---@param s table State table
 ---@param opts table {on_before_only: fun()|nil, on_after: fun()|nil}
 function M.teardown_viewer(s, opts)
@@ -1548,7 +1560,10 @@ function M.teardown_viewer(s, opts)
   if s.sidebar_win and vim.api.nvim_win_is_valid(s.sidebar_win) then
     vim.api.nvim_set_current_win(s.sidebar_win)
   end
-  vim.cmd("only")
+  local ok_only, only_err = pcall(vim.cmd, "only")
+  if not ok_only then
+    vim.notify("Warning: could not close viewer windows: " .. tostring(only_err), vim.log.levels.WARN)
+  end
 
   if s.saved_buf and vim.api.nvim_buf_is_valid(s.saved_buf) then
     vim.api.nvim_set_current_buf(s.saved_buf)

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -28,6 +28,42 @@ function M.safe_close_timer(handle)
   end
 end
 
+--- Create the base state table shared by both commit viewer modules.
+--- Callers extend the returned table with module-specific fields.
+---@return table Base state with shared UI fields
+function M.make_base_state()
+  return {
+    active = false,
+    sidebar_win = nil,
+    sidebar_buf = nil,
+    selected_index = 1,
+    grid_wins = {},
+    grid_bufs = {},
+    all_hunks = {},
+    commit_files = {},
+    file_stats = {},
+    current_page = 1,
+    saved_buf = nil,
+    saved_laststatus = nil,
+    grid_rows = 2,
+    grid_cols = 2,
+    maximize_win = nil,
+    maximize_buf = nil,
+    focus_augroup = nil,
+    header_win = nil,
+    header_buf = nil,
+    filetree_win = nil,
+    filetree_buf = nil,
+    select_generation = 0,
+    cached_sha = nil,
+    cached_tree_lines = nil,
+    cached_line_paths = nil,
+    cached_stat_lines = nil,
+    cached_file_count = nil,
+    focus_target = "sidebar",
+  }
+end
+
 --- Parse and clamp commit viewer config values from user config.
 ---@return table {rows: number, cols: number, base_count: number, sidebar_width: number, sync_interval: number}
 function M.parse_viewer_config()

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -28,6 +28,33 @@ function M.safe_close_timer(handle)
   end
 end
 
+--- Parse and clamp commit viewer config values from user config.
+---@return table {rows: number, cols: number, base_count: number, sidebar_width: number, sync_interval: number}
+function M.parse_viewer_config()
+  local cfg = config.load()
+  local rows = 2
+  local cols = 2
+  local base_count = 20
+  local sidebar_width = 50
+  local sync_interval = 60
+  if cfg and cfg.commit_viewer then
+    if cfg.commit_viewer.grid then
+      rows = M.clamp_int(cfg.commit_viewer.grid.rows, 2, 1, 10)
+      cols = M.clamp_int(cfg.commit_viewer.grid.cols, 2, 1, 10)
+    end
+    base_count = M.clamp_int(cfg.commit_viewer.base_commits_count, 20, 1, 200)
+    sidebar_width = M.clamp_int(cfg.commit_viewer.sidebar_width, 50, 20, 120)
+    sync_interval = M.clamp_int(cfg.commit_viewer.sync_interval, 60, 10, 3600)
+  end
+  return {
+    rows = rows,
+    cols = cols,
+    base_count = base_count,
+    sidebar_width = sidebar_width,
+    sync_interval = sync_interval,
+  }
+end
+
 --- Approximate usable editor height for grid layout.
 --- Subtracts cmdheight and global chrome (statusline + header separator); intentionally omits
 --- header content height and inter-row separators since this feeds a heuristic, not exact layout.

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -508,9 +508,14 @@ end
 function M.open_maximize(opts)
   local git = require("raccoon.git")
 
-  local fetch_patch = opts.is_working_dir
-    and function(cb) git.diff_working_dir_file(opts.repo_path, opts.filename, cb) end
-    or function(cb) git.show_commit_file(opts.repo_path, opts.sha, opts.filename, cb) end
+  local fetch_patch
+  if opts.is_working_dir then
+    fetch_patch = function(cb) git.diff_working_dir_file(opts.repo_path, opts.filename, cb) end
+  elseif opts.is_combined_diff then
+    fetch_patch = function(cb) git.diff_combined_file(opts.repo_path, opts.base_ref, opts.filename, cb) end
+  else
+    fetch_patch = function(cb) git.show_commit_file(opts.repo_path, opts.sha, opts.filename, cb) end
+  end
 
   fetch_patch(function(patch, err)
     if opts.get_generation() ~= opts.generation then return end
@@ -1113,6 +1118,9 @@ function M.setup_filetree_nav(s, opts)
     if not repo_path then return end
     local is_changed = s.commit_files and s.commit_files[path]
     local commit_msg = opts.get_commit_message and opts.get_commit_message() or ""
+    local git = require("raccoon.git")
+    local is_combined = sha == git.COMBINED_DIFF_SHA
+    local base_ref = opts.get_base_ref and opts.get_base_ref()
     if is_changed then
       M.open_maximize({
         ns_id = opts.ns_id,
@@ -1124,11 +1132,13 @@ function M.setup_filetree_nav(s, opts)
         get_generation = function() return s.select_generation end,
         state = s,
         is_working_dir = sha == nil,
+        is_combined_diff = is_combined,
+        base_ref = base_ref,
       })
     else
       M.open_file_content({
         repo_path = repo_path,
-        sha = sha,
+        sha = is_combined and "HEAD" or sha,
         filename = path,
         generation = s.select_generation,
         get_generation = function() return s.select_generation end,

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -528,7 +528,10 @@ function M.open_maximize(opts)
       vim.notify("Failed to get full file diff: " .. err, vim.log.levels.ERROR)
       return
     end
-    if not patch or patch == "" then return end
+    if not patch or patch == "" then
+      vim.notify("No diff content for " .. opts.filename, vim.log.levels.INFO)
+      return
+    end
 
     local hunks = diff.parse_patch(patch)
     if #hunks == 0 then return end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1329,4 +1329,60 @@ function M.split_sidebar_cursor_to_index(cursor_line, section1_count)
   return line_0 - 2 -- subtract blank + header to get combined index
 end
 
+--- Process a diff result and populate state (shared by both commit viewer modules).
+--- Handles file tracking, stat computation, hunk list building, empty-diff fallback, and render.
+---@param s table State table
+---@param opts table {files, err, generation, get_generation, build_cache_fn, get_commit_fn, total_pages_fn, ns_id, render_grid_fn}
+function M.apply_diff_result(s, opts)
+  if opts.get_generation() ~= opts.generation then return end
+
+  if opts.err then
+    vim.notify("Failed to get commit diff: " .. opts.err, vim.log.levels.ERROR)
+    return
+  end
+
+  s.commit_files = {}
+  s.file_stats = {}
+  s.all_hunks = {}
+  s.cached_sha = nil
+  s.cached_stat_lines = nil
+  for _, file in ipairs(opts.files or {}) do
+    s.commit_files[file.filename] = true
+    local additions = 0
+    local deletions = 0
+    local hunks = diff.parse_patch(file.patch)
+    for _, hunk in ipairs(hunks) do
+      table.insert(s.all_hunks, { hunk = hunk, filename = file.filename })
+      for _, line_data in ipairs(hunk.lines) do
+        if line_data.type == "add" then
+          additions = additions + 1
+        elseif line_data.type == "del" then
+          deletions = deletions + 1
+        end
+      end
+    end
+    s.file_stats[file.filename] = { additions = additions, deletions = deletions }
+  end
+  opts.build_cache_fn()
+
+  if #s.all_hunks == 0 then
+    for i, buf in ipairs(s.grid_bufs) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.bo[buf].modifiable = true
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", "  No changes in this commit" })
+        vim.bo[buf].modifiable = false
+      end
+      local win = s.grid_wins[i]
+      if win and vim.api.nvim_win_is_valid(win) then
+        vim.wo[win].winbar = "%=#" .. i
+      end
+    end
+    M.update_header(s, opts.get_commit_fn(), opts.total_pages_fn())
+    M.render_filetree(s)
+    return
+  end
+
+  opts.render_grid_fn()
+end
+
 return M

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -792,6 +792,8 @@ end
 ---@param sha string|nil Commit SHA, or nil for working directory
 function M.build_filetree_cache(s, repo_path, sha)
   local git = require("raccoon.git")
+  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
+  if sha == git.COMBINED_DIFF_SHA then sha = "HEAD" end
   local cache_key = sha or "WORKDIR"
   if s.cached_sha == cache_key then return end
 
@@ -1045,6 +1047,7 @@ function M.setup_focus_lock(s, augroup_name)
       local target = (s.focus_target == "filetree" and s.filetree_win) or s.sidebar_win
       if cur_win ~= target then
         vim.schedule(function()
+          if s.popup_win then return end
           if target and vim.api.nvim_win_is_valid(target) then
             vim.api.nvim_set_current_win(target)
           end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1397,6 +1397,11 @@ function M.teardown_viewer(s, opts)
 
   if opts.on_before_only then opts.on_before_only() end
 
+  -- Switch to sidebar before :only so the main content window survives
+  -- (not the narrow filetree if it happened to have focus)
+  if s.sidebar_win and vim.api.nvim_win_is_valid(s.sidebar_win) then
+    vim.api.nvim_set_current_win(s.sidebar_win)
+  end
   vim.cmd("only")
 
   if s.saved_buf and vim.api.nvim_buf_is_valid(s.saved_buf) then

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -671,13 +671,14 @@ end
 ---@param s table State table
 function M.stop_maximize_watcher(s)
   if s.maximize_fs_event then
+    local handle = s.maximize_fs_event
+    s.maximize_fs_event = nil
+    pcall(handle.stop, handle)
     pcall(function()
-      s.maximize_fs_event:stop()
-      if not s.maximize_fs_event:is_closing() then
-        s.maximize_fs_event:close()
+      if not handle:is_closing() then
+        handle:close()
       end
     end)
-    s.maximize_fs_event = nil
   end
 end
 
@@ -693,7 +694,10 @@ function M.start_maximize_watcher(s)
 
   s.maximize_fs_event = handle
   handle:start(filepath, {}, vim.schedule_wrap(function(err)
-    if err then return end
+    if err then
+      vim.notify("File watcher error: " .. tostring(err), vim.log.levels.DEBUG)
+      return
+    end
     if not s.maximize_workdir_opts then return end
     M.refresh_maximize(s)
   end))
@@ -825,7 +829,10 @@ function M.build_filetree_cache(s, repo_path, sha)
 
   s.cached_sha = cache_key
 
-  git.list_files(repo_path, sha, function(raw, _)
+  git.list_files(repo_path, sha, function(raw, list_err)
+    if list_err then
+      vim.notify("Failed to list files for tree: " .. tostring(list_err), vim.log.levels.DEBUG)
+    end
     if s.cached_sha ~= cache_key then return end
 
     table.sort(raw)

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -357,6 +357,13 @@ local function refresh_commits(on_complete)
   local new_pr, new_base
 
   local function on_both_ready()
+    -- When both calls failed, skip re-render to avoid clobbering valid state
+    if not new_pr and not new_base then
+      vim.notify("Sync: failed to refresh commits", vim.log.levels.WARN)
+      if on_complete then on_complete() end
+      return
+    end
+
     commit_state.pr_commits = new_pr or commit_state.pr_commits
     commit_state.base_commits = new_base or commit_state.base_commits
 
@@ -723,6 +730,7 @@ local function enter_commit_mode()
 
       git.log_base_commits(clone_path, base_branch, base_count, function(commits, err)
         if err then
+          vim.notify("Failed to get base commits", vim.log.levels.WARN)
           commit_state.base_commits = {}
         else
           commit_state.base_commits = commits or {}

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -58,8 +58,8 @@ local function make_initial_state()
     last_head_sha = nil,
     last_base_sha = nil,
     base_branch = nil,
-    base_count = 20,
-    sync_interval_ms = 60000,
+    base_count = nil,
+    sync_interval_ms = nil,
   }
 end
 
@@ -449,7 +449,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
 end
 
 --- Start the background sync timer.
---- On each tick: fetch PR branch from origin, check for new commits, reset and refresh if needed.
+--- On each tick: fetch PR and base branches from origin, check for new commits, reset and refresh if needed.
 local function start_poll_timer()
   stop_poll_timer()
   if not commit_state.active then return end

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -45,6 +45,10 @@ local poll_timer_handle = nil
 --- In-flight guard: prevents overlapping sync ticks from running concurrent git operations.
 local sync_in_flight = false
 
+--- Session generation counter. Incremented in reset_state() so that async callbacks
+--- from a previous viewer session can detect they are stale and bail out.
+local session_gen = 0
+
 --- Stop the background sync timer
 local function stop_poll_timer()
   if poll_timer_handle then
@@ -57,6 +61,7 @@ end
 
 local function reset_state()
   stop_poll_timer()
+  session_gen = session_gen + 1
   commit_state = make_initial_state()
 end
 
@@ -274,6 +279,7 @@ local function refresh_commits(on_complete)
     return
   end
 
+  local my_gen = session_gen
   local sel = get_commit(commit_state.selected_index)
   local selected_sha = sel and sel.sha
 
@@ -281,6 +287,10 @@ local function refresh_commits(on_complete)
   local new_pr, new_base
 
   local function on_both_ready()
+    if my_gen ~= session_gen then
+      if on_complete then on_complete() end
+      return
+    end
     -- When both calls failed, skip re-render to avoid clobbering valid state
     if not new_pr and not new_base then
       vim.notify("Sync: failed to refresh commits", vim.log.levels.WARN)
@@ -334,20 +344,25 @@ local function sync_tick(clone_path, pr_branch, base_branch)
   if sync_in_flight then return end
   if not commit_state.active then return end
   sync_in_flight = true
+  local my_gen = session_gen
 
   local function done()
     sync_in_flight = false
   end
 
+  local function stale()
+    return my_gen ~= session_gen
+  end
+
   git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
-    if not commit_state.active then done(); return end
+    if stale() then done(); return end
     if fetch_err then
       vim.notify("Sync: failed to fetch PR branch", vim.log.levels.DEBUG)
       done(); return
     end
 
     git.fetch_branch(clone_path, base_branch, function(_, base_fetch_err)
-      if not commit_state.active then done(); return end
+      if stale() then done(); return end
       if base_fetch_err then
         vim.notify("Sync: failed to fetch base branch", vim.log.levels.DEBUG)
       end
@@ -358,7 +373,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
       local function check_both()
         pending = pending - 1
         if pending > 0 then return end
-        if not commit_state.active then done(); return end
+        if stale() then done(); return end
 
         -- Defensive fallback: seed SHAs if start_poll_timer's seeding was incomplete
         if not commit_state.last_head_sha then
@@ -381,7 +396,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         if pr_changed then
           -- PR branch advanced — reset local clone to match origin
           git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
-            if not commit_state.active then done(); return end
+            if stale() then done(); return end
             if not ok then
               vim.notify("Sync: failed to reset to remote: " .. (reset_err or ""), vim.log.levels.DEBUG)
               done(); return
@@ -427,18 +442,19 @@ local function start_poll_timer()
 
   local pr_branch = pr.head.ref
   local base_branch = commit_state.base_branch
+  local my_gen = session_gen
 
   -- Seed last_head_sha and last_base_sha before starting the timer to avoid spurious refresh on first tick
   sync_in_flight = false
   git.get_current_sha(clone_path, function(sha, seed_err)
-    if not commit_state.active then return end
+    if my_gen ~= session_gen then return end
     if seed_err then
       vim.notify("Sync: failed to seed HEAD SHA", vim.log.levels.DEBUG)
     end
     if sha then commit_state.last_head_sha = sha end
 
     git.ref_sha(clone_path, "origin/" .. base_branch, function(base_sha, base_seed_err)
-      if not commit_state.active then return end
+      if my_gen ~= session_gen then return end
       if base_seed_err then
         vim.notify("Sync: failed to seed base SHA", vim.log.levels.DEBUG)
       end
@@ -446,7 +462,7 @@ local function start_poll_timer()
 
       -- Guard against concurrent timer creation from rapid toggle
       stop_poll_timer()
-      if not commit_state.active then return end
+      if my_gen ~= session_gen then return end
 
       local timer = vim.uv.new_timer()
       if not timer then
@@ -456,6 +472,7 @@ local function start_poll_timer()
       poll_timer_handle = timer
       timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
         vim.schedule_wrap(function()
+          if my_gen ~= session_gen then return end
           sync_tick(clone_path, pr_branch, base_branch)
         end))
     end)
@@ -691,5 +708,7 @@ M._render_tree_node = ui.render_tree_node
 M._compute_file_stats = ui.compute_file_stats
 M._format_stat_bar = ui.format_stat_bar
 M._close_filetree = function() ui.close_win_pair(commit_state, "filetree_win", "filetree_buf") end
+M._get_session_gen = function() return session_gen end
+M._reset_state = reset_state
 
 return M

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -620,6 +620,7 @@ local function enter_commit_mode()
   open.pause_sync()
   state.set_commit_mode(true)
   commit_state.active = true
+  state.set_mode_exit(function() exit_commit_mode() end)
 
   local vcfg = ui.parse_viewer_config()
   ui.SIDEBAR_WIDTH = vcfg.sidebar_width
@@ -704,6 +705,7 @@ local function exit_commit_mode()
     on_before_only = function()
       commit_mode_keymaps = {}
       state.set_commit_mode(false)
+      state.set_mode_exit(nil)
     end,
     on_after = function()
       keymaps.setup()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -13,6 +13,13 @@ local ui = require("raccoon.commit_ui")
 
 local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
 
+--- Compute the base ref for combined diff operations.
+---@return string base_ref e.g. "origin/main"
+local function get_base_ref()
+  local pr = state.get_pr()
+  return pr and ("origin/" .. pr.base.ref) or "origin/main"
+end
+
 --- Namespace for commit viewer highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_commits")
 
@@ -48,6 +55,11 @@ local commit_state = {
   cached_stat_lines = nil,
   cached_file_count = nil,
   focus_target = "sidebar",
+  poll_timer = nil,
+  last_head_sha = nil,
+  base_branch = nil,
+  base_count = 20,
+  sync_interval_ms = 60000,
 }
 
 --- Commit mode keymaps (global)
@@ -86,6 +98,11 @@ local function reset_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    poll_timer = nil,
+    last_head_sha = nil,
+    base_branch = nil,
+    base_count = 20,
+    sync_interval_ms = 60000,
   }
 end
 
@@ -153,9 +170,6 @@ local function maximize_cell(cell_num)
   local clone_path = state.get_clone_path()
   if not commit or not clone_path then return end
 
-  local pr = state.get_pr()
-  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
-
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = clone_path,
@@ -166,7 +180,7 @@ local function maximize_cell(cell_num)
     get_generation = function() return commit_state.select_generation end,
     state = commit_state,
     is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
-    base_ref = base_ref,
+    base_ref = get_base_ref(),
   })
 end
 
@@ -190,12 +204,14 @@ local function select_commit(index)
   if not clone_path then return end
 
   local context = ui.compute_grid_context(commit_state.grid_rows)
-  local pr = state.get_pr()
-  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
 
-  local fetch_diff = commit.sha == COMBINED_DIFF_SHA
-    and function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
-    or function(cb) git.show_commit(clone_path, commit.sha, context, cb) end
+  local fetch_diff
+  if commit.sha == COMBINED_DIFF_SHA then
+    local base_ref = get_base_ref()
+    fetch_diff = function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
+  else
+    fetch_diff = function(cb) git.show_commit(clone_path, commit.sha, context, cb) end
+  end
 
   fetch_diff(function(files, err)
     if generation ~= commit_state.select_generation then return end
@@ -327,9 +343,127 @@ build_filetree_cache = function()
   if not clone_path then return end
   local commit = get_commit(commit_state.selected_index)
   local sha = commit and commit.sha or "HEAD"
-  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
-  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(commit_state, clone_path, sha)
+end
+
+--- Stop the background sync timer
+local function stop_poll_timer()
+  if commit_state.poll_timer then
+    commit_state.poll_timer:stop()
+    commit_state.poll_timer:close()
+    commit_state.poll_timer = nil
+  end
+end
+
+--- Preserve selected commit across a refresh
+local function restore_selection_by_sha(selected_sha)
+  if selected_sha then
+    for i = 1, total_commits() do
+      local c = get_commit(i)
+      if c and c.sha == selected_sha then
+        commit_state.selected_index = i
+        return
+      end
+    end
+  end
+  if commit_state.selected_index > total_commits() then
+    commit_state.selected_index = math.max(1, total_commits())
+  end
+end
+
+--- Refresh commits after detecting remote changes.
+--- Fetches updated commit lists and rebuilds the sidebar, preserving selection.
+local function refresh_commits()
+  local clone_path = state.get_clone_path()
+  local base_branch = commit_state.base_branch
+  if not clone_path or not base_branch then return end
+
+  local selected_sha = get_commit(commit_state.selected_index)
+    and get_commit(commit_state.selected_index).sha
+
+  local pending = 2
+  local new_pr, new_base
+
+  local function on_both_ready()
+    commit_state.pr_commits = new_pr or {}
+    commit_state.base_commits = new_base or {}
+
+    if #commit_state.pr_commits > 1 then
+      table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
+    end
+
+    restore_selection_by_sha(selected_sha)
+    render_sidebar()
+
+    -- Re-select current commit to refresh the grid diff
+    if total_commits() > 0 then
+      select_commit(commit_state.selected_index)
+    end
+  end
+
+  local function check_done()
+    pending = pending - 1
+    if pending == 0 then on_both_ready() end
+  end
+
+  git.log_commits(clone_path, base_branch, function(commits, err)
+    new_pr = (not err) and commits or {}
+    check_done()
+  end)
+
+  git.log_base_commits(clone_path, base_branch, commit_state.base_count, function(commits, err)
+    new_base = (not err) and commits or {}
+    check_done()
+  end)
+end
+
+--- Start the background sync timer.
+--- On each tick: fetch PR + base branches from origin, check if HEAD changed, reset and refresh if so.
+local function start_poll_timer()
+  stop_poll_timer()
+  if not commit_state.active then return end
+  if commit_state.sync_interval_ms <= 0 then return end
+
+  local clone_path = state.get_clone_path()
+  local pr = state.get_pr()
+  if not clone_path or not pr then return end
+
+  local pr_branch = pr.head.ref
+  local base_branch = commit_state.base_branch
+
+  -- Seed last_head_sha
+  git.get_current_sha(clone_path, function(sha, _)
+    if sha then commit_state.last_head_sha = sha end
+  end)
+
+  commit_state.poll_timer = vim.uv.new_timer()
+  commit_state.poll_timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
+    vim.schedule_wrap(function()
+      if not commit_state.active then return end
+
+      -- Fetch PR branch from origin
+      git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
+        if fetch_err or not commit_state.active then return end
+
+        -- Also fetch base branch to keep it current
+        git.fetch_branch(clone_path, base_branch, function(_, _)
+          if not commit_state.active then return end
+
+          -- Check if origin/<pr_branch> has new commits
+          git.ref_sha(clone_path, "origin/" .. pr_branch, function(remote_sha, _)
+            if not remote_sha or not commit_state.active then return end
+            if remote_sha == commit_state.last_head_sha then return end
+
+            -- New commits detected — reset local to match origin
+            git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, _)
+              if not ok or not commit_state.active then return end
+              commit_state.last_head_sha = remote_sha
+              refresh_commits()
+            end)
+          end)
+        end)
+      end)
+    end))
 end
 
 --- Setup commit mode keymaps (buffer-local to all commit-mode buffers)
@@ -411,10 +545,7 @@ local function setup_keymaps()
       local c = get_commit(commit_state.selected_index)
       return c and c.message or ""
     end,
-    get_base_ref = function()
-      local pr = state.get_pr()
-      return pr and ("origin/" .. pr.base.ref) or "origin/main"
-    end,
+    get_base_ref = get_base_ref,
   })
 
   -- Focus lock autocmd
@@ -453,6 +584,7 @@ local function enter_commit_mode()
   local rows = 2
   local cols = 2
   local base_count = 20
+  local sync_interval = 60
   if cfg and cfg.commit_viewer then
     if cfg.commit_viewer.grid then
       rows = ui.clamp_int(cfg.commit_viewer.grid.rows, 2, 1, 10)
@@ -460,9 +592,13 @@ local function enter_commit_mode()
     end
     base_count = ui.clamp_int(cfg.commit_viewer.base_commits_count, 20, 1, 200)
     ui.SIDEBAR_WIDTH = ui.clamp_int(cfg.commit_viewer.sidebar_width, 50, 20, 120)
+    sync_interval = ui.clamp_int(cfg.commit_viewer.sync_interval, 60, 10, 3600)
   end
 
   local base_branch = pr.base.ref
+  commit_state.base_branch = base_branch
+  commit_state.base_count = base_count
+  commit_state.sync_interval_ms = sync_interval * 1000
 
   vim.notify("Entering commit viewer mode...", vim.log.levels.INFO)
 
@@ -489,14 +625,14 @@ local function enter_commit_mode()
 
         -- Add combined diff entry at the top when there are multiple PR commits
         if #commit_state.pr_commits > 1 then
-          table.insert(commit_state.pr_commits, 1,
-            { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+          table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
         end
 
         ui.create_grid_layout(commit_state, rows, cols)
         render_sidebar()
         setup_keymaps()
         select_commit(1)
+        start_poll_timer()
         vim.notify(string.format("Commit viewer: %d PR commits, %d base commits",
           #commit_state.pr_commits, #commit_state.base_commits))
       end
@@ -532,6 +668,8 @@ end
 
 --- Exit commit viewer mode
 local function exit_commit_mode()
+  stop_poll_timer()
+
   if commit_state.focus_augroup then
     pcall(vim.api.nvim_del_augroup_by_id, commit_state.focus_augroup)
   end
@@ -558,6 +696,12 @@ local function exit_commit_mode()
 
   reset_state()
   vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
+end
+
+--- Register or clear an external popup window so the focus lock allows it.
+---@param win? number Window handle, or nil to clear
+function M.set_popup_win(win)
+  commit_state.popup_win = win
 end
 
 --- Toggle commit viewer mode

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -604,25 +604,15 @@ local function enter_commit_mode()
   state.set_commit_mode(true)
   commit_state.active = true
 
-  local cfg = config.load()
-  local rows = 2
-  local cols = 2
-  local base_count = 20
-  local sync_interval = 60
-  if cfg and cfg.commit_viewer then
-    if cfg.commit_viewer.grid then
-      rows = ui.clamp_int(cfg.commit_viewer.grid.rows, 2, 1, 10)
-      cols = ui.clamp_int(cfg.commit_viewer.grid.cols, 2, 1, 10)
-    end
-    base_count = ui.clamp_int(cfg.commit_viewer.base_commits_count, 20, 1, 200)
-    ui.SIDEBAR_WIDTH = ui.clamp_int(cfg.commit_viewer.sidebar_width, 50, 20, 120)
-    sync_interval = ui.clamp_int(cfg.commit_viewer.sync_interval, 60, 10, 3600)
-  end
+  local vcfg = ui.parse_viewer_config()
+  ui.SIDEBAR_WIDTH = vcfg.sidebar_width
 
+  local rows = vcfg.rows
+  local cols = vcfg.cols
   local base_branch = pr.base.ref
   commit_state.base_branch = base_branch
-  commit_state.base_count = base_count
-  commit_state.sync_interval_ms = sync_interval * 1000
+  commit_state.base_count = vcfg.base_count
+  commit_state.sync_interval_ms = vcfg.sync_interval * 1000
 
   vim.notify("Entering commit viewer mode...", vim.log.levels.INFO)
 

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -14,10 +14,12 @@ local ui = require("raccoon.commit_ui")
 local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
 
 --- Compute the base ref for combined diff operations.
----@return string base_ref
+--- Returns nil when no PR is active; callers should handle nil (diff_combined already guards it).
+---@return string|nil base_ref
 local function get_base_ref()
   local pr = state.get_pr()
-  return pr and ("origin/" .. pr.base.ref) or "origin/main"
+  if not pr then return nil end
+  return "origin/" .. pr.base.ref
 end
 
 --- Namespace for commit viewer highlights
@@ -79,11 +81,10 @@ local sync_in_flight = false
 --- Stop the background sync timer
 local function stop_poll_timer()
   if poll_timer_handle then
-    pcall(function()
-      poll_timer_handle:stop()
-      poll_timer_handle:close()
-    end)
+    local handle = poll_timer_handle
     poll_timer_handle = nil
+    pcall(handle.stop, handle)
+    pcall(handle.close, handle)
   end
   sync_in_flight = false
 end
@@ -172,7 +173,6 @@ local function maximize_cell(cell_num)
   })
 end
 
--- Forward declaration
 local build_filetree_cache
 
 --- Select a commit and load its hunks into the grid
@@ -336,18 +336,7 @@ end
 
 --- Preserve selected commit across a refresh
 local function restore_selection_by_sha(selected_sha)
-  if selected_sha then
-    for i = 1, total_commits() do
-      local c = get_commit(i)
-      if c and c.sha == selected_sha then
-        commit_state.selected_index = i
-        return
-      end
-    end
-  end
-  if commit_state.selected_index > total_commits() then
-    commit_state.selected_index = math.max(1, total_commits())
-  end
+  ui.restore_selection_by_sha(commit_state, selected_sha, total_commits, get_commit)
 end
 
 --- Refresh commits after detecting remote changes.
@@ -367,14 +356,14 @@ local function refresh_commits()
     commit_state.pr_commits = new_pr or commit_state.pr_commits
     commit_state.base_commits = new_base or commit_state.base_commits
 
-    if #commit_state.pr_commits > 1 then
+    if #commit_state.pr_commits > 1
+      and commit_state.pr_commits[1].sha ~= COMBINED_DIFF_SHA then
       table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
     end
 
     restore_selection_by_sha(selected_sha)
     render_sidebar()
 
-    -- Re-select current commit to refresh the grid diff
     if total_commits() > 0 then
       select_commit(commit_state.selected_index)
     end
@@ -386,12 +375,18 @@ local function refresh_commits()
   end
 
   git.log_commits(clone_path, base_branch, function(commits, err)
-    new_pr = (not err) and commits or {}
+    if err then
+      vim.notify("Sync: failed to refresh PR commits", vim.log.levels.DEBUG)
+    end
+    new_pr = (not err) and commits or nil
     check_done()
   end)
 
   git.log_base_commits(clone_path, base_branch, commit_state.base_count, function(commits, err)
-    new_base = (not err) and commits or {}
+    if err then
+      vim.notify("Sync: failed to refresh base commits", vim.log.levels.DEBUG)
+    end
+    new_base = (not err) and commits or nil
     check_done()
   end)
 end
@@ -417,8 +412,11 @@ local function sync_tick(clone_path, pr_branch, base_branch)
       done(); return
     end
 
-    git.fetch_branch(clone_path, base_branch, function(_, _)
+    git.fetch_branch(clone_path, base_branch, function(_, base_fetch_err)
       if not commit_state.active then done(); return end
+      if base_fetch_err then
+        vim.notify("Sync: failed to fetch base branch", vim.log.levels.DEBUG)
+      end
 
       -- Check both PR and base branch SHAs in parallel
       local pending = 2
@@ -465,12 +463,18 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         end
       end
 
-      git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, _)
+      git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, ref_err)
+        if ref_err then
+          vim.notify("Sync: could not resolve PR branch SHA", vim.log.levels.DEBUG)
+        end
         pr_sha = sha
         check_both()
       end)
 
-      git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, _)
+      git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, ref_err)
+        if ref_err then
+          vim.notify("Sync: could not resolve base branch SHA", vim.log.levels.DEBUG)
+        end
         base_sha = sha
         check_both()
       end)
@@ -494,12 +498,18 @@ local function start_poll_timer()
 
   -- Seed last_head_sha and last_base_sha before starting the timer to avoid spurious refresh on first tick
   sync_in_flight = false
-  git.get_current_sha(clone_path, function(sha, _)
+  git.get_current_sha(clone_path, function(sha, seed_err)
     if not commit_state.active then return end
+    if seed_err then
+      vim.notify("Sync: failed to seed HEAD SHA", vim.log.levels.DEBUG)
+    end
     if sha then commit_state.last_head_sha = sha end
 
-    git.ref_sha(clone_path, "origin/" .. base_branch, function(base_sha, _)
+    git.ref_sha(clone_path, "origin/" .. base_branch, function(base_sha, base_seed_err)
       if not commit_state.active then return end
+      if base_seed_err then
+        vim.notify("Sync: failed to seed base SHA", vim.log.levels.DEBUG)
+      end
       if base_sha then commit_state.last_base_sha = base_sha end
 
       -- Guard against concurrent timer creation from rapid toggle
@@ -507,6 +517,10 @@ local function start_poll_timer()
       if not commit_state.active then return end
 
       local timer = vim.uv.new_timer()
+      if not timer then
+        vim.notify("Failed to create sync timer", vim.log.levels.WARN)
+        return
+      end
       poll_timer_handle = timer
       timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
         vim.schedule_wrap(function()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -14,7 +14,7 @@ local ui = require("raccoon.commit_ui")
 local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
 
 --- Compute the base ref for combined diff operations.
----@return string base_ref e.g. "origin/main"
+---@return string base_ref
 local function get_base_ref()
   local pr = state.get_pr()
   return pr and ("origin/" .. pr.base.ref) or "origin/main"
@@ -23,52 +23,8 @@ end
 --- Namespace for commit viewer highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_commits")
 
---- Module-local state
-local commit_state = {
-  active = false,
-  sidebar_win = nil,
-  sidebar_buf = nil,
-  pr_commits = {},
-  base_commits = {},
-  selected_index = 1,
-  grid_wins = {},
-  grid_bufs = {},
-  all_hunks = {},
-  commit_files = {},
-  file_stats = {},
-  current_page = 1,
-  saved_buf = nil,
-  saved_laststatus = nil,
-  grid_rows = 2,
-  grid_cols = 2,
-  maximize_win = nil,
-  maximize_buf = nil,
-  focus_augroup = nil,
-  header_win = nil,
-  header_buf = nil,
-  filetree_win = nil,
-  filetree_buf = nil,
-  select_generation = 0,
-  cached_sha = nil,
-  cached_tree_lines = nil,
-  cached_line_paths = nil,
-  cached_stat_lines = nil,
-  cached_file_count = nil,
-  focus_target = "sidebar",
-  poll_timer = nil,
-  last_head_sha = nil,
-  base_branch = nil,
-  base_count = 20,
-  sync_interval_ms = 60000,
-}
-
---- Commit mode keymaps (global)
-local commit_mode_keymaps = {}
-
---- Reset module state
-local function reset_state()
-  stop_poll_timer()
-  commit_state = {
+local function make_initial_state()
+  return {
     active = false,
     sidebar_win = nil,
     sidebar_buf = nil,
@@ -105,6 +61,21 @@ local function reset_state()
     base_count = 20,
     sync_interval_ms = 60000,
   }
+end
+
+--- Module-local state
+local commit_state = make_initial_state()
+
+--- Commit mode keymaps (global)
+local commit_mode_keymaps = {}
+
+--- Forward declarations
+local stop_poll_timer
+
+--- Reset module state
+local function reset_state()
+  stop_poll_timer()
+  commit_state = make_initial_state()
 end
 
 --- Calculate total pages
@@ -348,10 +319,12 @@ build_filetree_cache = function()
 end
 
 --- Stop the background sync timer
-local function stop_poll_timer()
+function stop_poll_timer()
   if commit_state.poll_timer then
-    commit_state.poll_timer:stop()
-    commit_state.poll_timer:close()
+    pcall(function()
+      commit_state.poll_timer:stop()
+      commit_state.poll_timer:close()
+    end)
     commit_state.poll_timer = nil
   end
 end
@@ -386,8 +359,9 @@ local function refresh_commits()
   local new_pr, new_base
 
   local function on_both_ready()
-    commit_state.pr_commits = new_pr or {}
-    commit_state.base_commits = new_base or {}
+    if not new_pr and not new_base then return end
+    commit_state.pr_commits = new_pr or commit_state.pr_commits
+    commit_state.base_commits = new_base or commit_state.base_commits
 
     if #commit_state.pr_commits > 1 then
       table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
@@ -419,7 +393,8 @@ local function refresh_commits()
 end
 
 --- Start the background sync timer.
---- On each tick: fetch PR + base branches from origin, check if HEAD changed, reset and refresh if so.
+--- On each tick: fetch PR branch from origin (required), optionally refresh base branch,
+--- then check if HEAD changed and reset/refresh if so.
 local function start_poll_timer()
   stop_poll_timer()
   if not commit_state.active then return end
@@ -432,39 +407,52 @@ local function start_poll_timer()
   local pr_branch = pr.head.ref
   local base_branch = commit_state.base_branch
 
-  -- Seed last_head_sha
+  -- Seed last_head_sha before starting the timer to avoid spurious reset on first tick
   git.get_current_sha(clone_path, function(sha, _)
+    if not commit_state.active then return end
     if sha then commit_state.last_head_sha = sha end
-  end)
 
-  commit_state.poll_timer = vim.uv.new_timer()
-  commit_state.poll_timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
-    vim.schedule_wrap(function()
-      if not commit_state.active then return end
+    commit_state.poll_timer = vim.uv.new_timer()
+    commit_state.poll_timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
+      vim.schedule_wrap(function()
+        if not commit_state.active then return end
 
-      -- Fetch PR branch from origin
-      git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
-        if fetch_err or not commit_state.active then return end
-
-        -- Also fetch base branch to keep it current
-        git.fetch_branch(clone_path, base_branch, function(_, _)
+        -- Fetch PR branch from origin
+        git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
           if not commit_state.active then return end
+          if fetch_err then
+            vim.notify("Sync: failed to fetch PR branch", vim.log.levels.DEBUG)
+            return
+          end
 
-          -- Check if origin/<pr_branch> has new commits
-          git.ref_sha(clone_path, "origin/" .. pr_branch, function(remote_sha, _)
-            if not remote_sha or not commit_state.active then return end
-            if remote_sha == commit_state.last_head_sha then return end
+          -- Also fetch base branch to keep it current (non-blocking on failure)
+          git.fetch_branch(clone_path, base_branch, function(_, _)
+            if not commit_state.active then return end
 
-            -- New commits detected — reset local to match origin
-            git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, _)
-              if not ok or not commit_state.active then return end
-              commit_state.last_head_sha = remote_sha
-              refresh_commits()
+            -- Check if origin/<pr_branch> has new commits
+            git.ref_sha(clone_path, "origin/" .. pr_branch, function(remote_sha, _)
+              if not remote_sha or not commit_state.active then return end
+              if not commit_state.last_head_sha then
+                commit_state.last_head_sha = remote_sha
+                return
+              end
+              if remote_sha == commit_state.last_head_sha then return end
+
+              -- New commits detected — reset local to match origin
+              git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
+                if not commit_state.active then return end
+                if not ok then
+                  vim.notify("Sync: failed to reset to remote: " .. (reset_err or ""), vim.log.levels.DEBUG)
+                  return
+                end
+                commit_state.last_head_sha = remote_sha
+                refresh_commits()
+              end)
             end)
           end)
         end)
-      end)
-    end))
+      end))
+  end)
 end
 
 --- Setup commit mode keymaps (buffer-local to all commit-mode buffers)
@@ -624,8 +612,8 @@ local function enter_commit_mode()
           return
         end
 
-        -- Add combined diff entry at the top when there are multiple PR commits
-        if #commit_state.pr_commits > 1 then
+        local real_pr_count = #commit_state.pr_commits
+        if real_pr_count > 1 then
           table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
         end
 
@@ -635,7 +623,7 @@ local function enter_commit_mode()
         select_commit(1)
         start_poll_timer()
         vim.notify(string.format("Commit viewer: %d PR commits, %d base commits",
-          #commit_state.pr_commits, #commit_state.base_commits))
+          real_pr_count, #commit_state.base_commits))
       end
 
       local function check_done()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -49,6 +49,11 @@ local sync_in_flight = false
 --- from a previous viewer session can detect they are stale and bail out.
 local session_gen = 0
 
+--- Consecutive sync failure counter. After SYNC_FAIL_ESCALATION_THRESHOLD,
+--- notifications escalate from DEBUG to WARN so the user knows sync is broken.
+local sync_fail_count = 0
+local SYNC_FAIL_ESCALATION_THRESHOLD = 3
+
 --- Stop the background sync timer
 local function stop_poll_timer()
   if poll_timer_handle then
@@ -298,6 +303,12 @@ local function refresh_commits(on_complete)
       return
     end
 
+    if not new_pr then
+      vim.notify("Sync: PR commits are stale (refresh failed)", vim.log.levels.WARN)
+    end
+    if not new_base then
+      vim.notify("Sync: base commits are stale (refresh failed)", vim.log.levels.WARN)
+    end
     commit_state.pr_commits = new_pr or commit_state.pr_commits
     commit_state.base_commits = new_base or commit_state.base_commits
 
@@ -346,8 +357,21 @@ local function sync_tick(clone_path, pr_branch, base_branch)
   sync_in_flight = true
   local my_gen = session_gen
 
-  local function done()
+  --- Escalate from DEBUG to WARN after repeated failures so the user is informed.
+  local function sync_log(msg)
+    local level = sync_fail_count >= SYNC_FAIL_ESCALATION_THRESHOLD
+      and vim.log.levels.WARN or vim.log.levels.DEBUG
+    vim.notify(msg, level)
+  end
+
+  local function done_fail()
     sync_in_flight = false
+    sync_fail_count = sync_fail_count + 1
+  end
+
+  local function done_ok()
+    sync_in_flight = false
+    sync_fail_count = 0
   end
 
   local function stale()
@@ -355,16 +379,16 @@ local function sync_tick(clone_path, pr_branch, base_branch)
   end
 
   git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
-    if stale() then done(); return end
+    if stale() then done_fail(); return end
     if fetch_err then
-      vim.notify("Sync: failed to fetch PR branch", vim.log.levels.DEBUG)
-      done(); return
+      sync_log("Sync: failed to fetch PR branch")
+      done_fail(); return
     end
 
     git.fetch_branch(clone_path, base_branch, function(_, base_fetch_err)
-      if stale() then done(); return end
+      if stale() then done_fail(); return end
       if base_fetch_err then
-        vim.notify("Sync: failed to fetch base branch", vim.log.levels.DEBUG)
+        sync_log("Sync: failed to fetch base branch")
       end
 
       -- Check both PR and base branch SHAs in parallel
@@ -373,7 +397,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
       local function check_both()
         pending = pending - 1
         if pending > 0 then return end
-        if stale() then done(); return end
+        if stale() then done_fail(); return end
 
         -- Defensive fallback: seed SHAs if start_poll_timer's seeding was incomplete
         if not commit_state.last_head_sha then
@@ -387,7 +411,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         local base_changed = base_sha and base_sha ~= commit_state.last_base_sha
 
         if not pr_changed and not base_changed then
-          done(); return
+          done_ok(); return
         end
 
         -- Update tracked base SHA
@@ -396,23 +420,23 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         if pr_changed then
           -- PR branch advanced — reset local clone to match origin
           git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
-            if stale() then done(); return end
+            if stale() then done_fail(); return end
             if not ok then
-              vim.notify("Sync: failed to reset to remote: " .. (reset_err or ""), vim.log.levels.DEBUG)
-              done(); return
+              sync_log("Sync: failed to reset to remote: " .. (reset_err or ""))
+              done_fail(); return
             end
             commit_state.last_head_sha = pr_sha
-            refresh_commits(done)
+            refresh_commits(done_ok)
           end)
         else
           -- Only base branch changed — refresh commit lists without reset
-          refresh_commits(done)
+          refresh_commits(done_ok)
         end
       end
 
       git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, ref_err)
         if ref_err then
-          vim.notify("Sync: could not resolve PR branch SHA", vim.log.levels.DEBUG)
+          sync_log("Sync: could not resolve PR branch SHA")
         end
         pr_sha = sha
         check_both()
@@ -420,7 +444,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
 
       git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, ref_err)
         if ref_err then
-          vim.notify("Sync: could not resolve base branch SHA", vim.log.levels.DEBUG)
+          sync_log("Sync: could not resolve base branch SHA")
         end
         base_sha = sha
         check_both()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -38,6 +38,9 @@ end
 local commit_state = make_initial_state()
 local commit_mode_keymaps = {}
 
+-- Forward declaration to allow enter_commit_mode to register the exit hook.
+local exit_commit_mode
+
 --- Module-level timer handle. Stored outside commit_state so stop_poll_timer()
 --- can always reach it, even when reset_state() replaces the state table.
 local poll_timer_handle = nil
@@ -637,7 +640,7 @@ local function enter_commit_mode()
   open.pause_sync()
   state.set_commit_mode(true)
   commit_state.active = true
-  state.set_mode_exit(function() exit_commit_mode() end)
+  state.set_mode_exit(exit_commit_mode)
 
   local vcfg = ui.parse_viewer_config()
   ui.SIDEBAR_WIDTH = vcfg.sidebar_width

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -78,8 +78,7 @@ local function stop_poll_timer()
   if poll_timer_handle then
     local handle = poll_timer_handle
     poll_timer_handle = nil
-    pcall(handle.stop, handle)
-    pcall(handle.close, handle)
+    ui.safe_close_timer(handle)
   end
   sync_in_flight = false
 end

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -742,6 +742,17 @@ function M.toggle()
   end
 end
 
+function M.is_active()
+  return commit_state.active
+end
+
+function M.close()
+  if commit_state.active then
+    exit_commit_mode()
+  end
+end
+
+-- Exposed for testing
 M._lock_buf = ui.lock_buf
 M._lock_maximize_buf = function(buf) ui.lock_maximize_buf(buf, commit_state.grid_rows, commit_state.grid_cols) end
 M._clamp_int = ui.clamp_int

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -16,7 +16,7 @@ local ui = require("raccoon.commit_ui")
 ---@return string|nil base_ref
 local function get_base_ref()
   local pr = state.get_pr()
-  if not pr then return nil end
+  if not pr or not pr.base or not pr.base.ref then return nil end
   return "origin/" .. pr.base.ref
 end
 
@@ -384,14 +384,14 @@ local function sync_tick(clone_path, pr_branch, base_branch)
   end
 
   git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
-    if stale() then done_fail(); return end
+    if stale() then sync_in_flight = false; return end
     if fetch_err then
       sync_log("Sync: failed to fetch PR branch: " .. tostring(fetch_err))
       done_fail(); return
     end
 
     git.fetch_branch(clone_path, base_branch, function(_, base_fetch_err)
-      if stale() then done_fail(); return end
+      if stale() then sync_in_flight = false; return end
       -- Base fetch is non-fatal: we still check PR branch SHAs.
       -- Use stale base SHA to avoid false "changed" detection.
       local base_fetch_failed = false
@@ -406,7 +406,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
       local function check_both()
         pending = pending - 1
         if pending > 0 then return end
-        if stale() then done_fail(); return end
+        if stale() then sync_in_flight = false; return end
 
         -- Defensive fallback: seed SHAs if start_poll_timer's seeding was incomplete
         if not commit_state.last_head_sha then
@@ -435,7 +435,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         if pr_changed then
           -- PR branch advanced — reset local clone to match origin
           git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
-            if stale() then done_fail(); return end
+            if stale() then sync_in_flight = false; return end
             if not ok then
               sync_log("Sync: failed to reset to remote: " .. (reset_err or ""))
               done_fail(); return
@@ -449,11 +449,9 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         end
       end
 
-      local sha_failures = 0
       git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, ref_err)
         if ref_err then
           sync_log("Sync: could not resolve PR branch SHA: " .. tostring(ref_err))
-          sha_failures = sha_failures + 1
         end
         pr_sha = sha
         check_both()
@@ -467,7 +465,6 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, ref_err)
           if ref_err then
             sync_log("Sync: could not resolve base branch SHA: " .. tostring(ref_err))
-            sha_failures = sha_failures + 1
           end
           base_sha = sha
           check_both()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -4,7 +4,6 @@ local M = {}
 
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
-local diff = require("raccoon.diff")
 local git = require("raccoon.git")
 local keymaps = require("raccoon.keymaps")
 local open = require("raccoon.open")
@@ -202,56 +201,17 @@ local function select_commit(index)
   end
 
   fetch_diff(function(files, err)
-    if generation ~= commit_state.select_generation then return end
-
-    if err then
-      vim.notify("Failed to get commit diff: " .. err, vim.log.levels.ERROR)
-      return
-    end
-
-    -- Track files, compute stats, and build flat hunk list in a single pass
-    commit_state.commit_files = {}
-    commit_state.file_stats = {}
-    commit_state.all_hunks = {}
-    commit_state.cached_sha = nil
-    commit_state.cached_stat_lines = nil
-    for _, file in ipairs(files or {}) do
-      commit_state.commit_files[file.filename] = true
-      local additions = 0
-      local deletions = 0
-      local hunks = diff.parse_patch(file.patch)
-      for _, hunk in ipairs(hunks) do
-        table.insert(commit_state.all_hunks, { hunk = hunk, filename = file.filename })
-        for _, line_data in ipairs(hunk.lines) do
-          if line_data.type == "add" then
-            additions = additions + 1
-          elseif line_data.type == "del" then
-            deletions = deletions + 1
-          end
-        end
-      end
-      commit_state.file_stats[file.filename] = { additions = additions, deletions = deletions }
-    end
-    build_filetree_cache()
-
-    if #commit_state.all_hunks == 0 then
-      for i, buf in ipairs(commit_state.grid_bufs) do
-        if vim.api.nvim_buf_is_valid(buf) then
-          vim.bo[buf].modifiable = true
-          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", "  No changes in this commit" })
-          vim.bo[buf].modifiable = false
-        end
-        local win = commit_state.grid_wins[i]
-        if win and vim.api.nvim_win_is_valid(win) then
-          vim.wo[win].winbar = "%=#" .. i
-        end
-      end
-      ui.update_header(commit_state, get_commit(commit_state.selected_index), total_pages())
-      ui.render_filetree(commit_state)
-      return
-    end
-
-    render_grid_page()
+    ui.apply_diff_result(commit_state, {
+      files = files,
+      err = err,
+      generation = generation,
+      get_generation = function() return commit_state.select_generation end,
+      build_cache_fn = build_filetree_cache,
+      get_commit_fn = function() return get_commit(commit_state.selected_index) end,
+      total_pages_fn = total_pages,
+      ns_id = ns_id,
+      render_grid_fn = render_grid_page,
+    })
   end)
 end
 

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -63,14 +63,11 @@ local function make_initial_state()
   }
 end
 
---- Module-local state
 local commit_state = make_initial_state()
-
---- Commit mode keymaps (global)
 local commit_mode_keymaps = {}
 
---- Module-level timer handle. Stored outside commit_state so it survives
---- state table reassignment in reset_state() and can always be stopped.
+--- Module-level timer handle. Stored outside commit_state so stop_poll_timer()
+--- can always reach it, even when reset_state() replaces the state table.
 local poll_timer_handle = nil
 
 --- In-flight guard: prevents overlapping sync ticks from running concurrent git operations.
@@ -87,13 +84,11 @@ local function stop_poll_timer()
   sync_in_flight = false
 end
 
---- Reset module state
 local function reset_state()
   stop_poll_timer()
   commit_state = make_initial_state()
 end
 
---- Calculate total pages
 ---@return number
 local function total_pages()
   local cells = commit_state.grid_rows * commit_state.grid_cols
@@ -119,7 +114,6 @@ local function get_commit(index)
   end
 end
 
---- Render the current page of hunks into the grid
 local function render_grid_page()
   ui.render_grid_page(commit_state, ns_id, function()
     return get_commit(commit_state.selected_index)
@@ -359,7 +353,8 @@ local function refresh_commits(on_complete)
   end)
 end
 
---- Single sync tick: fetch branches, check for new commits, reset and refresh if needed.
+--- Single sync tick: fetch branches, compare SHAs, and refresh commit lists.
+--- Hard-resets the local clone only when the PR branch has advanced.
 --- Guarded by sync_in_flight to prevent overlapping git operations.
 ---@param clone_path string
 ---@param pr_branch string
@@ -394,7 +389,7 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         if pending > 0 then return end
         if not commit_state.active then done(); return end
 
-        -- Seed SHAs on first tick
+        -- Defensive fallback: seed SHAs if start_poll_timer's seeding was incomplete
         if not commit_state.last_head_sha then
           commit_state.last_head_sha = pr_sha
         end

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -67,6 +67,7 @@ end
 local function reset_state()
   stop_poll_timer()
   session_gen = session_gen + 1
+  sync_fail_count = 0
   commit_state = make_initial_state()
 end
 
@@ -77,7 +78,7 @@ local function total_pages()
   return math.max(1, math.ceil(#commit_state.all_hunks / cells))
 end
 
---- Total navigable commits (PR + base)
+--- Total navigable sidebar entries (PR section + base section, including synthetic entries)
 ---@return number
 local function total_commits()
   return #commit_state.pr_commits + #commit_state.base_commits
@@ -334,7 +335,7 @@ local function refresh_commits(on_complete)
 
   git.log_commits(clone_path, base_branch, function(commits, err)
     if err then
-      vim.notify("Sync: failed to refresh PR commits", vim.log.levels.DEBUG)
+      vim.notify("Sync: failed to refresh PR commits: " .. tostring(err), vim.log.levels.DEBUG)
     end
     new_pr = (not err) and commits or nil
     check_done()
@@ -342,7 +343,7 @@ local function refresh_commits(on_complete)
 
   git.log_base_commits(clone_path, base_branch, commit_state.base_count, function(commits, err)
     if err then
-      vim.notify("Sync: failed to refresh base commits", vim.log.levels.DEBUG)
+      vim.notify("Sync: failed to refresh base commits: " .. tostring(err), vim.log.levels.DEBUG)
     end
     new_base = (not err) and commits or nil
     check_done()
@@ -385,14 +386,18 @@ local function sync_tick(clone_path, pr_branch, base_branch)
   git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
     if stale() then done_fail(); return end
     if fetch_err then
-      sync_log("Sync: failed to fetch PR branch")
+      sync_log("Sync: failed to fetch PR branch: " .. tostring(fetch_err))
       done_fail(); return
     end
 
     git.fetch_branch(clone_path, base_branch, function(_, base_fetch_err)
       if stale() then done_fail(); return end
+      -- Base fetch is non-fatal: we still check PR branch SHAs.
+      -- Use stale base SHA to avoid false "changed" detection.
+      local base_fetch_failed = false
       if base_fetch_err then
-        sync_log("Sync: failed to fetch base branch")
+        sync_log("Sync: failed to fetch base branch: " .. tostring(base_fetch_err))
+        base_fetch_failed = true
       end
 
       -- Check both PR and base branch SHAs in parallel
@@ -409,6 +414,12 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         end
         if not commit_state.last_base_sha then
           commit_state.last_base_sha = base_sha
+        end
+
+        -- If both SHA resolutions failed, treat as sync failure
+        if not pr_sha and not base_sha then
+          sync_log("Sync: could not resolve any branch SHAs")
+          done_fail(); return
         end
 
         local pr_changed = pr_sha and pr_sha ~= commit_state.last_head_sha
@@ -438,21 +449,30 @@ local function sync_tick(clone_path, pr_branch, base_branch)
         end
       end
 
+      local sha_failures = 0
       git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, ref_err)
         if ref_err then
-          sync_log("Sync: could not resolve PR branch SHA")
+          sync_log("Sync: could not resolve PR branch SHA: " .. tostring(ref_err))
+          sha_failures = sha_failures + 1
         end
         pr_sha = sha
         check_both()
       end)
 
-      git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, ref_err)
-        if ref_err then
-          sync_log("Sync: could not resolve base branch SHA")
-        end
-        base_sha = sha
+      if base_fetch_failed then
+        -- Skip base SHA check since fetch failed; use stale value to prevent false "changed"
+        base_sha = commit_state.last_base_sha
         check_both()
-      end)
+      else
+        git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, ref_err)
+          if ref_err then
+            sync_log("Sync: could not resolve base branch SHA: " .. tostring(ref_err))
+            sha_failures = sha_failures + 1
+          end
+          base_sha = sha
+          check_both()
+        end)
+      end
     end)
   end)
 end
@@ -684,7 +704,7 @@ local function enter_commit_mode()
         check_done()
       end)
 
-      git.log_base_commits(clone_path, base_branch, base_count, function(commits, err)
+      git.log_base_commits(clone_path, base_branch, commit_state.base_count, function(commits, err)
         if err then
           vim.notify("Failed to get base commits", vim.log.levels.WARN)
           commit_state.base_commits = {}
@@ -725,7 +745,6 @@ function M.toggle()
   end
 end
 
--- Exposed for testing
 M._lock_buf = ui.lock_buf
 M._lock_maximize_buf = function(buf) ui.lock_maximize_buf(buf, commit_state.grid_rows, commit_state.grid_cols) end
 M._clamp_int = ui.clamp_int

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -640,7 +640,7 @@ local function enter_commit_mode()
   open.pause_sync()
   state.set_commit_mode(true)
   commit_state.active = true
-  state.set_mode_exit(exit_commit_mode)
+  state.set_mode_exit(function() exit_commit_mode() end)
 
   local vcfg = ui.parse_viewer_config()
   ui.SIDEBAR_WIDTH = vcfg.sidebar_width

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -341,10 +341,14 @@ end
 
 --- Refresh commits after detecting remote changes.
 --- Fetches updated commit lists and rebuilds the sidebar, preserving selection.
-local function refresh_commits()
+---@param on_complete fun()|nil Called after both git log calls finish and the UI is updated
+local function refresh_commits(on_complete)
   local clone_path = state.get_clone_path()
   local base_branch = commit_state.base_branch
-  if not clone_path or not base_branch then return end
+  if not clone_path or not base_branch then
+    if on_complete then on_complete() end
+    return
+  end
 
   local sel = get_commit(commit_state.selected_index)
   local selected_sha = sel and sel.sha
@@ -367,6 +371,7 @@ local function refresh_commits()
     if total_commits() > 0 then
       select_commit(commit_state.selected_index)
     end
+    if on_complete then on_complete() end
   end
 
   local function check_done()
@@ -453,13 +458,11 @@ local function sync_tick(clone_path, pr_branch, base_branch)
               done(); return
             end
             commit_state.last_head_sha = pr_sha
-            refresh_commits()
-            done()
+            refresh_commits(done)
           end)
         else
           -- Only base branch changed — refresh commit lists without reset
-          refresh_commits()
-          done()
+          refresh_commits(done)
         end
       end
 

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -24,43 +24,15 @@ end
 local ns_id = vim.api.nvim_create_namespace("raccoon_commits")
 
 local function make_initial_state()
-  return {
-    active = false,
-    sidebar_win = nil,
-    sidebar_buf = nil,
-    pr_commits = {},
-    base_commits = {},
-    selected_index = 1,
-    grid_wins = {},
-    grid_bufs = {},
-    all_hunks = {},
-    commit_files = {},
-    file_stats = {},
-    current_page = 1,
-    saved_buf = nil,
-    saved_laststatus = nil,
-    grid_rows = 2,
-    grid_cols = 2,
-    maximize_win = nil,
-    maximize_buf = nil,
-    focus_augroup = nil,
-    header_win = nil,
-    header_buf = nil,
-    filetree_win = nil,
-    filetree_buf = nil,
-    select_generation = 0,
-    cached_sha = nil,
-    cached_tree_lines = nil,
-    cached_line_paths = nil,
-    cached_stat_lines = nil,
-    cached_file_count = nil,
-    focus_target = "sidebar",
-    last_head_sha = nil,
-    last_base_sha = nil,
-    base_branch = nil,
-    base_count = nil,
-    sync_interval_ms = nil,
-  }
+  local s = ui.make_base_state()
+  s.pr_commits = {}
+  s.base_commits = {}
+  s.last_head_sha = nil
+  s.last_base_sha = nil
+  s.base_branch = nil
+  s.base_count = nil
+  s.sync_interval_ms = nil
+  return s
 end
 
 local commit_state = make_initial_state()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -10,7 +10,6 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
-local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
 
 --- Compute the base ref for combined diff operations.
 --- Returns nil when no PR is active; callers should handle nil (diff_combined already guards it).
@@ -167,7 +166,7 @@ local function maximize_cell(cell_num)
     generation = commit_state.select_generation,
     get_generation = function() return commit_state.select_generation end,
     state = commit_state,
-    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    is_combined_diff = git.is_combined_diff(commit),
     base_ref = get_base_ref(),
   })
 end
@@ -193,7 +192,7 @@ local function select_commit(index)
   local context = ui.compute_grid_context(commit_state.grid_rows)
 
   local fetch_diff
-  if commit.sha == COMBINED_DIFF_SHA then
+  if git.is_combined_diff(commit) then
     local base_ref = get_base_ref()
     fetch_diff = function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
   else
@@ -233,7 +232,7 @@ local function render_sidebar()
     section2_header = "── Base Branch ──",
     section2_commits = commit_state.base_commits,
     commit_hl_fn = function(commit)
-      if commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
+      if git.is_combined_diff(commit) then return "DiagnosticInfo" end
     end,
   })
   ui.update_sidebar_winbar(commit_state, total_commits())
@@ -327,10 +326,7 @@ local function refresh_commits(on_complete)
     commit_state.pr_commits = new_pr or commit_state.pr_commits
     commit_state.base_commits = new_base or commit_state.base_commits
 
-    if #commit_state.pr_commits > 1
-      and commit_state.pr_commits[1].sha ~= COMBINED_DIFF_SHA then
-      table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
-    end
+    git.maybe_prepend_combined_diff(commit_state.pr_commits)
 
     restore_selection_by_sha(selected_sha)
     render_sidebar()
@@ -658,9 +654,7 @@ local function enter_commit_mode()
         end
 
         local real_pr_count = #commit_state.pr_commits
-        if real_pr_count > 1 then
-          table.insert(commit_state.pr_commits, 1, git.make_combined_diff_entry())
-        end
+        git.maybe_prepend_combined_diff(commit_state.pr_commits)
 
         ui.create_grid_layout(commit_state, rows, cols)
         render_sidebar()
@@ -705,32 +699,18 @@ end
 local function exit_commit_mode()
   stop_poll_timer()
 
-  if commit_state.focus_augroup then
-    pcall(vim.api.nvim_del_augroup_by_id, commit_state.focus_augroup)
-  end
-
-  -- Close floating maximize window (not affected by :only)
-  ui.close_win_pair(commit_state, "maximize_win", "maximize_buf")
-  commit_mode_keymaps = {}
-
-  state.set_commit_mode(false)
-
-  -- Close all splits in one shot; scratch buffers auto-wipe (bufhidden=wipe)
-  vim.cmd("only")
-
-  if commit_state.saved_buf and vim.api.nvim_buf_is_valid(commit_state.saved_buf) then
-    vim.api.nvim_set_current_buf(commit_state.saved_buf)
-  end
-
-  if commit_state.saved_laststatus then
-    vim.o.laststatus = commit_state.saved_laststatus
-  end
-
-  keymaps.setup()
-  open.resume_sync()
-
-  reset_state()
-  vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
+  ui.teardown_viewer(commit_state, {
+    on_before_only = function()
+      commit_mode_keymaps = {}
+      state.set_commit_mode(false)
+    end,
+    on_after = function()
+      keymaps.setup()
+      open.resume_sync()
+      reset_state()
+      vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
+    end,
+  })
 end
 
 --- Toggle commit viewer mode

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -189,7 +189,7 @@ local function select_commit(index)
     if generation ~= commit_state.select_generation then return end
 
     if err then
-      vim.notify("Failed to get commit diff: " .. (err or "unknown error"), vim.log.levels.ERROR)
+      vim.notify("Failed to get commit diff: " .. err, vim.log.levels.ERROR)
       return
     end
 

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -67,6 +67,7 @@ local commit_mode_keymaps = {}
 
 --- Reset module state
 local function reset_state()
+  stop_poll_timer()
   commit_state = {
     active = false,
     sidebar_win = nil,
@@ -217,7 +218,7 @@ local function select_commit(index)
     if generation ~= commit_state.select_generation then return end
 
     if err then
-      vim.notify("Failed to get commit diff", vim.log.levels.ERROR)
+      vim.notify("Failed to get commit diff: " .. (err or "unknown error"), vim.log.levels.ERROR)
       return
     end
 
@@ -696,12 +697,6 @@ local function exit_commit_mode()
 
   reset_state()
   vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
-end
-
---- Register or clear an external popup window so the focus lock allows it.
----@param win? number Window handle, or nil to clear
-function M.set_popup_win(win)
-  commit_state.popup_win = win
 end
 
 --- Toggle commit viewer mode

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -11,6 +11,8 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
+local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
+
 --- Namespace for commit viewer highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_commits")
 
@@ -151,6 +153,9 @@ local function maximize_cell(cell_num)
   local clone_path = state.get_clone_path()
   if not commit or not clone_path then return end
 
+  local pr = state.get_pr()
+  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
+
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = clone_path,
@@ -160,6 +165,8 @@ local function maximize_cell(cell_num)
     generation = commit_state.select_generation,
     get_generation = function() return commit_state.select_generation end,
     state = commit_state,
+    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    base_ref = base_ref,
   })
 end
 
@@ -183,7 +190,14 @@ local function select_commit(index)
   if not clone_path then return end
 
   local context = ui.compute_grid_context(commit_state.grid_rows)
-  git.show_commit(clone_path, commit.sha, context, function(files, err)
+  local pr = state.get_pr()
+  local base_ref = pr and ("origin/" .. pr.base.ref) or "origin/main"
+
+  local fetch_diff = commit.sha == COMBINED_DIFF_SHA
+    and function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
+    or function(cb) git.show_commit(clone_path, commit.sha, context, cb) end
+
+  fetch_diff(function(files, err)
     if generation ~= commit_state.select_generation then return end
 
     if err then
@@ -254,6 +268,9 @@ local function render_sidebar()
     section1_commits = commit_state.pr_commits,
     section2_header = "── Base Branch ──",
     section2_commits = commit_state.base_commits,
+    commit_hl_fn = function(commit)
+      if commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
+    end,
   })
   ui.update_sidebar_winbar(commit_state, total_commits())
   update_sidebar_selection()
@@ -310,6 +327,8 @@ build_filetree_cache = function()
   if not clone_path then return end
   local commit = get_commit(commit_state.selected_index)
   local sha = commit and commit.sha or "HEAD"
+  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
+  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(commit_state, clone_path, sha)
 end
 
@@ -392,6 +411,10 @@ local function setup_keymaps()
       local c = get_commit(commit_state.selected_index)
       return c and c.message or ""
     end,
+    get_base_ref = function()
+      local pr = state.get_pr()
+      return pr and ("origin/" .. pr.base.ref) or "origin/main"
+    end,
   })
 
   -- Focus lock autocmd
@@ -462,6 +485,12 @@ local function enter_commit_mode()
           vim.notify("No commits found on PR branch", vim.log.levels.WARN)
           M.toggle()
           return
+        end
+
+        -- Add combined diff entry at the top when there are multiple PR commits
+        if #commit_state.pr_commits > 1 then
+          table.insert(commit_state.pr_commits, 1,
+            { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
         end
 
         ui.create_grid_layout(commit_state, rows, cols)

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -55,8 +55,8 @@ local function make_initial_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
-    poll_timer = nil,
     last_head_sha = nil,
+    last_base_sha = nil,
     base_branch = nil,
     base_count = 20,
     sync_interval_ms = 60000,
@@ -69,8 +69,24 @@ local commit_state = make_initial_state()
 --- Commit mode keymaps (global)
 local commit_mode_keymaps = {}
 
---- Forward declarations
-local stop_poll_timer
+--- Module-level timer handle. Stored outside commit_state so it survives
+--- state table reassignment in reset_state() and can always be stopped.
+local poll_timer_handle = nil
+
+--- In-flight guard: prevents overlapping sync ticks from running concurrent git operations.
+local sync_in_flight = false
+
+--- Stop the background sync timer
+local function stop_poll_timer()
+  if poll_timer_handle then
+    pcall(function()
+      poll_timer_handle:stop()
+      poll_timer_handle:close()
+    end)
+    poll_timer_handle = nil
+  end
+  sync_in_flight = false
+end
 
 --- Reset module state
 local function reset_state()
@@ -318,17 +334,6 @@ build_filetree_cache = function()
   ui.build_filetree_cache(commit_state, clone_path, sha)
 end
 
---- Stop the background sync timer
-function stop_poll_timer()
-  if commit_state.poll_timer then
-    pcall(function()
-      commit_state.poll_timer:stop()
-      commit_state.poll_timer:close()
-    end)
-    commit_state.poll_timer = nil
-  end
-end
-
 --- Preserve selected commit across a refresh
 local function restore_selection_by_sha(selected_sha)
   if selected_sha then
@@ -352,14 +357,13 @@ local function refresh_commits()
   local base_branch = commit_state.base_branch
   if not clone_path or not base_branch then return end
 
-  local selected_sha = get_commit(commit_state.selected_index)
-    and get_commit(commit_state.selected_index).sha
+  local sel = get_commit(commit_state.selected_index)
+  local selected_sha = sel and sel.sha
 
   local pending = 2
   local new_pr, new_base
 
   local function on_both_ready()
-    if not new_pr and not new_base then return end
     commit_state.pr_commits = new_pr or commit_state.pr_commits
     commit_state.base_commits = new_base or commit_state.base_commits
 
@@ -392,9 +396,90 @@ local function refresh_commits()
   end)
 end
 
+--- Single sync tick: fetch branches, check for new commits, reset and refresh if needed.
+--- Guarded by sync_in_flight to prevent overlapping git operations.
+---@param clone_path string
+---@param pr_branch string
+---@param base_branch string
+local function sync_tick(clone_path, pr_branch, base_branch)
+  if sync_in_flight then return end
+  if not commit_state.active then return end
+  sync_in_flight = true
+
+  local function done()
+    sync_in_flight = false
+  end
+
+  git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
+    if not commit_state.active then done(); return end
+    if fetch_err then
+      vim.notify("Sync: failed to fetch PR branch", vim.log.levels.DEBUG)
+      done(); return
+    end
+
+    git.fetch_branch(clone_path, base_branch, function(_, _)
+      if not commit_state.active then done(); return end
+
+      -- Check both PR and base branch SHAs in parallel
+      local pending = 2
+      local pr_sha, base_sha
+      local function check_both()
+        pending = pending - 1
+        if pending > 0 then return end
+        if not commit_state.active then done(); return end
+
+        -- Seed SHAs on first tick
+        if not commit_state.last_head_sha then
+          commit_state.last_head_sha = pr_sha
+        end
+        if not commit_state.last_base_sha then
+          commit_state.last_base_sha = base_sha
+        end
+
+        local pr_changed = pr_sha and pr_sha ~= commit_state.last_head_sha
+        local base_changed = base_sha and base_sha ~= commit_state.last_base_sha
+
+        if not pr_changed and not base_changed then
+          done(); return
+        end
+
+        -- Update tracked base SHA
+        if base_sha then commit_state.last_base_sha = base_sha end
+
+        if pr_changed then
+          -- PR branch advanced — reset local clone to match origin
+          git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
+            if not commit_state.active then done(); return end
+            if not ok then
+              vim.notify("Sync: failed to reset to remote: " .. (reset_err or ""), vim.log.levels.DEBUG)
+              done(); return
+            end
+            commit_state.last_head_sha = pr_sha
+            refresh_commits()
+            done()
+          end)
+        else
+          -- Only base branch changed — refresh commit lists without reset
+          refresh_commits()
+          done()
+        end
+      end
+
+      git.ref_sha(clone_path, "origin/" .. pr_branch, function(sha, _)
+        pr_sha = sha
+        check_both()
+      end)
+
+      git.ref_sha(clone_path, "origin/" .. base_branch, function(sha, _)
+        base_sha = sha
+        check_both()
+      end)
+    end)
+  end)
+end
+
 --- Start the background sync timer.
---- On each tick: fetch PR branch from origin (required), optionally refresh base branch,
---- then check if HEAD changed and reset/refresh if so.
+--- On each tick: fetch PR branch from origin, check for new commits, reset and refresh if needed.
 local function start_poll_timer()
   stop_poll_timer()
   if not commit_state.active then return end
@@ -407,51 +492,27 @@ local function start_poll_timer()
   local pr_branch = pr.head.ref
   local base_branch = commit_state.base_branch
 
-  -- Seed last_head_sha before starting the timer to avoid spurious reset on first tick
+  -- Seed last_head_sha and last_base_sha before starting the timer to avoid spurious refresh on first tick
+  sync_in_flight = false
   git.get_current_sha(clone_path, function(sha, _)
     if not commit_state.active then return end
     if sha then commit_state.last_head_sha = sha end
 
-    commit_state.poll_timer = vim.uv.new_timer()
-    commit_state.poll_timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
-      vim.schedule_wrap(function()
-        if not commit_state.active then return end
+    git.ref_sha(clone_path, "origin/" .. base_branch, function(base_sha, _)
+      if not commit_state.active then return end
+      if base_sha then commit_state.last_base_sha = base_sha end
 
-        -- Fetch PR branch from origin
-        git.fetch_branch(clone_path, pr_branch, function(_, fetch_err)
-          if not commit_state.active then return end
-          if fetch_err then
-            vim.notify("Sync: failed to fetch PR branch", vim.log.levels.DEBUG)
-            return
-          end
+      -- Guard against concurrent timer creation from rapid toggle
+      stop_poll_timer()
+      if not commit_state.active then return end
 
-          -- Also fetch base branch to keep it current (non-blocking on failure)
-          git.fetch_branch(clone_path, base_branch, function(_, _)
-            if not commit_state.active then return end
-
-            -- Check if origin/<pr_branch> has new commits
-            git.ref_sha(clone_path, "origin/" .. pr_branch, function(remote_sha, _)
-              if not remote_sha or not commit_state.active then return end
-              if not commit_state.last_head_sha then
-                commit_state.last_head_sha = remote_sha
-                return
-              end
-              if remote_sha == commit_state.last_head_sha then return end
-
-              -- New commits detected — reset local to match origin
-              git.reset_hard(clone_path, "origin/" .. pr_branch, function(ok, reset_err)
-                if not commit_state.active then return end
-                if not ok then
-                  vim.notify("Sync: failed to reset to remote: " .. (reset_err or ""), vim.log.levels.DEBUG)
-                  return
-                end
-                commit_state.last_head_sha = remote_sha
-                refresh_commits()
-              end)
-            end)
-          end)
-        end)
-      end))
+      local timer = vim.uv.new_timer()
+      poll_timer_handle = timer
+      timer:start(commit_state.sync_interval_ms, commit_state.sync_interval_ms,
+        vim.schedule_wrap(function()
+          sync_tick(clone_path, pr_branch, base_branch)
+        end))
+    end)
   end)
 end
 
@@ -667,6 +728,7 @@ local function exit_commit_mode()
   commit_mode_keymaps = {}
   ui.close_grid(commit_state)
   ui.close_win_pair(commit_state, "sidebar_win", "sidebar_buf")
+  ui.close_win_pair(commit_state, "header_win", "header_buf")
   ui.close_win_pair(commit_state, "filetree_win", "filetree_buf")
 
   state.set_commit_mode(false)

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -724,22 +724,21 @@ local function exit_commit_mode()
     pcall(vim.api.nvim_del_augroup_by_id, commit_state.focus_augroup)
   end
 
+  -- Close floating maximize window (not affected by :only)
   ui.close_win_pair(commit_state, "maximize_win", "maximize_buf")
   commit_mode_keymaps = {}
-  ui.close_grid(commit_state)
-  ui.close_win_pair(commit_state, "sidebar_win", "sidebar_buf")
-  ui.close_win_pair(commit_state, "header_win", "header_buf")
-  ui.close_win_pair(commit_state, "filetree_win", "filetree_buf")
 
   state.set_commit_mode(false)
 
-  if commit_state.saved_laststatus then
-    vim.o.laststatus = commit_state.saved_laststatus
-  end
-
+  -- Close all splits in one shot; scratch buffers auto-wipe (bufhidden=wipe)
   vim.cmd("only")
+
   if commit_state.saved_buf and vim.api.nvim_buf_is_valid(commit_state.saved_buf) then
     vim.api.nvim_set_current_buf(commit_state.saved_buf)
+  end
+
+  if commit_state.saved_laststatus then
+    vim.o.laststatus = commit_state.saved_laststatus
   end
 
   keymaps.setup()

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -169,6 +169,10 @@ local function select_commit(index)
   local fetch_diff
   if git.is_combined_diff(commit) then
     local base_ref = get_base_ref()
+    if not base_ref then
+      vim.notify("Combined diff requires a base branch", vim.log.levels.WARN)
+      return
+    end
     fetch_diff = function(cb) git.diff_combined(clone_path, base_ref, context, cb) end
   else
     fetch_diff = function(cb) git.show_commit(clone_path, commit.sha, context, cb) end

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -30,6 +30,7 @@ M.defaults = {
     grid = { rows = 2, cols = 2 },
     base_commits_count = 20,
     sidebar_width = 50,
+    sync_interval = 60,
   },
   parallel_agents = {
     enabled = false,

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -141,7 +141,6 @@ function M.load()
   end
 
   -- Warn about deprecated config keys
-  -- Warn about deprecated config keys
   local deprecated = {
     { key = "github_token", replacement = "tokens", since = "v0.5" },
     { key = "pull_changes_interval", replacement = "poll_interval_seconds", since = "v0.7" },

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -3,7 +3,7 @@
 ---@field tokens table<string, string|{token:string, host:string}> Per-owner/org tokens
 ---@field repos string[] Optional list of repos to show PRs from ("owner/repo" format)
 ---@field clone_root string Root directory for cloned PR repos
----@field pull_changes_interval number Auto-sync interval in seconds (default: 300)
+---@field poll_interval_seconds number Auto-sync interval in seconds (default: 300)
 
 local M = {}
 
@@ -25,7 +25,7 @@ M.defaults = {
   tokens = {},
   repos = {},
   clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos"),
-  pull_changes_interval = 300,
+  poll_interval_seconds = 300,
   commit_viewer = {
     grid = { rows = 2, cols = 2 },
     base_commits_count = 20,
@@ -140,6 +140,23 @@ function M.load()
     return nil, string.format("Invalid JSON in config file: %s", parsed)
   end
 
+  -- Warn about deprecated config keys
+  -- Warn about deprecated config keys
+  local deprecated = {
+    { key = "github_token", replacement = "tokens", since = "v0.5" },
+    { key = "pull_changes_interval", replacement = "poll_interval_seconds", since = "v0.7" },
+    { key = "github_username", replacement = nil, since = "v0.9.5" },
+  }
+  for _, dep in ipairs(deprecated) do
+    if parsed[dep.key] ~= nil then
+      local msg = string.format("Raccoon: '%s' was removed in %s", dep.key, dep.since)
+      if dep.replacement then
+        msg = msg .. string.format(", use '%s' instead", dep.replacement)
+      end
+      vim.schedule(function() vim.notify(msg, vim.log.levels.WARN) end)
+    end
+  end
+
   -- Merge with defaults
   local config = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), parsed)
 
@@ -189,7 +206,7 @@ function M.create_default()
     github_host = "github.com",
     tokens = { ["your-username"] = "ghp_xxxxxxxxxxxxxxxxxxxx" },
     clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos"),
-    pull_changes_interval = 300,
+    poll_interval_seconds = 300,
     commit_viewer = {
       grid = { rows = 2, cols = 2 },
       base_commits_count = 20,

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -52,6 +52,16 @@ local function run_git(args, opts)
     end,
   })
 
+  -- jobstart returns 0 for invalid args, -1 when the command is not executable.
+  -- In both cases on_exit is never called, so invoke the callback with an error immediately.
+  if job_id <= 0 and opts.on_exit then
+    vim.schedule(function()
+      local msg = job_id == 0 and "Invalid git command arguments"
+        or "Failed to start git process (is git installed?)"
+      opts.on_exit(-1, {}, { msg })
+    end)
+  end
+
   return job_id
 end
 
@@ -797,8 +807,9 @@ end
 local function list_untracked_files(path, callback)
   run_git({ "ls-files", "--others", "--exclude-standard" }, {
     cwd = path,
-    on_exit = function(code, stdout, _)
+    on_exit = function(code, stdout, stderr)
       if code ~= 0 then
+        vim.notify("Failed to list untracked files: " .. table.concat(stderr, " "), vim.log.levels.DEBUG)
         callback({})
         return
       end
@@ -815,7 +826,11 @@ end
 local function build_new_file_patch(path, filename)
   local filepath = vim.fs.joinpath(path, filename)
   local ok, lines = pcall(vim.fn.readfile, filepath)
-  if not ok or not lines then
+  if not ok then
+    vim.notify("Cannot read file for diff: " .. filepath .. " (" .. tostring(lines) .. ")", vim.log.levels.DEBUG)
+    return nil
+  end
+  if not lines then
     return nil
   end
   if #lines == 0 then

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -1012,6 +1012,10 @@ end
 ---@param context number|nil Lines of surrounding context
 ---@param callback fun(files: table[]|nil, err: string|nil)
 function M.diff_combined(path, base_ref, context, callback)
+  if not base_ref then
+    callback(nil, "No base ref available for combined diff")
+    return
+  end
   local args = { "diff" }
   if context and context > 0 then
     table.insert(args, "-U" .. tostring(math.floor(context)))
@@ -1035,6 +1039,10 @@ end
 ---@param filename string File path within the repo
 ---@param callback fun(patch: string|nil, err: string|nil)
 function M.diff_combined_file(path, base_ref, filename, callback)
+  if not base_ref then
+    callback(nil, "No base ref available for combined diff")
+    return
+  end
   run_git({ "diff", "-U99999", base_ref .. "...HEAD", "--", filename }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -1001,6 +1001,22 @@ function M.make_combined_diff_entry()
   return { sha = M.COMBINED_DIFF_SHA, message = "COMBINED DIFF" }
 end
 
+--- Check whether a commit entry is the synthetic combined-diff entry.
+---@param entry table Commit entry with .sha field
+---@return boolean
+function M.is_combined_diff(entry)
+  return entry and entry.sha == M.COMBINED_DIFF_SHA
+end
+
+--- Prepend a synthetic COMBINED DIFF entry to a commit list if there are
+--- multiple real commits and one isn't already present.
+---@param commits table[] Commit list to modify in place
+function M.maybe_prepend_combined_diff(commits)
+  if #commits > 1 and not M.is_combined_diff(commits[1]) then
+    table.insert(commits, 1, M.make_combined_diff_entry())
+  end
+end
+
 --- Get the combined diff of all branch changes vs a base ref.
 --- Uses three-dot diff (merge-base of base_ref and HEAD to HEAD), which approximates
 --- GitHub's "Files changed" view. Results may diverge if the base branch has advanced

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -1005,7 +1005,7 @@ end
 ---@param entry table Commit entry with .sha field
 ---@return boolean
 function M.is_combined_diff(entry)
-  return entry and entry.sha == M.COMBINED_DIFF_SHA
+  return entry ~= nil and entry.sha == M.COMBINED_DIFF_SHA
 end
 
 --- Prepend a synthetic COMBINED DIFF entry to a commit list if there are

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -964,4 +964,60 @@ function M.find_repo_root(path, callback)
   })
 end
 
+--- Sentinel SHA used for the "combined diff" synthetic commit entry.
+--- Must not collide with real SHAs or nil (which means working directory).
+M.COMBINED_DIFF_SHA = "__combined_diff__"
+
+--- Get the combined diff of all branch changes vs a base ref.
+--- Uses three-dot diff (merge-base to HEAD), matching what GitHub shows in "Files changed".
+---@param path string Repository path
+---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
+---@param context number|nil Lines of surrounding context
+---@param callback fun(files: table[]|nil, err: string|nil)
+function M.diff_combined(path, base_ref, context, callback)
+  local args = { "diff" }
+  if context and context > 0 then
+    table.insert(args, "-U" .. tostring(math.floor(context)))
+  end
+  table.insert(args, base_ref .. "...HEAD")
+  run_git(args, {
+    cwd = path,
+    on_exit = function(code, stdout, stderr)
+      if code ~= 0 then
+        callback(nil, table.concat(stderr, "\n"))
+        return
+      end
+      callback(parse_diff_output(stdout), nil)
+    end,
+  })
+end
+
+--- Get the combined diff for a single file (full context, for maximize view).
+---@param path string Repository path
+---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
+---@param filename string File path within the repo
+---@param callback fun(patch: string|nil, err: string|nil)
+function M.diff_combined_file(path, base_ref, filename, callback)
+  run_git({ "diff", "-U99999", base_ref .. "...HEAD", "--", filename }, {
+    cwd = path,
+    on_exit = function(code, stdout, stderr)
+      if code ~= 0 then
+        callback(nil, table.concat(stderr, "\n"))
+        return
+      end
+      local lines = {}
+      local in_patch = false
+      for _, line in ipairs(stdout) do
+        if line:match("^@@") then
+          in_patch = true
+        end
+        if in_patch then
+          table.insert(lines, line)
+        end
+      end
+      callback(table.concat(lines, "\n"), nil)
+    end,
+  })
+end
+
 return M

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -210,24 +210,11 @@ function M.get_current_branch(path, callback)
   })
 end
 
---- Get the current commit SHA
+--- Get the current commit SHA (convenience wrapper around ref_sha for HEAD)
 ---@param path string Repository path
 ---@param callback fun(sha: string|nil, err: string|nil)
 function M.get_current_sha(path, callback)
-  run_git({ "rev-parse", "HEAD" }, {
-    cwd = path,
-    on_exit = function(code, stdout, stderr)
-      if code == 0 and #stdout > 0 then
-        callback(stdout[1], nil)
-      else
-        local err_msg = table.concat(stderr, "\n")
-        if err_msg == "" then
-          err_msg = "Failed to get current SHA"
-        end
-        callback(nil, err_msg)
-      end
-    end,
-  })
+  M.ref_sha(path, "HEAD", callback)
 end
 
 --- Get the SHA for an arbitrary git ref (branch, tag, remote tracking ref, etc.)
@@ -1015,7 +1002,9 @@ function M.make_combined_diff_entry()
 end
 
 --- Get the combined diff of all branch changes vs a base ref.
---- Uses three-dot diff (merge-base to HEAD), matching what GitHub shows in "Files changed".
+--- Uses three-dot diff (merge-base of base_ref and HEAD to HEAD), which approximates
+--- GitHub's "Files changed" view. Results may diverge if the base branch has advanced
+--- since GitHub computed its merge-base.
 ---@param path string Repository path
 ---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
 ---@param context number|nil Lines of surrounding context

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -230,6 +230,40 @@ function M.get_current_sha(path, callback)
   })
 end
 
+--- Get the SHA for an arbitrary git ref (branch, tag, remote tracking ref, etc.)
+---@param path string Repository path
+---@param ref string Git ref (e.g. "origin/main", "HEAD", tag name)
+---@param callback fun(sha: string|nil, err: string|nil)
+function M.ref_sha(path, ref, callback)
+  run_git({ "rev-parse", ref }, {
+    cwd = path,
+    on_exit = function(code, stdout, stderr)
+      if code == 0 and #stdout > 0 then
+        callback(stdout[1], nil)
+      else
+        callback(nil, table.concat(stderr, "\n"))
+      end
+    end,
+  })
+end
+
+--- Hard-reset the current branch to a given ref
+---@param path string Repository path
+---@param ref string Target ref (e.g. "origin/feature-branch")
+---@param callback fun(success: boolean, err: string|nil)
+function M.reset_hard(path, ref, callback)
+  run_git({ "reset", "--hard", ref }, {
+    cwd = path,
+    on_exit = function(code, _, stderr)
+      if code == 0 then
+        callback(true, nil)
+      else
+        callback(false, table.concat(stderr, "\n"))
+      end
+    end,
+  })
+end
+
 --- Check if a path is a git repository
 ---@param path string|nil Path to check
 ---@return boolean
@@ -551,6 +585,23 @@ function M.log_base_commits(path, base_branch, count, callback)
   })
 end
 
+--- Extract only the patch body from git diff output (skip diff headers, start from first @@ line).
+---@param stdout string[] Raw git output lines
+---@return string patch Concatenated patch lines
+local function strip_to_patch(stdout)
+  local lines = {}
+  local in_patch = false
+  for _, line in ipairs(stdout) do
+    if line:match("^@@") then
+      in_patch = true
+    end
+    if in_patch then
+      table.insert(lines, line)
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
 --- Parse raw diff output into per-file patches
 ---@param stdout string[] Lines of unified diff output
 ---@return table[] files Array of {filename, patch}
@@ -617,17 +668,7 @@ function M.show_commit_file(path, sha, filename, callback)
         callback(nil, table.concat(stderr, "\n"))
         return
       end
-      local lines = {}
-      local in_patch = false
-      for _, line in ipairs(stdout) do
-        if line:match("^@@") then
-          in_patch = true
-        end
-        if in_patch then
-          table.insert(lines, line)
-        end
-      end
-      callback(table.concat(lines, "\n"), nil)
+      callback(strip_to_patch(stdout), nil)
     end,
   })
 end
@@ -849,17 +890,7 @@ function M.diff_working_dir_file(path, filename, callback)
             callback(nil, table.concat(stderr, "\n"))
             return
           end
-          local lines = {}
-          local in_patch = false
-          for _, line in ipairs(stdout) do
-            if line:match("^@@") then
-              in_patch = true
-            end
-            if in_patch then
-              table.insert(lines, line)
-            end
-          end
-          callback(table.concat(lines, "\n"), nil)
+          callback(strip_to_patch(stdout), nil)
         end,
       })
     end,
@@ -968,6 +999,12 @@ end
 --- Must not collide with real SHAs or nil (which means working directory).
 M.COMBINED_DIFF_SHA = "__combined_diff__"
 
+--- Create a synthetic "COMBINED DIFF" commit entry.
+---@return table entry {sha, message}
+function M.make_combined_diff_entry()
+  return { sha = M.COMBINED_DIFF_SHA, message = "COMBINED DIFF" }
+end
+
 --- Get the combined diff of all branch changes vs a base ref.
 --- Uses three-dot diff (merge-base to HEAD), matching what GitHub shows in "Files changed".
 ---@param path string Repository path
@@ -1005,17 +1042,7 @@ function M.diff_combined_file(path, base_ref, filename, callback)
         callback(nil, table.concat(stderr, "\n"))
         return
       end
-      local lines = {}
-      local in_patch = false
-      for _, line in ipairs(stdout) do
-        if line:match("^@@") then
-          in_patch = true
-        end
-        if in_patch then
-          table.insert(lines, line)
-        end
-      end
-      callback(table.concat(lines, "\n"), nil)
+      callback(strip_to_patch(stdout), nil)
     end,
   })
 end

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -241,7 +241,11 @@ function M.ref_sha(path, ref, callback)
       if code == 0 and #stdout > 0 then
         callback(stdout[1], nil)
       else
-        callback(nil, table.concat(stderr, "\n"))
+        local err_msg = table.concat(stderr, "\n")
+        if err_msg == "" then
+          err_msg = "Failed to resolve ref: " .. ref
+        end
+        callback(nil, err_msg)
       end
     end,
   })
@@ -258,7 +262,11 @@ function M.reset_hard(path, ref, callback)
       if code == 0 then
         callback(true, nil)
       else
-        callback(false, table.concat(stderr, "\n"))
+        local err_msg = table.concat(stderr, "\n")
+        if err_msg == "" then
+          err_msg = "Failed to reset to ref: " .. ref
+        end
+        callback(false, err_msg)
       end
     end,
   })
@@ -586,6 +594,7 @@ function M.log_base_commits(path, base_branch, count, callback)
 end
 
 --- Extract only the patch body from git diff output (skip diff headers, start from first @@ line).
+--- Intended for single-file diff output (e.g. after -- filename filtering).
 ---@param stdout string[] Raw git output lines
 ---@return string patch Concatenated patch lines
 local function strip_to_patch(stdout)
@@ -995,7 +1004,7 @@ function M.find_repo_root(path, callback)
   })
 end
 
---- Sentinel SHA used for the "combined diff" synthetic commit entry.
+--- Sentinel value used in place of a real SHA for the "combined diff" synthetic commit entry.
 --- Must not collide with real SHAs or nil (which means working directory).
 M.COMBINED_DIFF_SHA = "__combined_diff__"
 

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -895,13 +895,13 @@ end
 
 --- Get git status in porcelain format (cheap change detection)
 ---@param path string Repository path
----@param callback fun(output: string, err: string|nil)
+---@param callback fun(output: string|nil, err: string|nil)
 function M.status_porcelain(path, callback)
   run_git({ "status", "--porcelain" }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then
-        callback("", table.concat(stderr, "\n"))
+        callback(nil, table.concat(stderr, "\n"))
         return
       end
       callback(table.concat(stdout, "\n"), nil)
@@ -996,7 +996,7 @@ end
 M.COMBINED_DIFF_SHA = "__combined_diff__"
 
 --- Create a synthetic "COMBINED DIFF" commit entry.
----@return table entry {sha, message}
+---@return table entry {sha: string, message: string} sha is COMBINED_DIFF_SHA sentinel
 function M.make_combined_diff_entry()
   return { sha = M.COMBINED_DIFF_SHA, message = "COMBINED DIFF" }
 end
@@ -1023,7 +1023,7 @@ end
 --- since GitHub computed its merge-base.
 ---@param path string Repository path
 ---@param base_ref string Base ref (e.g. "origin/main" or a SHA)
----@param context number|nil Lines of surrounding context
+---@param context number|nil Lines of surrounding context (nil omits -U flag, deferring to git's default)
 ---@param callback fun(files: table[]|nil, err: string|nil)
 function M.diff_combined(path, base_ref, context, callback)
   if not base_ref then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -576,7 +576,12 @@ start_workdir_poll_timer = function()
     if not local_state.active then return end
 
     git.status_porcelain(local_state.repo_path, function(output, err)
-      if err or not local_state.active then
+      if not local_state.active then
+        start_workdir_poll_timer()
+        return
+      end
+      if err then
+        vim.notify("Workdir poll: status_porcelain failed", vim.log.levels.DEBUG)
         start_workdir_poll_timer()
         return
       end
@@ -612,7 +617,10 @@ local function refresh_commits()
   if local_state.base_branch and local_state.merge_base_sha then
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
-      if err or not new_branch then return end
+      if err or not new_branch then
+        vim.notify("Local sync: failed to refresh branch commits", vim.log.levels.WARN)
+        return
+      end
       prepend_synthetic_entries(new_branch)
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
@@ -623,7 +631,10 @@ local function refresh_commits()
     -- Flat mode: refresh all commits
     local count = math.max(total_commits() - 1, BATCH_SIZE)
     git.log_all_commits(local_state.repo_path, count, 0, function(new_commits, err)
-      if err or not new_commits then return end
+      if err or not new_commits then
+        vim.notify("Local sync: failed to refresh commits", vim.log.levels.WARN)
+        return
+      end
       table.insert(new_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
       local_state.branch_commits = new_commits
       local_state.last_status_output = ""
@@ -680,7 +691,11 @@ load_more_commits = function()
       BATCH_SIZE, local_state.total_base_loaded,
       function(new_commits, err)
         local_state.loading_more = false
-        if err or not new_commits or #new_commits == 0 then return end
+        if err then
+          vim.notify("Failed to load more base commits", vim.log.levels.DEBUG)
+          return
+        end
+        if not new_commits or #new_commits == 0 then return end
         for _, commit in ipairs(new_commits) do
           table.insert(local_state.base_commits, commit)
         end
@@ -693,7 +708,11 @@ load_more_commits = function()
     local skip = #local_state.branch_commits - 1 -- -1 for "Current changes"
     git.log_all_commits(local_state.repo_path, BATCH_SIZE, skip, function(new_commits, err)
       local_state.loading_more = false
-      if err or not new_commits or #new_commits == 0 then return end
+      if err then
+        vim.notify("Failed to load more commits", vim.log.levels.DEBUG)
+        return
+      end
+      if not new_commits or #new_commits == 0 then return end
       for _, commit in ipairs(new_commits) do
         table.insert(local_state.branch_commits, commit)
       end
@@ -827,12 +846,18 @@ local function enter_local_mode()
             if pending == 0 then on_both_ready() end
           end
 
-          git.log_branch_commits(repo_root, merge_sha, function(commits, _)
+          git.log_branch_commits(repo_root, merge_sha, function(commits, err)
+            if err then
+              vim.notify("Failed to load branch commits", vim.log.levels.WARN)
+            end
             branch_result = commits
             check_done()
           end)
 
-          git.log_from_ref(repo_root, merge_sha, base_count, 0, function(commits, _)
+          git.log_from_ref(repo_root, merge_sha, base_count, 0, function(commits, err)
+            if err then
+              vim.notify("Failed to load base commits", vim.log.levels.WARN)
+            end
             base_result = commits
             check_done()
           end)

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -184,7 +184,7 @@ local function select_commit(index)
     if generation ~= local_state.select_generation then return end
 
     if err then
-      vim.notify("Failed to get commit diff: " .. (err or "unknown error"), vim.log.levels.ERROR)
+      vim.notify("Failed to get commit diff: " .. err, vim.log.levels.ERROR)
       return
     end
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -745,6 +745,7 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
+            local real_branch_count = #branch_commits
             prepend_synthetic_entries(branch_commits)
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch
@@ -754,7 +755,7 @@ local function enter_local_mode()
             local_state.total_base_loaded = #base_commits
             activate_mode(repo_root, rows, cols,
               string.format("Local commit viewer: %d branch + %d base commits",
-                #branch_commits - 1, #base_commits))
+                real_branch_count, #base_commits))
           end
 
           local function check_done()

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -839,6 +839,16 @@ function M.toggle()
   end
 end
 
+function M.is_active()
+  return local_state.active
+end
+
+function M.close()
+  if local_state.active then
+    exit_local_mode()
+  end
+end
+
 -- Exposed for testing
 M._get_state = function() return local_state end
 M._select_commit = select_commit

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -11,6 +11,8 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
+local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
+
 local ns_id = vim.api.nvim_create_namespace("raccoon_local_commits")
 
 local BATCH_SIZE = 100
@@ -127,6 +129,8 @@ local function maximize_cell(cell_num)
   local commit = get_commit(local_state.selected_index)
   if not commit or not local_state.repo_path then return end
 
+  local base_ref = local_state.merge_base_sha or local_state.base_branch
+
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = local_state.repo_path,
@@ -137,6 +141,8 @@ local function maximize_cell(cell_num)
     get_generation = function() return local_state.select_generation end,
     state = local_state,
     is_working_dir = commit.sha == nil,
+    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    base_ref = base_ref,
   })
 end
 
@@ -153,9 +159,16 @@ local function select_commit(index)
   if not local_state.repo_path then return end
 
   local context = ui.compute_grid_context(local_state.grid_rows)
-  local fetch_diff = commit.sha
-    and function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end
-    or function(cb) git.diff_working_dir(local_state.repo_path, context, cb) end
+  local base_ref = local_state.merge_base_sha or local_state.base_branch
+
+  local fetch_diff
+  if commit.sha == COMBINED_DIFF_SHA then
+    fetch_diff = function(cb) git.diff_combined(local_state.repo_path, base_ref, context, cb) end
+  elseif commit.sha then
+    fetch_diff = function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end
+  else
+    fetch_diff = function(cb) git.diff_working_dir(local_state.repo_path, context, cb) end
+  end
 
   fetch_diff(function(files, err)
     if generation ~= local_state.select_generation then return end
@@ -252,7 +265,7 @@ local function render_sidebar()
       section2_header = "── " .. local_state.base_branch .. " ──",
       section2_commits = local_state.base_commits,
       commit_hl_fn = function(commit)
-        if commit.sha == nil then return "DiagnosticInfo" end
+        if commit.sha == nil or commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
       end,
       loading = local_state.loading_more,
     })
@@ -358,6 +371,8 @@ build_filetree_cache = function()
   if not local_state.repo_path then return end
   local commit = get_commit(local_state.selected_index)
   local sha = (commit and commit.sha) or nil
+  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
+  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(local_state, local_state.repo_path, sha)
 end
 
@@ -494,6 +509,9 @@ local function setup_keymaps()
       local c = get_commit(local_state.selected_index)
       return c and c.message or ""
     end,
+    get_base_ref = function()
+      return local_state.merge_base_sha or local_state.base_branch
+    end,
   })
 
   -- Focus lock autocmd
@@ -585,7 +603,10 @@ local function refresh_commits()
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
       if err or not new_branch then return end
-      table.insert(new_branch, 1, { sha = nil, message = "Current changes" })
+      table.insert(new_branch, 1, { sha = nil, message = "CURRENT CHANGES" })
+      if #new_branch > 2 then
+        table.insert(new_branch, 2, { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+      end
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -596,7 +617,7 @@ local function refresh_commits()
     local count = math.max(total_commits() - 1, BATCH_SIZE)
     git.log_all_commits(local_state.repo_path, count, 0, function(new_commits, err)
       if err or not new_commits then return end
-      table.insert(new_commits, 1, { sha = nil, message = "Current changes" })
+      table.insert(new_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
       local_state.branch_commits = new_commits
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -719,7 +740,7 @@ local function enter_local_mode()
             vim.notify("No commits found", vim.log.levels.WARN)
             return
           end
-          table.insert(commits, 1, { sha = nil, message = "Current changes" })
+          table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
           local_state.branch_commits = commits
           activate_mode(repo_root, rows, cols,
             string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -737,7 +758,7 @@ local function enter_local_mode()
               return
             end
             local_state.current_branch = current_branch
-            table.insert(commits, 1, { sha = nil, message = "Current changes" })
+            table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
             local_state.branch_commits = commits
             activate_mode(repo_root, rows, cols,
               string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -755,7 +776,7 @@ local function enter_local_mode()
                 return
               end
               local_state.current_branch = current_branch
-              table.insert(commits, 1, { sha = nil, message = "Current changes" })
+              table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
               local_state.branch_commits = commits
               activate_mode(repo_root, rows, cols,
                 string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -770,7 +791,12 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
-            table.insert(branch_commits, 1, { sha = nil, message = "Current changes" })
+            table.insert(branch_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+            -- Add combined diff entry when there are multiple branch commits
+            if #branch_commits > 2 then -- >2 because index 1 is CURRENT CHANGES
+              table.insert(branch_commits, 2,
+                { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+            end
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch
             local_state.merge_base_sha = merge_sha

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -21,50 +21,22 @@ local WORKDIR_POLL_SLOW_MS = 30000
 local WORKDIR_IDLE_THRESHOLD_MS = 180000
 
 local function make_initial_state()
-  return {
-    active = false,
-    repo_path = nil,
-    branch_commits = {},
-    base_commits = {},
-    current_branch = nil,
-    base_branch = nil,
-    merge_base_sha = nil,
-    total_base_loaded = 0,
-    loading_more = false,
-    poll_timer = nil,
-    last_head_sha = nil,
-    workdir_poll_timer = nil,
-    last_status_output = "",
-    last_change_time = 0,
-    sidebar_win = nil,
-    sidebar_buf = nil,
-    selected_index = 1,
-    grid_wins = {},
-    grid_bufs = {},
-    all_hunks = {},
-    commit_files = {},
-    file_stats = {},
-    current_page = 1,
-    saved_buf = nil,
-    saved_laststatus = nil,
-    grid_rows = 2,
-    grid_cols = 2,
-    maximize_win = nil,
-    maximize_buf = nil,
-    focus_augroup = nil,
-    header_win = nil,
-    header_buf = nil,
-    filetree_win = nil,
-    filetree_buf = nil,
-    select_generation = 0,
-    cached_sha = nil,
-    cached_tree_lines = nil,
-    cached_line_paths = nil,
-    cached_stat_lines = nil,
-    cached_file_count = nil,
-    focus_target = "sidebar",
-    pr_was_active = false,
-  }
+  local s = ui.make_base_state()
+  s.repo_path = nil
+  s.branch_commits = {}
+  s.base_commits = {}
+  s.current_branch = nil
+  s.base_branch = nil
+  s.merge_base_sha = nil
+  s.total_base_loaded = 0
+  s.loading_more = false
+  s.poll_timer = nil
+  s.last_head_sha = nil
+  s.workdir_poll_timer = nil
+  s.last_status_output = ""
+  s.last_change_time = 0
+  s.pr_was_active = false
+  return s
 end
 
 local local_state = make_initial_state()

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -12,7 +12,7 @@ local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
 local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
-local CURRENT_CHANGES_MSG = "CURRENT CHANGES"
+local CURRENT_CHANGES_MSG = "UNCOMMITTED CHANGES"
 
 local ns_id = vim.api.nvim_create_namespace("raccoon_local_commits")
 
@@ -179,7 +179,7 @@ local function select_commit(index)
     if generation ~= local_state.select_generation then return end
 
     if err then
-      vim.notify("Failed to get commit diff", vim.log.levels.ERROR)
+      vim.notify("Failed to get commit diff: " .. (err or "unknown error"), vim.log.levels.ERROR)
       return
     end
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -663,6 +663,8 @@ load_more_commits = function()
   end
 end
 
+local exit_local_mode -- forward declaration (defined below activate_mode)
+
 --- Activate local mode with the given state
 local function activate_mode(repo_root, rows, cols, notify_msg)
   local_state.saved_buf = vim.api.nvim_get_current_buf()
@@ -807,7 +809,7 @@ local function enter_local_mode()
 end
 
 --- Exit local commit viewer mode
-local function exit_local_mode()
+exit_local_mode = function()
   stop_poll_timer()
   stop_workdir_poll_timer()
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -12,6 +12,7 @@ local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
 local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
+local CURRENT_CHANGES_MSG = "CURRENT CHANGES"
 
 local ns_id = vim.api.nvim_create_namespace("raccoon_local_commits")
 
@@ -71,6 +72,12 @@ end
 local local_state = make_initial_state()
 local local_mode_keymaps = {}
 
+--- Compute the base ref for combined diff operations.
+---@return string|nil base_ref
+local function get_base_ref()
+  return local_state.merge_base_sha or local_state.base_branch
+end
+
 -- Forward declarations
 local load_more_commits
 local build_filetree_cache
@@ -129,8 +136,6 @@ local function maximize_cell(cell_num)
   local commit = get_commit(local_state.selected_index)
   if not commit or not local_state.repo_path then return end
 
-  local base_ref = local_state.merge_base_sha or local_state.base_branch
-
   ui.open_maximize({
     ns_id = ns_id,
     repo_path = local_state.repo_path,
@@ -142,7 +147,7 @@ local function maximize_cell(cell_num)
     state = local_state,
     is_working_dir = commit.sha == nil,
     is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
-    base_ref = base_ref,
+    base_ref = get_base_ref(),
   })
 end
 
@@ -159,10 +164,10 @@ local function select_commit(index)
   if not local_state.repo_path then return end
 
   local context = ui.compute_grid_context(local_state.grid_rows)
-  local base_ref = local_state.merge_base_sha or local_state.base_branch
 
   local fetch_diff
   if commit.sha == COMBINED_DIFF_SHA then
+    local base_ref = get_base_ref()
     fetch_diff = function(cb) git.diff_combined(local_state.repo_path, base_ref, context, cb) end
   elseif commit.sha then
     fetch_diff = function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end
@@ -371,8 +376,6 @@ build_filetree_cache = function()
   if not local_state.repo_path then return end
   local commit = get_commit(local_state.selected_index)
   local sha = (commit and commit.sha) or nil
-  -- Combined diff sentinel is not a real git ref; use HEAD for file listing
-  if sha == COMBINED_DIFF_SHA then sha = "HEAD" end
   ui.build_filetree_cache(local_state, local_state.repo_path, sha)
 end
 
@@ -509,9 +512,7 @@ local function setup_keymaps()
       local c = get_commit(local_state.selected_index)
       return c and c.message or ""
     end,
-    get_base_ref = function()
-      return local_state.merge_base_sha or local_state.base_branch
-    end,
+    get_base_ref = get_base_ref,
   })
 
   -- Focus lock autocmd
@@ -603,9 +604,9 @@ local function refresh_commits()
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
       if err or not new_branch then return end
-      table.insert(new_branch, 1, { sha = nil, message = "CURRENT CHANGES" })
+      table.insert(new_branch, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
       if #new_branch > 2 then
-        table.insert(new_branch, 2, { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+        table.insert(new_branch, 2, git.make_combined_diff_entry())
       end
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
@@ -617,7 +618,7 @@ local function refresh_commits()
     local count = math.max(total_commits() - 1, BATCH_SIZE)
     git.log_all_commits(local_state.repo_path, count, 0, function(new_commits, err)
       if err or not new_commits then return end
-      table.insert(new_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+      table.insert(new_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
       local_state.branch_commits = new_commits
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -740,7 +741,7 @@ local function enter_local_mode()
             vim.notify("No commits found", vim.log.levels.WARN)
             return
           end
-          table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+          table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
           local_state.branch_commits = commits
           activate_mode(repo_root, rows, cols,
             string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -758,7 +759,7 @@ local function enter_local_mode()
               return
             end
             local_state.current_branch = current_branch
-            table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+            table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
             local_state.branch_commits = commits
             activate_mode(repo_root, rows, cols,
               string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -776,7 +777,7 @@ local function enter_local_mode()
                 return
               end
               local_state.current_branch = current_branch
-              table.insert(commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+              table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
               local_state.branch_commits = commits
               activate_mode(repo_root, rows, cols,
                 string.format("Local commit viewer: %d commits loaded", #commits - 1))
@@ -791,11 +792,11 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
-            table.insert(branch_commits, 1, { sha = nil, message = "CURRENT CHANGES" })
+            table.insert(branch_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
             -- Add combined diff entry when there are multiple branch commits
             if #branch_commits > 2 then -- >2 because index 1 is CURRENT CHANGES
               table.insert(branch_commits, 2,
-                { sha = COMBINED_DIFF_SHA, message = "COMBINED DIFF" })
+                git.make_combined_diff_entry())
             end
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -64,7 +64,7 @@ end
 local load_more_commits
 local build_filetree_cache
 
---- Total navigable commits (branch + base)
+--- Total navigable sidebar entries (branch section + base section, including synthetic entries)
 local function total_commits()
   return #local_state.branch_commits + #local_state.base_commits
 end
@@ -607,7 +607,11 @@ local function start_poll_timer()
       if not local_state.active then return end
 
       git.get_current_sha(local_state.repo_path, function(new_sha, err)
-        if err or not new_sha then return end
+        if err then
+          vim.notify("Local sync: HEAD SHA check failed: " .. tostring(err), vim.log.levels.DEBUG)
+          return
+        end
+        if not new_sha then return end
         if new_sha == local_state.last_head_sha then return end
 
         local_state.last_head_sha = new_sha
@@ -642,7 +646,7 @@ load_more_commits = function()
   else
     -- Flat mode: load more into branch_commits
     local_state.loading_more = true
-    local skip = #local_state.branch_commits - 1 -- -1 for "Current changes"
+    local skip = #local_state.branch_commits - 1 -- -1 for synthetic UNCOMMITTED CHANGES entry
     git.log_all_commits(local_state.repo_path, BATCH_SIZE, skip, function(new_commits, err)
       local_state.loading_more = false
       if err then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -850,6 +850,7 @@ local function exit_local_mode()
   local_mode_keymaps = {}
   ui.close_grid(local_state)
   ui.close_win_pair(local_state, "sidebar_win", "sidebar_buf")
+  ui.close_win_pair(local_state, "header_win", "header_buf")
   ui.close_win_pair(local_state, "filetree_win", "filetree_buf")
 
   if local_state.saved_laststatus then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -670,6 +670,7 @@ local function activate_mode(repo_root, rows, cols, notify_msg)
   vim.o.laststatus = 3
   local_state.active = true
   local_state.repo_path = repo_root
+  state.set_mode_exit(function() exit_local_mode() end)
   local_state.last_change_time = vim.uv.now()
   workdir_fail_count = 0
 
@@ -809,6 +810,7 @@ local function exit_local_mode()
   ui.teardown_viewer(local_state, {
     on_before_only = function()
       local_mode_keymaps = {}
+      state.set_mode_exit(nil)
     end,
     on_after = function()
       if was_pr_active then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -604,9 +604,11 @@ local function refresh_commits()
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
       if err or not new_branch then return end
-      table.insert(new_branch, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-      if #new_branch > 2 then
-        table.insert(new_branch, 2, git.make_combined_diff_entry())
+      if #new_branch > 1 then
+        table.insert(new_branch, 1, git.make_combined_diff_entry())
+        table.insert(new_branch, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
+      else
+        table.insert(new_branch, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
       end
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
@@ -792,11 +794,12 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
-            table.insert(branch_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-            -- Add combined diff entry when there are multiple branch commits
-            if #branch_commits > 2 then -- >2 because index 1 is CURRENT CHANGES
-              table.insert(branch_commits, 2,
-                git.make_combined_diff_entry())
+            -- Combined diff on top when there are multiple branch commits
+            if #branch_commits > 1 then
+              table.insert(branch_commits, 1, git.make_combined_diff_entry())
+              table.insert(branch_commits, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
+            else
+              table.insert(branch_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
             end
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -489,23 +489,19 @@ local function setup_keymaps()
   local_state.focus_augroup = ui.setup_focus_lock(local_state, "RaccoonLocalCommitFocus")
 end
 
---- Stop the poll timer
 local function stop_poll_timer()
   if local_state.poll_timer then
     local handle = local_state.poll_timer
     local_state.poll_timer = nil
-    pcall(handle.stop, handle)
-    pcall(handle.close, handle)
+    ui.safe_close_timer(handle)
   end
 end
 
---- Stop the working directory poll timer
 local function stop_workdir_poll_timer()
   if local_state.workdir_poll_timer then
     local handle = local_state.workdir_poll_timer
     local_state.workdir_poll_timer = nil
-    pcall(handle.stop, handle)
-    pcall(handle.close, handle)
+    ui.safe_close_timer(handle)
   end
 end
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -846,20 +846,19 @@ local function exit_local_mode()
     pcall(vim.api.nvim_del_augroup_by_id, local_state.focus_augroup)
   end
 
+  -- Close floating maximize window (not affected by :only)
   ui.close_win_pair(local_state, "maximize_win", "maximize_buf")
   local_mode_keymaps = {}
-  ui.close_grid(local_state)
-  ui.close_win_pair(local_state, "sidebar_win", "sidebar_buf")
-  ui.close_win_pair(local_state, "header_win", "header_buf")
-  ui.close_win_pair(local_state, "filetree_win", "filetree_buf")
+
+  -- Close all splits in one shot; scratch buffers auto-wipe (bufhidden=wipe)
+  vim.cmd("only")
+
+  if local_state.saved_buf and vim.api.nvim_buf_is_valid(local_state.saved_buf) then
+    vim.api.nvim_set_current_buf(local_state.saved_buf)
+  end
 
   if local_state.saved_laststatus then
     vim.o.laststatus = local_state.saved_laststatus
-  end
-
-  vim.cmd("only")
-  if local_state.saved_buf and vim.api.nvim_buf_is_valid(local_state.saved_buf) then
-    vim.api.nvim_set_current_buf(local_state.saved_buf)
   end
 
   -- Restore PR session if it was active

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -540,12 +540,12 @@ start_workdir_poll_timer = function()
         return
       end
 
-      if output == local_state.last_status_output then
+      if (output or "") == local_state.last_status_output then
         start_workdir_poll_timer()
         return
       end
 
-      local_state.last_status_output = output
+      local_state.last_status_output = output or ""
       local_state.last_change_time = vim.uv.now()
       render_sidebar()
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -668,6 +668,21 @@ local function activate_mode(repo_root, rows, cols, notify_msg)
   end)
 end
 
+--- Flat-mode entry: prepend UNCOMMITTED CHANGES and activate.
+--- Shared by all code paths that skip branch-mode (detached HEAD, default branch, merge-base failure).
+---@param repo_root string
+---@param rows number
+---@param cols number
+---@param commits table[] Commit list from git log
+---@param current_branch string|nil
+local function enter_flat_mode(repo_root, rows, cols, commits, current_branch)
+  table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
+  if current_branch then local_state.current_branch = current_branch end
+  local_state.branch_commits = commits
+  activate_mode(repo_root, rows, cols,
+    string.format("Local commit viewer: %d commits loaded", #commits - 1))
+end
+
 --- Enter local commit viewer mode
 local function enter_local_mode()
   local vcfg = ui.parse_viewer_config()
@@ -687,16 +702,12 @@ local function enter_local_mode()
     -- Detect current branch
     git.get_current_branch(repo_root, function(current_branch, _)
       if not current_branch or current_branch == "HEAD" then
-        -- Detached HEAD or error: flat mode
         git.log_all_commits(repo_root, BATCH_SIZE, 0, function(commits, err)
           if err or not commits or #commits == 0 then
             vim.notify("No commits found", vim.log.levels.WARN)
             return
           end
-          table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-          local_state.branch_commits = commits
-          activate_mode(repo_root, rows, cols,
-            string.format("Local commit viewer: %d commits loaded", #commits - 1))
+          enter_flat_mode(repo_root, rows, cols, commits, nil)
         end)
         return
       end
@@ -704,17 +715,12 @@ local function enter_local_mode()
       -- Detect default branch
       git.find_default_branch(repo_root, function(default_branch, _)
         if not default_branch or current_branch == default_branch then
-          -- On default branch or detection failed: flat mode
           git.log_all_commits(repo_root, BATCH_SIZE, 0, function(commits, err)
             if err or not commits or #commits == 0 then
               vim.notify("No commits found", vim.log.levels.WARN)
               return
             end
-            local_state.current_branch = current_branch
-            table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-            local_state.branch_commits = commits
-            activate_mode(repo_root, rows, cols,
-              string.format("Local commit viewer: %d commits loaded", #commits - 1))
+            enter_flat_mode(repo_root, rows, cols, commits, current_branch)
           end)
           return
         end
@@ -722,17 +728,12 @@ local function enter_local_mode()
         -- Feature branch: find merge-base and split
         git.merge_base(repo_root, "HEAD", default_branch, function(merge_sha, merge_err)
           if merge_err or not merge_sha then
-            -- Merge-base failed: flat mode fallback
             git.log_all_commits(repo_root, BATCH_SIZE, 0, function(commits, err)
               if err or not commits or #commits == 0 then
                 vim.notify("No commits found", vim.log.levels.WARN)
                 return
               end
-              local_state.current_branch = current_branch
-              table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-              local_state.branch_commits = commits
-              activate_mode(repo_root, rows, cols,
-                string.format("Local commit viewer: %d commits loaded", #commits - 1))
+              enter_flat_mode(repo_root, rows, cols, commits, current_branch)
             end)
             return
           end

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -633,30 +633,40 @@ local function refresh_commits()
   end
 end
 
---- Start the 10-second HEAD polling timer
+--- Start the 10-second HEAD polling timer.
+--- Seeds last_head_sha before starting the timer to avoid spurious refresh on first tick.
 local function start_poll_timer()
   stop_poll_timer()
+  if not local_state.active then return end
 
-  git.get_current_sha(local_state.repo_path, function(sha, _)
+  git.get_current_sha(local_state.repo_path, function(sha, seed_err)
+    if not local_state.active then return end
+    if seed_err then
+      vim.notify("Local sync: failed to seed HEAD SHA", vim.log.levels.DEBUG)
+    end
     if sha then
       local_state.last_head_sha = sha
     end
-  end)
 
-  local timer = vim.uv.new_timer()
-  if not timer then return end
-  local_state.poll_timer = timer
-  timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
+    -- Guard against concurrent timer creation from rapid toggle
+    stop_poll_timer()
     if not local_state.active then return end
 
-    git.get_current_sha(local_state.repo_path, function(sha, err)
-      if err or not sha then return end
-      if sha == local_state.last_head_sha then return end
+    local timer = vim.uv.new_timer()
+    if not timer then return end
+    local_state.poll_timer = timer
+    timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
+      if not local_state.active then return end
 
-      local_state.last_head_sha = sha
-      refresh_commits()
-    end)
-  end))
+      git.get_current_sha(local_state.repo_path, function(new_sha, err)
+        if err or not new_sha then return end
+        if new_sha == local_state.last_head_sha then return end
+
+        local_state.last_head_sha = new_sha
+        refresh_commits()
+      end)
+    end))
+  end)
 end
 
 --- Load more commits (triggered by approaching end of list)

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -43,10 +43,11 @@ end
 local local_state = make_initial_state()
 local local_mode_keymaps = {}
 
---- Compute the base ref for combined diff operations.
+--- Compute the local base ref for combined diff operations.
+--- Differs from commits.get_base_ref() which returns "origin/" + pr.base.ref.
 --- Prefers merge-base SHA (exact ancestor) when available; falls back to branch name.
 ---@return string|nil base_ref
-local function get_base_ref()
+local function get_local_base_ref()
   return local_state.merge_base_sha or local_state.base_branch
 end
 
@@ -128,7 +129,7 @@ local function maximize_cell(cell_num)
     state = local_state,
     is_working_dir = commit.sha == nil,
     is_combined_diff = git.is_combined_diff(commit),
-    base_ref = get_base_ref(),
+    base_ref = get_local_base_ref(),
   })
 end
 
@@ -148,7 +149,7 @@ local function select_commit(index)
 
   local fetch_diff
   if git.is_combined_diff(commit) then
-    local base_ref = get_base_ref()
+    local base_ref = get_local_base_ref()
     if not base_ref then
       vim.notify("Combined diff requires a base branch", vim.log.levels.WARN)
       return
@@ -455,7 +456,7 @@ local function setup_keymaps()
       local c = get_commit(local_state.selected_index)
       return c and c.message or ""
     end,
-    get_base_ref = get_base_ref,
+    get_base_ref = get_local_base_ref,
   })
 
   -- Focus lock autocmd

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -598,7 +598,7 @@ local function refresh_commits()
   end
 end
 
---- Start the 10-second HEAD polling timer.
+--- Start the HEAD polling timer (interval: POLL_INTERVAL_MS).
 --- Seeds last_head_sha before starting the timer to avoid spurious refresh on first tick.
 local function start_poll_timer()
   stop_poll_timer()

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -494,7 +494,10 @@ start_workdir_poll_timer = function()
   local interval = idle and WORKDIR_POLL_SLOW_MS or WORKDIR_POLL_FAST_MS
 
   local timer = vim.uv.new_timer()
-  if not timer then return end
+  if not timer then
+    vim.notify("Failed to create workdir poll timer", vim.log.levels.WARN)
+    return
+  end
   local_state.workdir_poll_timer = timer
   timer:start(interval, 0, vim.schedule_wrap(function()
     if not local_state.active then return end
@@ -594,7 +597,10 @@ local function start_poll_timer()
     if not local_state.active then return end
 
     local timer = vim.uv.new_timer()
-    if not timer then return end
+    if not timer then
+      vim.notify("Failed to create HEAD poll timer", vim.log.levels.WARN)
+      return
+    end
     local_state.poll_timer = timer
     timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
       if not local_state.active then return end

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -4,7 +4,6 @@ local M = {}
 
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
-local diff = require("raccoon.diff")
 local git = require("raccoon.git")
 local keymaps = require("raccoon.keymaps")
 local open = require("raccoon.open")
@@ -192,59 +191,17 @@ local function select_commit(index)
   end
 
   fetch_diff(function(files, err)
-    if generation ~= local_state.select_generation then return end
-
-    if err then
-      vim.notify("Failed to get commit diff: " .. err, vim.log.levels.ERROR)
-      return
-    end
-
-    local_state.commit_files = {}
-    local_state.file_stats = {}
-    local_state.all_hunks = {}
-    local_state.cached_sha = nil
-    local_state.cached_stat_lines = nil
-    for _, file in ipairs(files or {}) do
-      local_state.commit_files[file.filename] = true
-      local additions = 0
-      local deletions = 0
-      local hunks = diff.parse_patch(file.patch)
-      for _, hunk in ipairs(hunks) do
-        table.insert(local_state.all_hunks, {
-          hunk = hunk, filename = file.filename,
-        })
-        for _, line_data in ipairs(hunk.lines) do
-          if line_data.type == "add" then
-            additions = additions + 1
-          elseif line_data.type == "del" then
-            deletions = deletions + 1
-          end
-        end
-      end
-      local_state.file_stats[file.filename] = {
-        additions = additions, deletions = deletions,
-      }
-    end
-    build_filetree_cache()
-
-    if #local_state.all_hunks == 0 then
-      for i, buf in ipairs(local_state.grid_bufs) do
-        if vim.api.nvim_buf_is_valid(buf) then
-          vim.bo[buf].modifiable = true
-          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", "  No changes in this commit" })
-          vim.bo[buf].modifiable = false
-        end
-        local win = local_state.grid_wins[i]
-        if win and vim.api.nvim_win_is_valid(win) then
-          vim.wo[win].winbar = "%=#" .. i
-        end
-      end
-      ui.update_header(local_state, get_commit(local_state.selected_index), total_pages())
-      ui.render_filetree(local_state)
-      return
-    end
-
-    render_grid_page()
+    ui.apply_diff_result(local_state, {
+      files = files,
+      err = err,
+      generation = generation,
+      get_generation = function() return local_state.select_generation end,
+      build_cache_fn = build_filetree_cache,
+      get_commit_fn = function() return get_commit(local_state.selected_index) end,
+      total_pages_fn = total_pages,
+      ns_id = ns_id,
+      render_grid_fn = render_grid_page,
+    })
   end)
 end
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -52,6 +52,7 @@ local function get_local_base_ref()
 end
 
 --- Prepend synthetic entries (COMBINED DIFF + UNCOMMITTED CHANGES) to a branch commit list.
+--- Always inserts UNCOMMITTED CHANGES regardless of commit count.
 --- Inserts COMBINED DIFF only when there are multiple real commits.
 ---@param commits table[] Commit list to modify in place
 local function prepend_synthetic_entries(commits)
@@ -646,7 +647,7 @@ load_more_commits = function()
   else
     -- Flat mode: load more into branch_commits
     local_state.loading_more = true
-    local skip = #local_state.branch_commits - 1 -- -1 for synthetic UNCOMMITTED CHANGES entry
+    local skip = #local_state.branch_commits - 1 -- -1 for the single synthetic entry (UNCOMMITTED CHANGES); flat mode has no COMBINED DIFF
     git.log_all_commits(local_state.repo_path, BATCH_SIZE, skip, function(new_commits, err)
       local_state.loading_more = false
       if err then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -698,18 +698,11 @@ end
 
 --- Enter local commit viewer mode
 local function enter_local_mode()
-  local cfg = config.load()
-  local rows = 2
-  local cols = 2
-  local base_count = 20
-  if cfg and cfg.commit_viewer then
-    if cfg.commit_viewer.grid then
-      rows = ui.clamp_int(cfg.commit_viewer.grid.rows, 2, 1, 10)
-      cols = ui.clamp_int(cfg.commit_viewer.grid.cols, 2, 1, 10)
-    end
-    base_count = ui.clamp_int(cfg.commit_viewer.base_commits_count, 20, 1, 200)
-    ui.SIDEBAR_WIDTH = ui.clamp_int(cfg.commit_viewer.sidebar_width, 50, 20, 120)
-  end
+  local vcfg = ui.parse_viewer_config()
+  ui.SIDEBAR_WIDTH = vcfg.sidebar_width
+  local rows = vcfg.rows
+  local cols = vcfg.cols
+  local base_count = vcfg.base_count
 
   vim.notify("Loading commits...", vim.log.levels.INFO)
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -10,7 +10,6 @@ local open = require("raccoon.open")
 local state = require("raccoon.state")
 local ui = require("raccoon.commit_ui")
 
-local COMBINED_DIFF_SHA = git.COMBINED_DIFF_SHA
 local CURRENT_CHANGES_MSG = "UNCOMMITTED CHANGES"
 
 local ns_id = vim.api.nvim_create_namespace("raccoon_local_commits")
@@ -82,12 +81,10 @@ end
 --- Inserts COMBINED DIFF only when there are multiple real commits.
 ---@param commits table[] Commit list to modify in place
 local function prepend_synthetic_entries(commits)
-  if #commits > 1 then
-    table.insert(commits, 1, git.make_combined_diff_entry())
-    table.insert(commits, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
-  else
-    table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-  end
+  git.maybe_prepend_combined_diff(commits)
+  -- Insert UNCOMMITTED CHANGES after COMBINED DIFF (or at position 1 if no combined diff)
+  local insert_pos = git.is_combined_diff(commits[1]) and 2 or 1
+  table.insert(commits, insert_pos, { sha = nil, message = CURRENT_CHANGES_MSG })
 end
 
 local load_more_commits
@@ -157,7 +154,7 @@ local function maximize_cell(cell_num)
     get_generation = function() return local_state.select_generation end,
     state = local_state,
     is_working_dir = commit.sha == nil,
-    is_combined_diff = commit.sha == COMBINED_DIFF_SHA,
+    is_combined_diff = git.is_combined_diff(commit),
     base_ref = get_base_ref(),
   })
 end
@@ -177,7 +174,7 @@ local function select_commit(index)
   local context = ui.compute_grid_context(local_state.grid_rows)
 
   local fetch_diff
-  if commit.sha == COMBINED_DIFF_SHA then
+  if git.is_combined_diff(commit) then
     local base_ref = get_base_ref()
     if not base_ref then
       vim.notify("Combined diff requires a base branch", vim.log.levels.WARN)
@@ -243,7 +240,7 @@ local function render_sidebar()
       section2_header = "── " .. local_state.base_branch .. " ──",
       section2_commits = local_state.base_commits,
       commit_hl_fn = function(commit)
-        if commit.sha == nil or commit.sha == COMBINED_DIFF_SHA then return "DiagnosticInfo" end
+        if commit.sha == nil or git.is_combined_diff(commit) then return "DiagnosticInfo" end
       end,
       loading = local_state.loading_more,
     })
@@ -829,33 +826,20 @@ local function exit_local_mode()
   stop_poll_timer()
   stop_workdir_poll_timer()
 
-  if local_state.focus_augroup then
-    pcall(vim.api.nvim_del_augroup_by_id, local_state.focus_augroup)
-  end
-
-  -- Close floating maximize window (not affected by :only)
-  ui.close_win_pair(local_state, "maximize_win", "maximize_buf")
-  local_mode_keymaps = {}
-
-  -- Close all splits in one shot; scratch buffers auto-wipe (bufhidden=wipe)
-  vim.cmd("only")
-
-  if local_state.saved_buf and vim.api.nvim_buf_is_valid(local_state.saved_buf) then
-    vim.api.nvim_set_current_buf(local_state.saved_buf)
-  end
-
-  if local_state.saved_laststatus then
-    vim.o.laststatus = local_state.saved_laststatus
-  end
-
-  -- Restore PR session if it was active
-  if local_state.pr_was_active then
-    keymaps.setup()
-    open.resume_sync()
-  end
-
-  local_state = make_initial_state()
-  vim.notify("Exited local commit viewer", vim.log.levels.INFO)
+  local was_pr_active = local_state.pr_was_active
+  ui.teardown_viewer(local_state, {
+    on_before_only = function()
+      local_mode_keymaps = {}
+    end,
+    on_after = function()
+      if was_pr_active then
+        keymaps.setup()
+        open.resume_sync()
+      end
+      local_state = make_initial_state()
+      vim.notify("Exited local commit viewer", vim.log.levels.INFO)
+    end,
+  })
 end
 
 --- Toggle local commit viewer mode

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -73,6 +73,7 @@ local local_state = make_initial_state()
 local local_mode_keymaps = {}
 
 --- Compute the base ref for combined diff operations.
+--- Prefers merge-base SHA (exact ancestor) when available; falls back to branch name.
 ---@return string|nil base_ref
 local function get_base_ref()
   return local_state.merge_base_sha or local_state.base_branch
@@ -168,6 +169,10 @@ local function select_commit(index)
   local fetch_diff
   if commit.sha == COMBINED_DIFF_SHA then
     local base_ref = get_base_ref()
+    if not base_ref then
+      vim.notify("Combined diff requires a base branch", vim.log.levels.WARN)
+      return
+    end
     fetch_diff = function(cb) git.diff_combined(local_state.repo_path, base_ref, context, cb) end
   elseif commit.sha then
     fetch_diff = function(cb) git.show_commit(local_state.repo_path, commit.sha, context, cb) end

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -79,7 +79,18 @@ local function get_base_ref()
   return local_state.merge_base_sha or local_state.base_branch
 end
 
--- Forward declarations
+--- Prepend synthetic entries (COMBINED DIFF + UNCOMMITTED CHANGES) to a branch commit list.
+--- Inserts COMBINED DIFF only when there are multiple real commits.
+---@param commits table[] Commit list to modify in place
+local function prepend_synthetic_entries(commits)
+  if #commits > 1 then
+    table.insert(commits, 1, git.make_combined_diff_entry())
+    table.insert(commits, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
+  else
+    table.insert(commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
+  end
+end
+
 local load_more_commits
 local build_filetree_cache
 
@@ -527,26 +538,28 @@ end
 --- Stop the poll timer
 local function stop_poll_timer()
   if local_state.poll_timer then
-    local_state.poll_timer:stop()
-    local_state.poll_timer:close()
+    local handle = local_state.poll_timer
     local_state.poll_timer = nil
+    pcall(handle.stop, handle)
+    pcall(handle.close, handle)
   end
 end
 
 --- Stop the working directory poll timer
 local function stop_workdir_poll_timer()
   if local_state.workdir_poll_timer then
-    local_state.workdir_poll_timer:stop()
-    local_state.workdir_poll_timer:close()
+    local handle = local_state.workdir_poll_timer
     local_state.workdir_poll_timer = nil
+    pcall(handle.stop, handle)
+    pcall(handle.close, handle)
   end
 end
 
--- Forward declaration
 local start_workdir_poll_timer
 
---- Start the adaptive working directory poll timer
---- Fast (3s) when changes are recent, slow (30s) after 3 minutes idle
+--- Start the adaptive working directory poll timer.
+--- Fast (WORKDIR_POLL_FAST_MS) when changes are recent,
+--- slow (WORKDIR_POLL_SLOW_MS) after WORKDIR_IDLE_THRESHOLD_MS idle.
 start_workdir_poll_timer = function()
   stop_workdir_poll_timer()
   if not local_state.active then return end
@@ -556,8 +569,10 @@ start_workdir_poll_timer = function()
     or (now - local_state.last_change_time) >= WORKDIR_IDLE_THRESHOLD_MS
   local interval = idle and WORKDIR_POLL_SLOW_MS or WORKDIR_POLL_FAST_MS
 
-  local_state.workdir_poll_timer = vim.uv.new_timer()
-  local_state.workdir_poll_timer:start(interval, 0, vim.schedule_wrap(function()
+  local timer = vim.uv.new_timer()
+  if not timer then return end
+  local_state.workdir_poll_timer = timer
+  timer:start(interval, 0, vim.schedule_wrap(function()
     if not local_state.active then return end
 
     git.status_porcelain(local_state.repo_path, function(output, err)
@@ -586,18 +601,7 @@ end
 
 --- Preserve selected commit across a refresh
 local function restore_selection_by_sha(selected_sha)
-  if selected_sha then
-    for i = 1, total_commits() do
-      local c = get_commit(i)
-      if c and c.sha == selected_sha then
-        local_state.selected_index = i
-        return
-      end
-    end
-  end
-  if local_state.selected_index > total_commits() then
-    local_state.selected_index = math.max(1, total_commits())
-  end
+  ui.restore_selection_by_sha(local_state, selected_sha, total_commits, get_commit)
 end
 
 --- Refresh commits from git (called when HEAD changes)
@@ -609,12 +613,7 @@ local function refresh_commits()
     -- Branch mode: refresh branch commits only (base stays static)
     git.log_branch_commits(local_state.repo_path, local_state.merge_base_sha, function(new_branch, err)
       if err or not new_branch then return end
-      if #new_branch > 1 then
-        table.insert(new_branch, 1, git.make_combined_diff_entry())
-        table.insert(new_branch, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
-      else
-        table.insert(new_branch, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-      end
+      prepend_synthetic_entries(new_branch)
       local_state.branch_commits = new_branch
       local_state.last_status_output = ""
       restore_selection_by_sha(selected_sha)
@@ -644,8 +643,10 @@ local function start_poll_timer()
     end
   end)
 
-  local_state.poll_timer = vim.uv.new_timer()
-  local_state.poll_timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
+  local timer = vim.uv.new_timer()
+  if not timer then return end
+  local_state.poll_timer = timer
+  timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
     if not local_state.active then return end
 
     git.get_current_sha(local_state.repo_path, function(sha, err)
@@ -799,13 +800,7 @@ local function enter_local_mode()
           local function on_both_ready()
             local branch_commits = branch_result or {}
             local base_commits = base_result or {}
-            -- Combined diff on top when there are multiple branch commits
-            if #branch_commits > 1 then
-              table.insert(branch_commits, 1, git.make_combined_diff_entry())
-              table.insert(branch_commits, 2, { sha = nil, message = CURRENT_CHANGES_MSG })
-            else
-              table.insert(branch_commits, 1, { sha = nil, message = CURRENT_CHANGES_MSG })
-            end
+            prepend_synthetic_entries(branch_commits)
             local_state.current_branch = current_branch
             local_state.base_branch = default_branch
             local_state.merge_base_sha = merge_sha

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -19,6 +19,7 @@ local POLL_INTERVAL_MS = 10000
 local WORKDIR_POLL_FAST_MS = 3000
 local WORKDIR_POLL_SLOW_MS = 30000
 local WORKDIR_IDLE_THRESHOLD_MS = 180000
+local MAX_WORKDIR_FAILURES = 5
 
 local function make_initial_state()
   local s = ui.make_base_state()
@@ -478,6 +479,7 @@ local function stop_workdir_poll_timer()
 end
 
 local start_workdir_poll_timer
+local workdir_fail_count = 0
 
 --- Start the adaptive working directory poll timer.
 --- Fast (WORKDIR_POLL_FAST_MS) when changes are recent,
@@ -503,10 +505,16 @@ start_workdir_poll_timer = function()
         return
       end
       if err then
+        workdir_fail_count = workdir_fail_count + 1
+        if workdir_fail_count >= MAX_WORKDIR_FAILURES then
+          vim.notify("Workdir poll: stopped after " .. workdir_fail_count .. " consecutive failures", vim.log.levels.WARN)
+          return
+        end
         vim.notify("Workdir poll: status_porcelain failed", vim.log.levels.DEBUG)
         start_workdir_poll_timer()
         return
       end
+      workdir_fail_count = 0
 
       if (output or "") == local_state.last_status_output then
         start_workdir_poll_timer()
@@ -656,6 +664,7 @@ local function activate_mode(repo_root, rows, cols, notify_msg)
   local_state.active = true
   local_state.repo_path = repo_root
   local_state.last_change_time = vim.uv.now()
+  workdir_fail_count = 0
 
   vim.schedule(function()
     ui.create_grid_layout(local_state, rows, cols)

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -289,9 +289,16 @@ end
 --- Stop the sync timer
 local function stop_sync_timer()
   if sync_timer then
-    sync_timer:stop()
-    sync_timer:close()
+    local handle = sync_timer
     sync_timer = nil
+    local ok1, err1 = pcall(handle.stop, handle)
+    if not ok1 then
+      vim.notify("Sync timer stop failed: " .. tostring(err1), vim.log.levels.DEBUG)
+    end
+    local ok2, err2 = pcall(handle.close, handle)
+    if not ok2 then
+      vim.notify("Sync timer close failed: " .. tostring(err2), vim.log.levels.DEBUG)
+    end
   end
 end
 

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -543,9 +543,29 @@ local function prepare_repo(clone_path, repo_url, branch, callback)
   end
 end
 
+--- Close the current PR session without notifications.
+--- Shared by close_pr() and open_pr() to avoid duplication.
+local function close_session()
+  stop_sync_timer()
+  last_known_sha = nil
+  commits_behind = 0
+  has_conflicts = false
+  vim.wo.statusline = ""
+  keymaps.clear()
+  state.stop()
+end
+
 --- Open a PR for review
 ---@param url string GitHub PR URL
 function M.open_pr(url)
+  -- Exit any active viewer mode (commit viewer, local commits) before opening
+  state.exit_active_mode()
+
+  -- Close existing PR session if one is active
+  if state.is_active() then
+    close_session()
+  end
+
   -- Load config first (needed for github_host)
   local cfg, cfg_err = config.load()
   if cfg_err then
@@ -674,19 +694,10 @@ function M.close_pr()
     return
   end
 
-  -- Stop sync timer
-  stop_sync_timer()
-  last_known_sha = nil
-  commits_behind = 0
-  has_conflicts = false
+  -- Exit any active viewer mode first (commit viewer, local commits)
+  state.exit_active_mode()
 
-  -- Reset statusline to default
-  vim.wo.statusline = ""
-
-  -- Clear all PR review keymaps
-  keymaps.clear()
-
-  state.stop()
+  close_session()
   vim.notify("PR review session closed", vim.log.levels.INFO)
 end
 

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -562,16 +562,24 @@ local function close_session()
   state.stop()
 end
 
+--- Close any active viewer mode and PR session before starting a new flow.
+---@param opts table|nil {silent: boolean}
+function M.close_all_sessions(opts)
+  opts = opts or {}
+  state.exit_active_mode()
+  if state.is_active() then
+    if opts.silent then
+      close_session()
+    else
+      M.close_pr()
+    end
+  end
+end
+
 --- Open a PR for review
 ---@param url string GitHub PR URL
 function M.open_pr(url)
-  -- Exit any active viewer mode (commit viewer, local commits) before opening
-  state.exit_active_mode()
-
-  -- Close existing PR session if one is active
-  if state.is_active() then
-    close_session()
-  end
+  M.close_all_sessions({ silent = true })
 
   -- Load config first (needed for github_host)
   local cfg, cfg_err = config.load()

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -584,7 +584,7 @@ function M.open_pr(url)
   api.init(url_host)
 
   -- Set sync interval from config (clamped to 10s minimum)
-  local interval_s = math.max(10, cfg.pull_changes_interval or 300)
+  local interval_s = math.max(10, cfg.poll_interval_seconds or 300)
   sync_interval_ms = interval_s * 1000
 
   -- Build clone path

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -291,14 +291,7 @@ local function stop_sync_timer()
   if sync_timer then
     local handle = sync_timer
     sync_timer = nil
-    local ok1, err1 = pcall(handle.stop, handle)
-    if not ok1 then
-      vim.notify("Sync timer stop failed: " .. tostring(err1), vim.log.levels.DEBUG)
-    end
-    local ok2, err2 = pcall(handle.close, handle)
-    if not ok2 then
-      vim.notify("Sync timer close failed: " .. tostring(err2), vim.log.levels.DEBUG)
-    end
+    require("raccoon.commit_ui").safe_close_timer(handle)
   end
 end
 
@@ -328,6 +321,9 @@ local function sync_pr(silent, force)
   if not owner or not repo or not number or not clone_path or not pr then
     return
   end
+  if not pr.head or not pr.head.ref or not pr.base or not pr.base.ref then
+    return
+  end
 
   -- Initialize API URLs for this session's host
   api.init(github_host)
@@ -350,7 +346,7 @@ local function sync_pr(silent, force)
     end
 
     -- Check if SHA changed (skip check if force = true)
-    local new_sha = new_pr.head.sha
+    local new_sha = new_pr and new_pr.head and new_pr.head.sha
     if new_sha == last_known_sha and not force then
       -- No changes
       if not silent then
@@ -500,6 +496,10 @@ local function start_sync_timer()
   if not sync_interval_ms then return end
 
   sync_timer = vim.uv.new_timer()
+  if not sync_timer then
+    vim.notify("Failed to create PR sync timer", vim.log.levels.WARN)
+    return
+  end
   sync_timer:start(sync_interval_ms, sync_interval_ms, vim.schedule_wrap(function()
     sync_pr(true) -- silent sync
   end))

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -695,13 +695,16 @@ function M.open_pr(url)
 end
 
 --- Close the current PR review session
-function M.close_pr()
+---@param opts table|nil {silent: boolean}
+function M.close_pr(opts)
+  opts = opts or {}
   if not state.is_active() then
-    vim.notify("No active PR review session", vim.log.levels.WARN)
+    if not opts.silent then
+      vim.notify("No active PR review session", vim.log.levels.WARN)
+    end
     return
   end
 
-  -- Exit any active viewer mode first (commit viewer, local commits)
   state.exit_active_mode()
 
   close_session()

--- a/lua/raccoon/state.lua
+++ b/lua/raccoon/state.lua
@@ -260,7 +260,7 @@ function M.get_statusline_component()
 end
 
 --- Shared popup window handle. When set, all focus locks allow this window.
---- Lives in state (rather than a UI module) to avoid coupling between ui.lua and commit_ui.lua.
+--- Lives in state to avoid circular requires between ui.lua (which sets it) and commit_ui.lua (which checks it in focus locks).
 ---@type number|nil
 M.global_popup_win = nil
 

--- a/lua/raccoon/state.lua
+++ b/lua/raccoon/state.lua
@@ -61,6 +61,7 @@ function M.reset()
     },
     commit_mode = false,
   }
+  M.global_popup_win = nil
 end
 
 --- Start a new review session

--- a/lua/raccoon/state.lua
+++ b/lua/raccoon/state.lua
@@ -264,6 +264,28 @@ end
 ---@type number|nil
 M.global_popup_win = nil
 
+--- Cleanup function for the active viewer mode (commit viewer or local commits).
+--- Registered by the mode when it becomes active; called before resetting state.
+---@type fun()|nil
+local mode_exit_fn = nil
+
+--- Register a cleanup function for the active viewer mode.
+--- Called when entering commit viewer or local commit mode.
+---@param fn fun()|nil
+function M.set_mode_exit(fn)
+  mode_exit_fn = fn
+end
+
+--- Exit the active viewer mode if one is registered.
+--- Called before closing a PR session or opening a new one.
+function M.exit_active_mode()
+  if mode_exit_fn then
+    local fn = mode_exit_fn
+    mode_exit_fn = nil
+    fn()
+  end
+end
+
 --- Check if commit viewer mode is active
 ---@return boolean
 function M.is_commit_mode()

--- a/lua/raccoon/state.lua
+++ b/lua/raccoon/state.lua
@@ -258,6 +258,11 @@ function M.get_statusline_component()
   return table.concat(parts, " │ ")
 end
 
+--- Shared popup window handle. When set, all focus locks allow this window.
+--- Lives in state (rather than a UI module) to avoid coupling between ui.lua and commit_ui.lua.
+---@type number|nil
+M.global_popup_win = nil
+
 --- Check if commit viewer mode is active
 ---@return boolean
 function M.is_commit_mode()

--- a/lua/raccoon/state.lua
+++ b/lua/raccoon/state.lua
@@ -265,7 +265,8 @@ end
 M.global_popup_win = nil
 
 --- Cleanup function for the active viewer mode (commit viewer or local commits).
---- Registered by the mode when it becomes active; called before resetting state.
+--- Registered by a viewer mode when it activates. exit_active_mode() invokes this
+--- to tear down the mode before the caller resets state.
 ---@type fun()|nil
 local mode_exit_fn = nil
 

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -283,9 +283,6 @@ function M.show_pr_list()
     return
   end
 
-  -- Tell any active focus lock to allow this popup (sentinel before open_win)
-  commit_ui.global_popup_win = -1
-
   -- Create floating window
   local win, buf = M.create_floating_window({
     width_pct = 0.7,
@@ -300,7 +297,7 @@ function M.show_pr_list()
   M.state.prs = {}
   M.state.selected = 1
 
-  -- Replace sentinel with real window handle
+  -- Tell any active focus lock to allow this popup
   commit_ui.global_popup_win = win
 
   -- Show loading state

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local api = require("raccoon.api")
 local config = require("raccoon.config")
-local commit_ui = require("raccoon.commit_ui")
+local state = require("raccoon.state")
 local NORMAL_MODE = config.NORMAL
 
 --- Current floating window state
@@ -70,7 +70,7 @@ end
 
 --- Close the PR list window
 function M.close_pr_list()
-  commit_ui.global_popup_win = nil
+  state.global_popup_win = nil
   if M.state.win and vim.api.nvim_win_is_valid(M.state.win) then
     vim.api.nvim_win_close(M.state.win, true)
   end
@@ -298,7 +298,7 @@ function M.show_pr_list()
   M.state.selected = 1
 
   -- Tell any active focus lock to allow this popup
-  commit_ui.global_popup_win = win
+  state.global_popup_win = win
 
   -- Show loading state
   vim.bo[buf].modifiable = true

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local api = require("raccoon.api")
 local config = require("raccoon.config")
-local app_state = require("raccoon.state")
+local commit_ui = require("raccoon.commit_ui")
 local NORMAL_MODE = config.NORMAL
 
 --- Current floating window state
@@ -70,9 +70,7 @@ end
 
 --- Close the PR list window
 function M.close_pr_list()
-  if app_state.is_commit_mode() then
-    require("raccoon.commits").set_popup_win(nil)
-  end
+  commit_ui.global_popup_win = nil
   if M.state.win and vim.api.nvim_win_is_valid(M.state.win) then
     vim.api.nvim_win_close(M.state.win, true)
   end
@@ -285,10 +283,8 @@ function M.show_pr_list()
     return
   end
 
-  -- Tell commit mode focus lock to allow this popup (sentinel before open_win)
-  if app_state.is_commit_mode() then
-    require("raccoon.commits").set_popup_win(-1)
-  end
+  -- Tell any active focus lock to allow this popup (sentinel before open_win)
+  commit_ui.global_popup_win = -1
 
   -- Create floating window
   local win, buf = M.create_floating_window({
@@ -305,9 +301,7 @@ function M.show_pr_list()
   M.state.selected = 1
 
   -- Replace sentinel with real window handle
-  if app_state.is_commit_mode() then
-    require("raccoon.commits").set_popup_win(win)
-  end
+  commit_ui.global_popup_win = win
 
   -- Show loading state
   vim.bo[buf].modifiable = true

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -4,6 +4,7 @@ local M = {}
 
 local api = require("raccoon.api")
 local config = require("raccoon.config")
+local app_state = require("raccoon.state")
 local NORMAL_MODE = config.NORMAL
 
 --- Current floating window state
@@ -69,6 +70,9 @@ end
 
 --- Close the PR list window
 function M.close_pr_list()
+  if app_state.is_commit_mode() then
+    require("raccoon.commits").set_popup_win(nil)
+  end
   if M.state.win and vim.api.nvim_win_is_valid(M.state.win) then
     vim.api.nvim_win_close(M.state.win, true)
   end
@@ -281,6 +285,11 @@ function M.show_pr_list()
     return
   end
 
+  -- Tell commit mode focus lock to allow this popup (sentinel before open_win)
+  if app_state.is_commit_mode() then
+    require("raccoon.commits").set_popup_win(-1)
+  end
+
   -- Create floating window
   local win, buf = M.create_floating_window({
     width_pct = 0.7,
@@ -295,6 +304,11 @@ function M.show_pr_list()
   M.state.prs = {}
   M.state.selected = 1
 
+  -- Replace sentinel with real window handle
+  if app_state.is_commit_mode() then
+    require("raccoon.commits").set_popup_win(win)
+  end
+
   -- Show loading state
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "  Loading..." })
@@ -302,6 +316,16 @@ function M.show_pr_list()
 
   -- Load shortcuts from config
   local shortcuts = config.load_shortcuts()
+
+  -- Update title to include close hint (derived from config, like other plugin windows)
+  local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. " or Esc") or "Esc"
+  vim.api.nvim_win_set_config(win, {
+    title = {
+      { " Pull Requests  ", "FloatTitle" },
+      { close_hint .. " to close ", "FloatBorder" },
+    },
+    title_pos = "center",
+  })
 
   -- Setup buffer-local keymaps
   local opts = { buffer = buf, noremap = true, silent = true }

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -299,6 +299,16 @@ function M.show_pr_list()
 
   -- Tell any active focus lock to allow this popup
   state.global_popup_win = win
+  -- Clear the global reference when the window is closed (e.g. by :q or user)
+  vim.api.nvim_create_autocmd("WinClosed", {
+    pattern = tostring(win),
+    once = true,
+    callback = function()
+      if state.global_popup_win == win then
+        state.global_popup_win = nil
+      end
+    end,
+  })
 
   -- Show loading state
   vim.bo[buf].modifiable = true

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -609,14 +609,14 @@ function M.show_description()
     return
   end
 
-  local state = require("raccoon.state")
+  local review_state = require("raccoon.state")
 
-  if not state.is_active() then
+  if not review_state.is_active() then
     vim.notify("No active PR review session", vim.log.levels.WARN)
     return
   end
 
-  local pr = state.get_pr()
+  local pr = review_state.get_pr()
   if not pr then
     vim.notify("No PR data available", vim.log.levels.WARN)
     return

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -283,6 +283,9 @@ function M.show_pr_list()
     return
   end
 
+  local open = require("raccoon.open")
+  open.close_all_sessions({ silent = true })
+
   -- Create floating window
   local win, buf = M.create_floating_window({
     width_pct = 0.7,

--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -142,7 +142,7 @@ vim.api.nvim_create_user_command("Raccoon", function(opts)
     "your-username": "ghp_xxxxxxxxxxxxxxxxxxxx"
   },
   "clone_root": "%s",
-  "pull_changes_interval": 300,
+  "poll_interval_seconds": 300,
   "commit_viewer": {
     "grid": { "rows": 2, "cols": 2 },
     "base_commits_count": 20

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -534,6 +534,45 @@ describe("raccoon.commits select_generation guard", function()
   end)
 end)
 
+describe("raccoon.commits error messages include error details", function()
+  local original_show_commit
+  local captured_callback
+  local notified_msg
+
+  before_each(function()
+    state.reset()
+    original_show_commit = git.show_commit
+    git.show_commit = function(_, _, _, cb)
+      captured_callback = cb
+    end
+    notified_msg = nil
+    vim.notify = function(msg, _) notified_msg = msg end
+
+    local cs = commits._get_state()
+    cs.pr_commits = { { sha = "abc123", message = "test commit" } }
+    cs.active = true
+    cs.grid_bufs = {}
+    cs.grid_wins = {}
+    cs.all_hunks = {}
+    cs.select_generation = 0
+    state.session = state.session or {}
+    state.session.clone_path = "/tmp/fake"
+  end)
+
+  after_each(function()
+    git.show_commit = original_show_commit
+    state.reset()
+  end)
+
+  it("includes error string in diff failure notification", function()
+    commits._select_commit(1)
+    captured_callback(nil, "fatal: bad object abc123")
+
+    assert.is_not_nil(notified_msg)
+    assert.is_truthy(notified_msg:match("fatal: bad object abc123"),
+      "expected error detail in notification, got: " .. (notified_msg or ""))
+  end)
+end)
 
 describe("raccoon.config commit_viewer defaults", function()
   it("has commit_viewer in defaults", function()
@@ -548,6 +587,10 @@ describe("raccoon.config commit_viewer defaults", function()
 
   it("has base_commits_count default", function()
     assert.equals(20, config.defaults.commit_viewer.base_commits_count)
+  end)
+
+  it("has sync_interval default", function()
+    assert.equals(60, config.defaults.commit_viewer.sync_interval)
   end)
 end)
 

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -60,6 +60,26 @@ describe("raccoon.git commit operations", function()
     it("has show_commit_file function", function()
       assert.is_function(git.show_commit_file)
     end)
+
+    it("has ref_sha function", function()
+      assert.is_function(git.ref_sha)
+    end)
+
+    it("has reset_hard function", function()
+      assert.is_function(git.reset_hard)
+    end)
+
+    it("has diff_combined function", function()
+      assert.is_function(git.diff_combined)
+    end)
+
+    it("has diff_combined_file function", function()
+      assert.is_function(git.diff_combined_file)
+    end)
+
+    it("has make_combined_diff_entry function", function()
+      assert.is_function(git.make_combined_diff_entry)
+    end)
   end)
 
   describe("log_commits on current repo", function()
@@ -1545,5 +1565,185 @@ describe("raccoon.commits render_tree_node with file_stats", function()
     assert.is_not_nil(few_stat)
     assert.is_not_nil(many_stat)
     assert.is_true(few_stat.add_chars < many_stat.add_chars + many_stat.del_chars)
+  end)
+end)
+
+describe("raccoon.git combined diff sentinel", function()
+  it("COMBINED_DIFF_SHA is a non-empty string", function()
+    assert.is_string(git.COMBINED_DIFF_SHA)
+    assert.is_true(#git.COMBINED_DIFF_SHA > 0)
+  end)
+
+  it("make_combined_diff_entry returns correct shape", function()
+    local entry = git.make_combined_diff_entry()
+    assert.is_table(entry)
+    assert.equals(git.COMBINED_DIFF_SHA, entry.sha)
+    assert.equals("COMBINED DIFF", entry.message)
+  end)
+
+  it("sentinel does not look like a real 40-char hex SHA", function()
+    assert.is_not_equal(40, #git.COMBINED_DIFF_SHA)
+  end)
+
+  it("diff_combined returns error when base_ref is nil", function()
+    local done = false
+    local result_err = nil
+    git.diff_combined(vim.fn.getcwd(), nil, nil, function(_, err)
+      result_err = err
+      done = true
+    end)
+    -- Synchronous early return, no need for vim.wait
+    assert.is_true(done)
+    assert.is_string(result_err)
+    assert.is_truthy(result_err:match("No base ref"))
+  end)
+
+  it("diff_combined_file returns error when base_ref is nil", function()
+    local done = false
+    local result_err = nil
+    git.diff_combined_file(vim.fn.getcwd(), nil, "test.lua", function(_, err)
+      result_err = err
+      done = true
+    end)
+    assert.is_true(done)
+    assert.is_string(result_err)
+    assert.is_truthy(result_err:match("No base ref"))
+  end)
+end)
+
+describe("raccoon.commits combined diff insertion", function()
+  local original_show_commit
+  local original_diff_combined
+  local original_list_files
+  local captured_diff_combined
+  local captured_show_commit
+
+  before_each(function()
+    state.reset()
+    original_show_commit = git.show_commit
+    original_diff_combined = git.diff_combined
+    original_list_files = git.list_files
+    captured_diff_combined = false
+    captured_show_commit = false
+    git.diff_combined = function(_, _, _, cb)
+      captured_diff_combined = true
+      cb({}, nil)
+    end
+    git.show_commit = function(_, _, _, cb)
+      captured_show_commit = true
+      cb({}, nil)
+    end
+    git.list_files = function(_, _, cb) cb({}, nil) end
+    local cs = commits._get_state()
+    cs.active = true
+    cs.grid_bufs = {}
+    cs.grid_wins = {}
+    cs.all_hunks = {}
+    cs.select_generation = 0
+    state.session = state.session or {}
+    state.session.clone_path = "/tmp/fake"
+    state.session.pr = { base = { ref = "main" } }
+  end)
+
+  after_each(function()
+    git.show_commit = original_show_commit
+    git.diff_combined = original_diff_combined
+    git.list_files = original_list_files
+    state.reset()
+  end)
+
+  it("inserts COMBINED DIFF at index 1 when PR has >1 commits", function()
+    local cs = commits._get_state()
+    cs.pr_commits = {
+      { sha = "aaaa", message = "commit 1" },
+      { sha = "bbbb", message = "commit 2" },
+    }
+    -- Simulate what enter_commit_mode does:
+    -- real_pr_count > 1 => insert combined diff
+    assert.is_true(#cs.pr_commits > 1)
+    table.insert(cs.pr_commits, 1, git.make_combined_diff_entry())
+    assert.equals(git.COMBINED_DIFF_SHA, cs.pr_commits[1].sha)
+    assert.equals(3, #cs.pr_commits)
+  end)
+
+  it("does NOT insert COMBINED DIFF when PR has exactly 1 commit", function()
+    local cs = commits._get_state()
+    cs.pr_commits = {
+      { sha = "aaaa", message = "only commit" },
+    }
+    -- real_pr_count == 1 => no combined diff
+    assert.is_false(#cs.pr_commits > 1)
+    assert.equals(1, #cs.pr_commits)
+    assert.is_not_equal(git.COMBINED_DIFF_SHA, cs.pr_commits[1].sha)
+  end)
+
+  it("dispatches to diff_combined when selecting COMBINED DIFF entry", function()
+    local cs = commits._get_state()
+    cs.pr_commits = {
+      git.make_combined_diff_entry(),
+      { sha = "aaaa", message = "commit 1" },
+    }
+    commits._select_commit(1)
+    assert.is_true(captured_diff_combined)
+    assert.is_false(captured_show_commit)
+  end)
+
+  it("dispatches to show_commit when selecting a regular commit", function()
+    local cs = commits._get_state()
+    cs.pr_commits = {
+      git.make_combined_diff_entry(),
+      { sha = "aaaa", message = "commit 1" },
+    }
+    commits._select_commit(2)
+    assert.is_false(captured_diff_combined)
+    assert.is_true(captured_show_commit)
+  end)
+end)
+
+describe("raccoon.commit_ui restore_selection_by_sha", function()
+  it("finds and selects matching SHA", function()
+    local s = { selected_index = 1 }
+    local items = {
+      { sha = "aaa", message = "first" },
+      { sha = "bbb", message = "second" },
+      { sha = "ccc", message = "third" },
+    }
+    commit_ui.restore_selection_by_sha(s, "bbb",
+      function() return #items end,
+      function(i) return items[i] end)
+    assert.equals(2, s.selected_index)
+  end)
+
+  it("clamps index when SHA is not found", function()
+    local s = { selected_index = 5 }
+    local items = {
+      { sha = "aaa", message = "first" },
+      { sha = "bbb", message = "second" },
+    }
+    commit_ui.restore_selection_by_sha(s, "zzz",
+      function() return #items end,
+      function(i) return items[i] end)
+    assert.equals(2, s.selected_index)
+  end)
+
+  it("clamps to 1 when list is empty", function()
+    local s = { selected_index = 3 }
+    commit_ui.restore_selection_by_sha(s, "zzz",
+      function() return 0 end,
+      function() return nil end)
+    -- math.max(1, 0) = 1 when total is 0 but index exceeds it
+    assert.equals(1, s.selected_index)
+  end)
+
+  it("preserves index when SHA is nil and index is valid", function()
+    local s = { selected_index = 2 }
+    local items = {
+      { sha = "aaa", message = "first" },
+      { sha = "bbb", message = "second" },
+    }
+    commit_ui.restore_selection_by_sha(s, nil,
+      function() return #items end,
+      function(i) return items[i] end)
+    assert.equals(2, s.selected_index)
   end)
 end)

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -534,52 +534,6 @@ describe("raccoon.commits select_generation guard", function()
   end)
 end)
 
-describe("raccoon.commits error message sanitization", function()
-  local source
-
-  before_each(function()
-    if not source then
-      local src_path = vim.fn.getcwd() .. "/lua/raccoon/commits.lua"
-      local f = io.open(src_path, "r")
-      assert.is_truthy(f, "could not open commits.lua")
-      source = f:read("*a")
-      f:close()
-    end
-  end)
-
-  it("does not expose raw err in ERROR notifications", function()
-    for line in source:gmatch("[^\n]+") do
-      if line:match("vim%.notify%(") and line:match("levels%.ERROR") then
-        assert.is_falsy(
-          line:match('%.%.%s*err') or line:match('%.%.%s*fetch_err') or line:match('%.%.%s*unshallow_err'),
-          "ERROR notify should not concatenate raw error: " .. line
-        )
-      end
-    end
-  end)
-
-  it("does not expose raw err in WARN notifications", function()
-    for line in source:gmatch("[^\n]+") do
-      if line:match("vim%.notify%(") and line:match("levels%.WARN") then
-        assert.is_falsy(
-          line:match('%.%.%s*err') or line:match('%.%.%s*fetch_err') or line:match('%.%.%s*unshallow_err'),
-          "WARN notify should not concatenate raw error: " .. line
-        )
-      end
-    end
-  end)
-
-  it("does not expose raw err in INFO notifications", function()
-    for line in source:gmatch("[^\n]+") do
-      if line:match("vim%.notify%(") and line:match("levels%.INFO") then
-        assert.is_falsy(
-          line:match('%.%.%s*err') or line:match('%.%.%s*fetch_err') or line:match('%.%.%s*unshallow_err'),
-          "INFO notify should not concatenate raw error: " .. line
-        )
-      end
-    end
-  end)
-end)
 
 describe("raccoon.config commit_viewer defaults", function()
   it("has commit_viewer in defaults", function()

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -1970,4 +1970,188 @@ describe("raccoon.commit_ui teardown_viewer", function()
     assert.equals("before", call_order[1])
     assert.equals("after", call_order[2])
   end)
+
+  it("restores saved_laststatus", function()
+    local original = vim.o.laststatus
+    vim.o.laststatus = 3
+    local s = {
+      focus_augroup = nil,
+      maximize_win = nil,
+      maximize_buf = nil,
+      saved_buf = nil,
+      saved_laststatus = original,
+    }
+    commit_ui.teardown_viewer(s, {})
+    assert.equals(original, vim.o.laststatus)
+  end)
+
+  it("deletes augroup when present", function()
+    local augroup = vim.api.nvim_create_augroup("TestTeardownAugroup", { clear = true })
+    local s = {
+      focus_augroup = augroup,
+      maximize_win = nil,
+      maximize_buf = nil,
+      saved_buf = nil,
+      saved_laststatus = nil,
+    }
+    commit_ui.teardown_viewer(s, {})
+    -- Augroup should be deleted; re-creating with same name should not error
+    local new_id = vim.api.nvim_create_augroup("TestTeardownAugroup", { clear = true })
+    assert.is_number(new_id)
+    pcall(vim.api.nvim_del_augroup_by_id, new_id)
+  end)
+end)
+
+describe("raccoon.commit_ui apply_diff_result error path", function()
+  it("returns early on error without modifying state", function()
+    local rendered = false
+    local s = {
+      select_generation = 1,
+      commit_files = { existing = true },
+      file_stats = { existing = { additions = 1, deletions = 0 } },
+      all_hunks = { "old_hunk" },
+      cached_sha = "old_sha",
+      cached_stat_lines = { "old" },
+    }
+    commit_ui.apply_diff_result(s, {
+      files = { { filename = "new.lua", patch = "@@ -1,1 +1,1 @@\n-old\n+new" } },
+      err = "some git error",
+      generation = 1,
+      get_generation = function() return s.select_generation end,
+      build_cache_fn = function() end,
+      get_commit_fn = function() return nil end,
+      total_pages_fn = function() return 1 end,
+      ns_id = 0,
+      render_grid_fn = function() rendered = true end,
+    })
+    -- State unchanged
+    assert.equals(true, s.commit_files.existing)
+    assert.equals(1, #s.all_hunks)
+    assert.equals("old_hunk", s.all_hunks[1])
+    assert.is_false(rendered)
+  end)
+end)
+
+describe("raccoon.commit_ui apply_diff_result empty diff", function()
+  it("writes 'No changes' to grid bufs when 0 hunks", function()
+    local grid_buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[grid_buf].buftype = "nofile"
+    local rendered = false
+    local s = {
+      select_generation = 1,
+      commit_files = {},
+      file_stats = {},
+      all_hunks = {},
+      cached_sha = nil,
+      cached_stat_lines = nil,
+      grid_bufs = { grid_buf },
+      grid_wins = {},
+      grid_rows = 1,
+      grid_cols = 1,
+      current_page = 1,
+      header_win = nil,
+      header_buf = nil,
+      filetree_win = nil,
+      filetree_buf = nil,
+      cached_tree_lines = nil,
+      cached_line_paths = nil,
+    }
+    commit_ui.apply_diff_result(s, {
+      files = {},
+      err = nil,
+      generation = 1,
+      get_generation = function() return s.select_generation end,
+      build_cache_fn = function() end,
+      get_commit_fn = function() return { sha = "abc", message = "test" } end,
+      total_pages_fn = function() return 1 end,
+      ns_id = 0,
+      render_grid_fn = function() rendered = true end,
+    })
+    local lines = vim.api.nvim_buf_get_lines(grid_buf, 0, -1, false)
+    assert.equals("  No changes in this commit", lines[2])
+    assert.is_false(rendered)
+    vim.api.nvim_buf_delete(grid_buf, { force = true })
+  end)
+end)
+
+describe("raccoon.commit_ui safe_close_timer", function()
+  it("is a no-op for nil handle", function()
+    -- Should not error
+    commit_ui.safe_close_timer(nil)
+  end)
+
+  it("stops and closes a real timer", function()
+    local timer = vim.uv.new_timer()
+    assert.is_not_nil(timer)
+    timer:start(100000, 0, function() end)
+    commit_ui.safe_close_timer(timer)
+    -- Timer should be closed; calling again should be safe
+    commit_ui.safe_close_timer(timer)
+  end)
+end)
+
+describe("raccoon.commit_ui parse_viewer_config", function()
+  it("returns all expected fields with valid values", function()
+    local vcfg = commit_ui.parse_viewer_config()
+    assert.is_number(vcfg.rows)
+    assert.is_number(vcfg.cols)
+    assert.is_number(vcfg.base_count)
+    assert.is_number(vcfg.sidebar_width)
+    assert.is_number(vcfg.sync_interval)
+    -- Values should be within clamped ranges
+    assert.is_true(vcfg.rows >= 1 and vcfg.rows <= 10)
+    assert.is_true(vcfg.cols >= 1 and vcfg.cols <= 10)
+    assert.is_true(vcfg.base_count >= 1 and vcfg.base_count <= 200)
+    assert.is_true(vcfg.sidebar_width >= 20 and vcfg.sidebar_width <= 120)
+    assert.is_true(vcfg.sync_interval >= 10 and vcfg.sync_interval <= 3600)
+  end)
+end)
+
+describe("raccoon.commit_ui make_base_state", function()
+  it("returns table with shared UI fields", function()
+    local s = commit_ui.make_base_state()
+    assert.equals(false, s.active)
+    assert.equals(1, s.selected_index)
+    assert.equals(1, s.current_page)
+    assert.equals(2, s.grid_rows)
+    assert.equals(2, s.grid_cols)
+    assert.equals(0, s.select_generation)
+    assert.equals("sidebar", s.focus_target)
+    assert.is_table(s.grid_wins)
+    assert.is_table(s.grid_bufs)
+    assert.is_table(s.all_hunks)
+    assert.is_table(s.commit_files)
+    assert.is_table(s.file_stats)
+    assert.is_nil(s.sidebar_win)
+    assert.is_nil(s.maximize_win)
+    assert.is_nil(s.header_win)
+    assert.is_nil(s.filetree_win)
+    assert.is_nil(s.cached_sha)
+  end)
+
+  it("returns independent tables on each call", function()
+    local s1 = commit_ui.make_base_state()
+    local s2 = commit_ui.make_base_state()
+    assert.is_not_equal(s1, s2)
+    assert.is_not_equal(s1.grid_wins, s2.grid_wins)
+    s1.active = true
+    assert.is_false(s2.active)
+  end)
+end)
+
+describe("raccoon.commits session generation", function()
+  it("increments on reset_state", function()
+    local gen1 = commits._get_session_gen()
+    commits._reset_state()
+    local gen2 = commits._get_session_gen()
+    assert.equals(gen1 + 1, gen2)
+  end)
+
+  it("resets state to inactive on reset", function()
+    local cs = commits._get_state()
+    cs.active = true
+    commits._reset_state()
+    local new_cs = commits._get_state()
+    assert.is_false(new_cs.active)
+  end)
 end)

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -1747,3 +1747,227 @@ describe("raccoon.commit_ui restore_selection_by_sha", function()
     assert.equals(2, s.selected_index)
   end)
 end)
+
+describe("raccoon.git is_combined_diff", function()
+  it("returns true for combined diff entry", function()
+    local entry = git.make_combined_diff_entry()
+    assert.is_true(git.is_combined_diff(entry))
+  end)
+
+  it("returns false for regular commit", function()
+    assert.is_false(git.is_combined_diff({ sha = "abc123", message = "test" }))
+  end)
+
+  it("returns false for nil sha (working dir)", function()
+    assert.is_false(git.is_combined_diff({ sha = nil, message = "test" }))
+  end)
+
+  it("returns false for nil entry", function()
+    assert.is_false(git.is_combined_diff(nil))
+  end)
+end)
+
+describe("raccoon.git maybe_prepend_combined_diff", function()
+  it("inserts combined diff when >1 commits", function()
+    local commits_list = {
+      { sha = "aaa", message = "first" },
+      { sha = "bbb", message = "second" },
+    }
+    git.maybe_prepend_combined_diff(commits_list)
+    assert.equals(3, #commits_list)
+    assert.is_true(git.is_combined_diff(commits_list[1]))
+  end)
+
+  it("does not insert when only 1 commit", function()
+    local commits_list = {
+      { sha = "aaa", message = "only" },
+    }
+    git.maybe_prepend_combined_diff(commits_list)
+    assert.equals(1, #commits_list)
+    assert.is_false(git.is_combined_diff(commits_list[1]))
+  end)
+
+  it("does not insert when 0 commits", function()
+    local commits_list = {}
+    git.maybe_prepend_combined_diff(commits_list)
+    assert.equals(0, #commits_list)
+  end)
+
+  it("is idempotent — does not double-insert", function()
+    local commits_list = {
+      { sha = "aaa", message = "first" },
+      { sha = "bbb", message = "second" },
+    }
+    git.maybe_prepend_combined_diff(commits_list)
+    assert.equals(3, #commits_list)
+    git.maybe_prepend_combined_diff(commits_list)
+    assert.equals(3, #commits_list)
+    assert.is_true(git.is_combined_diff(commits_list[1]))
+  end)
+end)
+
+describe("raccoon.git status_porcelain error convention", function()
+  it("returns nil output on error", function()
+    -- Use an existing directory that is not a git repo to trigger a git error
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, "p")
+    local done = false
+    local result_output, result_err
+
+    git.status_porcelain(tmpdir, function(output, err)
+      result_output = output
+      result_err = err
+      done = true
+    end)
+
+    vim.wait(5000, function() return done end)
+    vim.fn.delete(tmpdir, "rf")
+    assert.is_true(done)
+    assert.is_nil(result_output)
+    assert.is_string(result_err)
+  end)
+
+  it("returns string output on success", function()
+    local done = false
+    local result_output, result_err
+
+    git.status_porcelain(vim.fn.getcwd(), function(output, err)
+      result_output = output
+      result_err = err
+      done = true
+    end)
+
+    vim.wait(5000, function() return done end)
+    assert.is_true(done)
+    assert.is_string(result_output)
+    assert.is_nil(result_err)
+  end)
+end)
+
+describe("raccoon.git new command functions", function()
+  it("ref_sha resolves HEAD", function()
+    local done = false
+    local result_sha
+
+    git.ref_sha(vim.fn.getcwd(), "HEAD", function(sha, err)
+      result_sha = sha
+      done = true
+    end)
+
+    vim.wait(5000, function() return done end)
+    assert.is_true(done)
+    assert.is_string(result_sha)
+    assert.equals(40, #result_sha)
+  end)
+
+  it("ref_sha returns nil for invalid ref", function()
+    local done = false
+    local result_sha, result_err
+
+    git.ref_sha(vim.fn.getcwd(), "nonexistent-ref-" .. os.time(), function(sha, err)
+      result_sha = sha
+      result_err = err
+      done = true
+    end)
+
+    vim.wait(5000, function() return done end)
+    assert.is_true(done)
+    assert.is_nil(result_sha)
+    assert.is_string(result_err)
+  end)
+
+  it("diff_combined returns files for valid base ref", function()
+    local has_origin_main = vim.fn.system("git rev-parse --verify origin/main 2>/dev/null"):match("^%x+") ~= nil
+    if not has_origin_main then return end
+
+    local done = false
+    local result_files
+
+    git.diff_combined(vim.fn.getcwd(), "origin/main", nil, function(files, err)
+      result_files = files
+      done = true
+    end)
+
+    vim.wait(5000, function() return done end)
+    assert.is_true(done)
+    assert.is_table(result_files)
+  end)
+end)
+
+describe("raccoon.commit_ui apply_diff_result", function()
+  it("discards stale callback via generation check", function()
+    local s = {
+      select_generation = 2,
+      commit_files = { old = true },
+      all_hunks = { "old" },
+    }
+    commit_ui.apply_diff_result(s, {
+      files = { { filename = "new.lua", patch = "@@ -1,1 +1,1 @@\n-old\n+new" } },
+      err = nil,
+      generation = 1,
+      get_generation = function() return s.select_generation end,
+      build_cache_fn = function() end,
+      get_commit_fn = function() return nil end,
+      total_pages_fn = function() return 1 end,
+      ns_id = 0,
+      render_grid_fn = function() end,
+    })
+    -- State unchanged because generation was stale
+    assert.equals(true, s.commit_files.old)
+    assert.equals(1, #s.all_hunks)
+  end)
+
+  it("processes diff result when generation matches", function()
+    local grid_buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[grid_buf].buftype = "nofile"
+    local rendered = false
+    local s = {
+      select_generation = 1,
+      commit_files = {},
+      file_stats = {},
+      all_hunks = {},
+      cached_sha = "old",
+      cached_stat_lines = {},
+      grid_bufs = { grid_buf },
+      grid_wins = {},
+      grid_rows = 1,
+      grid_cols = 1,
+      current_page = 1,
+    }
+    commit_ui.apply_diff_result(s, {
+      files = { { filename = "test.lua", patch = "@@ -1,1 +1,1 @@\n-old\n+new" } },
+      err = nil,
+      generation = 1,
+      get_generation = function() return s.select_generation end,
+      build_cache_fn = function() end,
+      get_commit_fn = function() return nil end,
+      total_pages_fn = function() return 1 end,
+      ns_id = 0,
+      render_grid_fn = function() rendered = true end,
+    })
+    assert.is_true(s.commit_files["test.lua"])
+    assert.is_true(#s.all_hunks > 0)
+    assert.is_true(rendered)
+    vim.api.nvim_buf_delete(grid_buf, { force = true })
+  end)
+end)
+
+describe("raccoon.commit_ui teardown_viewer", function()
+  it("calls on_before_only and on_after in order", function()
+    local call_order = {}
+    local s = {
+      focus_augroup = nil,
+      maximize_win = nil,
+      maximize_buf = nil,
+      saved_buf = nil,
+      saved_laststatus = nil,
+    }
+    commit_ui.teardown_viewer(s, {
+      on_before_only = function() table.insert(call_order, "before") end,
+      on_after = function() table.insert(call_order, "after") end,
+    })
+    assert.equals(2, #call_order)
+    assert.equals("before", call_order[1])
+    assert.equals("after", call_order[2])
+  end)
+end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -23,8 +23,8 @@ describe("raccoon.config", function()
       assert.is_table(config.defaults.tokens)
       assert.is_table(config.defaults.repos)
       assert.is_string(config.defaults.clone_root)
-      assert.is_number(config.defaults.pull_changes_interval)
-      assert.equals(300, config.defaults.pull_changes_interval)
+      assert.is_number(config.defaults.poll_interval_seconds)
+      assert.equals(300, config.defaults.poll_interval_seconds)
     end)
 
     it("repos defaults to empty table", function()
@@ -35,7 +35,6 @@ describe("raccoon.config", function()
       assert.is_nil(config.defaults.ghostty_path)
       assert.is_nil(config.defaults.nvim_path)
       assert.is_nil(config.defaults.notifications)
-      assert.is_nil(config.defaults.poll_interval_seconds)
     end)
   end)
 
@@ -107,17 +106,73 @@ describe("raccoon.config", function()
       os.remove(tmpfile)
     end)
 
-    it("silently ignores github_username in config (backward compat)", function()
+    it("warns about deprecated github_username in config (backward compat)", function()
       local tmpfile = test_tmp_dir .. "/legacy_username.json"
       local f = io.open(tmpfile, "w")
       f:write('{"github_username": "old-user", "tokens": {"owner": "ghp_xxx"}}')
       f:close()
+
+      local warnings = {}
+      local orig_notify = vim.notify
+      vim.notify = function(msg, level)
+        if level == vim.log.levels.WARN then table.insert(warnings, msg) end
+      end
 
       config.config_path = tmpfile
       local cfg, err = config.load()
       assert.is_not_nil(cfg)
       assert.is_nil(err)
 
+      -- Flush scheduled callbacks
+      vim.wait(10, function() return #warnings > 0 end)
+
+      assert.equals(1, #warnings)
+      assert.matches("github_username", warnings[1])
+      assert.matches("removed in v0.9.5", warnings[1])
+
+      vim.notify = orig_notify
+      os.remove(tmpfile)
+    end)
+
+    it("reads poll_interval_seconds from config", function()
+      local tmpfile = test_tmp_dir .. "/poll_interval.json"
+      local f = io.open(tmpfile, "w")
+      f:write('{"poll_interval_seconds": 120, "tokens": {"owner": "ghp_xxx"}}')
+      f:close()
+
+      config.config_path = tmpfile
+      local cfg, err = config.load()
+      assert.is_not_nil(cfg)
+      assert.is_nil(err)
+      assert.equals(120, cfg.poll_interval_seconds)
+
+      os.remove(tmpfile)
+    end)
+
+    it("warns about deprecated github_token with replacement", function()
+      local tmpfile = test_tmp_dir .. "/legacy_token.json"
+      local f = io.open(tmpfile, "w")
+      f:write('{"github_token": "ghp_old", "tokens": {"owner": "ghp_xxx"}}')
+      f:close()
+
+      local warnings = {}
+      local orig_notify = vim.notify
+      vim.notify = function(msg, level)
+        if level == vim.log.levels.WARN then table.insert(warnings, msg) end
+      end
+
+      config.config_path = tmpfile
+      local cfg, err = config.load()
+      assert.is_not_nil(cfg)
+      assert.is_nil(err)
+
+      vim.wait(10, function() return #warnings > 0 end)
+
+      assert.equals(1, #warnings)
+      assert.matches("github_token", warnings[1])
+      assert.matches("tokens", warnings[1])
+
+      vim.notify = orig_notify
       os.remove(tmpfile)
     end)
 

--- a/tests/open_spec.lua
+++ b/tests/open_spec.lua
@@ -240,6 +240,77 @@ describe("raccoon.open", function()
     end)
   end)
 
+  describe("close_all_sessions", function()
+    it("exits active viewer mode when no PR session", function()
+      local exited = false
+      state.set_mode_exit(function() exited = true end)
+
+      open.close_all_sessions({ silent = true })
+
+      assert.is_true(exited)
+    end)
+
+    it("closes active PR session", function()
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      open.close_all_sessions({ silent = true })
+
+      assert.is_false(state.is_active())
+    end)
+  end)
+
+  describe("close_all_sessions", function()
+    it("closes local commit viewer when no PR session", function()
+      local closed = false
+      local original_local = package.loaded["raccoon.localcommits"]
+      package.loaded["raccoon.localcommits"] = {
+        is_active = function() return true end,
+        close = function() closed = true end,
+      }
+
+      open.close_all_sessions({ silent = true })
+
+      package.loaded["raccoon.localcommits"] = original_local
+
+      assert.is_true(closed)
+    end)
+
+    it("closes commit viewer when no PR session", function()
+      local closed = false
+      local original_commits = package.loaded["raccoon.commits"]
+      package.loaded["raccoon.commits"] = {
+        is_active = function() return true end,
+        close = function() closed = true end,
+      }
+
+      open.close_all_sessions({ silent = true })
+
+      package.loaded["raccoon.commits"] = original_commits
+
+      assert.is_true(closed)
+    end)
+
+    it("closes active PR session", function()
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      open.close_all_sessions({ silent = true })
+
+      assert.is_false(state.is_active())
+    end)
+  end)
+
   describe("sync", function()
     it("does nothing when no active session", function()
       -- Should not error

--- a/tests/open_spec.lua
+++ b/tests/open_spec.lua
@@ -265,52 +265,6 @@ describe("raccoon.open", function()
     end)
   end)
 
-  describe("close_all_sessions", function()
-    it("closes local commit viewer when no PR session", function()
-      local closed = false
-      local original_local = package.loaded["raccoon.localcommits"]
-      package.loaded["raccoon.localcommits"] = {
-        is_active = function() return true end,
-        close = function() closed = true end,
-      }
-
-      open.close_all_sessions({ silent = true })
-
-      package.loaded["raccoon.localcommits"] = original_local
-
-      assert.is_true(closed)
-    end)
-
-    it("closes commit viewer when no PR session", function()
-      local closed = false
-      local original_commits = package.loaded["raccoon.commits"]
-      package.loaded["raccoon.commits"] = {
-        is_active = function() return true end,
-        close = function() closed = true end,
-      }
-
-      open.close_all_sessions({ silent = true })
-
-      package.loaded["raccoon.commits"] = original_commits
-
-      assert.is_true(closed)
-    end)
-
-    it("closes active PR session", function()
-      state.start({
-        owner = "test",
-        repo = "test",
-        number = 1,
-        url = "https://github.com/test/test/pull/1",
-        clone_path = "/tmp/test",
-      })
-
-      open.close_all_sessions({ silent = true })
-
-      assert.is_false(state.is_active())
-    end)
-  end)
-
   describe("sync", function()
     it("does nothing when no active session", function()
       -- Should not error

--- a/tests/open_spec.lua
+++ b/tests/open_spec.lua
@@ -194,6 +194,28 @@ describe("raccoon.open", function()
       assert.is_false(state.is_active())
     end)
 
+    it("exits active viewer mode before closing", function()
+      local exited = false
+      state.set_mode_exit(function() exited = true end)
+
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      local original_notify = vim.notify
+      vim.notify = function() end
+
+      open.close_pr({ silent = true })
+
+      vim.notify = original_notify
+
+      assert.is_true(exited)
+    end)
+
     it("notifies user on close", function()
       state.start({
         owner = "test",
@@ -247,6 +269,29 @@ describe("raccoon.open edge cases", function()
   end)
 
   describe("open_pr", function()
+    it("exits active viewer mode before opening", function()
+      local exited = false
+      state.set_mode_exit(function() exited = true end)
+
+      open.open_pr("not-a-valid-url")
+
+      assert.is_true(exited)
+    end)
+
+    it("closes active session before opening", function()
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      open.open_pr("not-a-valid-url")
+
+      assert.is_false(state.is_active())
+    end)
+
     it("handles invalid URL", function()
       -- Capture vim.notify error
       local error_msg = nil

--- a/tests/state_spec.lua
+++ b/tests/state_spec.lua
@@ -410,6 +410,39 @@ describe("raccoon.state", function()
     end)
   end)
 
+  describe("mode_exit", function()
+    it("exit_active_mode calls registered cleanup", function()
+      local called = false
+      state.set_mode_exit(function() called = true end)
+      state.exit_active_mode()
+      assert.is_true(called)
+    end)
+
+    it("exit_active_mode clears callback after calling", function()
+      local count = 0
+      state.set_mode_exit(function() count = count + 1 end)
+      state.exit_active_mode()
+      state.exit_active_mode()
+      assert.equals(1, count)
+    end)
+
+    it("exit_active_mode is no-op when nothing registered", function()
+      state.set_mode_exit(nil)
+      -- Should not error
+      state.exit_active_mode()
+    end)
+
+    it("set_mode_exit replaces previous callback", function()
+      local first_called = false
+      local second_called = false
+      state.set_mode_exit(function() first_called = true end)
+      state.set_mode_exit(function() second_called = true end)
+      state.exit_active_mode()
+      assert.is_false(first_called)
+      assert.is_true(second_called)
+    end)
+  end)
+
   describe("github_host", function()
     it("defaults to nil", function()
       assert.is_nil(state.get_github_host())


### PR DESCRIPTION
## Summary
This PR combines two features:

### 1. COMBINED DIFF entry in commit viewer sidebar (was PR #79)
- When a PR or local branch has more than 1 commit, adds a **COMBINED DIFF** entry at the top of the commit list in the sidebar
- Selecting it shows the full branch diff against the base branch (all changes merged into one view), equivalent to GitHub's "Files changed" tab
- Uses `DiagnosticInfo` highlight for visual distinction

### 2. Background sync for PR commit viewer
- Adds a background poll timer that automatically detects and syncs new commits pushed to the PR branch
- Configurable interval via `commit_viewer.sync_interval` in config (default: 60 seconds, min: 10, max: 3600)
- Preserves current selection when refreshing

## Additional cleanup
- Extracted `get_base_ref()` helper in both commits.lua and localcommits.lua (DRY)
- Extracted `strip_to_patch()` in git.lua to deduplicate patch extraction logic
- Added `git.make_combined_diff_entry()` factory function
- Added `CURRENT_CHANGES_MSG` constant in localcommits.lua
- Focus lock popup window support for PR list overlay in commit mode
- CHANGELOG updated for v0.11

## Test plan
- [x] All 124 existing tests pass
- [ ] Open a PR with multiple commits → verify COMBINED DIFF appears at top of sidebar
- [ ] Select COMBINED DIFF → verify grid shows all branch changes combined
- [ ] Open a PR with exactly 1 commit → verify no COMBINED DIFF entry appears
- [ ] Local branch mode with multiple commits → verify COMBINED DIFF and CURRENT CHANGES entries
- [ ] Enter PR commit viewer → wait for sync interval → push new commit → verify sidebar updates
- [ ] Verify selection is preserved after auto-sync refreshes
- [ ] Verify timer stops cleanly on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)