### PR TITLE
Fix PR picker session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.4] - 2026-03-13
+
+### Fixed
+- PR picker is now focusable in commit mode, and switching PRs exits commit mode and resets the session cleanly
+
 ## [0.10.3] - 2026-03-12
 
 ### Fixed

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -502,7 +502,19 @@ local function enter_commit_mode()
 end
 
 --- Exit commit viewer mode
-local function exit_commit_mode()
+---@param opts table|nil { resume_sync?: boolean }
+local function exit_commit_mode(opts)
+  opts = opts or {}
+  if not commit_state.active then
+    commit_mode_keymaps = {}
+    state.set_commit_mode(false)
+    if opts.resume_sync ~= false then
+      open.resume_sync()
+    end
+    reset_state()
+    return
+  end
+
   if commit_state.focus_augroup then
     pcall(vim.api.nvim_del_augroup_by_id, commit_state.focus_augroup)
   end
@@ -525,7 +537,9 @@ local function exit_commit_mode()
   end
 
   keymaps.setup()
-  open.resume_sync()
+  if opts.resume_sync ~= false then
+    open.resume_sync()
+  end
 
   reset_state()
   vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
@@ -538,6 +552,12 @@ function M.toggle()
   else
     enter_commit_mode()
   end
+end
+
+--- Exit commit viewer mode (safe to call when not active)
+---@param opts table|nil { resume_sync?: boolean }
+function M.exit_commit_mode(opts)
+  exit_commit_mode(opts)
 end
 
 -- Exposed for testing

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -39,6 +39,7 @@ local commit_state = {
   header_buf = nil,
   filetree_win = nil,
   filetree_buf = nil,
+  popup_win = nil,
   select_generation = 0,
   cached_sha = nil,
   cached_tree_lines = nil,
@@ -77,6 +78,7 @@ local function reset_state()
     header_buf = nil,
     filetree_win = nil,
     filetree_buf = nil,
+    popup_win = nil,
     select_generation = 0,
     cached_sha = nil,
     cached_tree_lines = nil,
@@ -558,6 +560,17 @@ end
 ---@param opts table|nil { resume_sync?: boolean }
 function M.exit_commit_mode(opts)
   exit_commit_mode(opts)
+end
+
+--- Allow a popup window while commit mode focus lock is active
+---@param win number|nil
+function M.set_popup_win(win)
+  commit_state.popup_win = win
+end
+
+--- Clear the commit mode popup window exception
+function M.clear_popup_win()
+  commit_state.popup_win = nil
 end
 
 -- Exposed for testing

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -75,6 +75,9 @@ function M.close_pr_list()
   end
   M.state.win = nil
   M.state.buf = nil
+  if state.is_commit_mode() then
+    require("raccoon.commits").clear_popup_win()
+  end
 end
 
 --- Convert UTC date components to Unix epoch via pure arithmetic.
@@ -305,6 +308,9 @@ function M.show_pr_list()
   M.state.buf = buf
   M.state.prs = {}
   M.state.selected = 1
+  if state.is_commit_mode() then
+    require("raccoon.commits").set_popup_win(win)
+  end
 
   -- Show loading state
   vim.bo[buf].modifiable = true

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -18,7 +18,7 @@ M.state = {
 }
 
 --- Create a centered floating window
----@param opts table Options: width, height, title, border, width_pct, height_pct
+---@param opts table Options: width, height, title, border, width_pct, height_pct, enter
 ---@return number win_id, number buf_id
 function M.create_floating_window(opts)
   opts = opts or {}
@@ -58,7 +58,8 @@ function M.create_floating_window(opts)
   end
 
   -- Create window
-  local win = vim.api.nvim_open_win(buf, true, win_opts)
+  local enter = opts.enter ~= false
+  local win = vim.api.nvim_open_win(buf, enter, win_opts)
 
   -- Set window options
   vim.wo[win].cursorline = true
@@ -296,11 +297,13 @@ function M.show_pr_list()
   end
 
   -- Create floating window
+  local in_commit_mode = state.is_commit_mode()
   local win, buf = M.create_floating_window({
     width_pct = 0.7,
     height_pct = 0.8,
     title = "Pull Requests",
     border = "rounded",
+    enter = not in_commit_mode,
   })
 
   -- Store state
@@ -308,8 +311,10 @@ function M.show_pr_list()
   M.state.buf = buf
   M.state.prs = {}
   M.state.selected = 1
-  if state.is_commit_mode() then
+
+  if in_commit_mode then
     require("raccoon.commits").set_popup_win(win)
+    vim.api.nvim_set_current_win(win)
   end
 
   -- Show loading state

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -5,6 +5,7 @@ local M = {}
 local api = require("raccoon.api")
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
+local state = require("raccoon.state")
 
 --- Current floating window state
 M.state = {
@@ -272,6 +273,16 @@ local function apply_highlights(buf, highlights)
   end
 end
 
+--- Close any active commit mode and PR session before opening another PR
+local function close_active_session_for_pr_switch()
+  if state.is_commit_mode() then
+    require("raccoon.commits").exit_commit_mode({ resume_sync = false })
+  end
+  if state.is_active() then
+    require("raccoon.open").close_pr()
+  end
+end
+
 --- Show the PR list picker
 --- Opens a floating window with all open PRs from configured repos
 function M.show_pr_list()
@@ -334,6 +345,7 @@ function M.show_pr_list()
     if not url then return end
 
     M.close_pr_list()
+    close_active_session_for_pr_switch()
 
     local open = require("raccoon.open")
     open.open_pr(url)
@@ -794,5 +806,8 @@ function M.show_shortcuts()
     pcall(vim.keymap.set, NORMAL_MODE, key, close_win, key_opts)
   end
 end
+
+-- Exposed for testing
+M._close_active_session_for_pr_switch = close_active_session_for_pr_switch
 
 return M

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -17,6 +17,10 @@ describe("raccoon.commits", function()
     it("has toggle function", function()
       assert.is_function(commits.toggle)
     end)
+
+    it("has exit_commit_mode function", function()
+      assert.is_function(commits.exit_commit_mode)
+    end)
   end)
 
   describe("toggle without active session", function()
@@ -25,6 +29,21 @@ describe("raccoon.commits", function()
       vim.notify = function() end
       commits.toggle()
       vim.notify = original_notify
+    end)
+  end)
+
+  describe("exit_commit_mode", function()
+    it("clears commit_mode flag even when not active", function()
+      state.set_commit_mode(true)
+
+      local original_notify = vim.notify
+      vim.notify = function() end
+
+      commits.exit_commit_mode({ resume_sync = false })
+
+      vim.notify = original_notify
+
+      assert.is_false(state.is_commit_mode())
     end)
   end)
 end)

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -21,6 +21,11 @@ describe("raccoon.commits", function()
     it("has exit_commit_mode function", function()
       assert.is_function(commits.exit_commit_mode)
     end)
+
+    it("has popup window helpers", function()
+      assert.is_function(commits.set_popup_win)
+      assert.is_function(commits.clear_popup_win)
+    end)
   end)
 
   describe("toggle without active session", function()
@@ -44,6 +49,16 @@ describe("raccoon.commits", function()
       vim.notify = original_notify
 
       assert.is_false(state.is_commit_mode())
+    end)
+  end)
+
+  describe("popup window helpers", function()
+    it("sets and clears popup_win on commit state", function()
+      commits.set_popup_win(123)
+      assert.equals(123, commits._get_state().popup_win)
+
+      commits.clear_popup_win()
+      assert.is_nil(commits._get_state().popup_win)
     end)
   end)
 end)

--- a/tests/e2e/workflow_spec.lua
+++ b/tests/e2e/workflow_spec.lua
@@ -4,6 +4,7 @@
 local state = require("raccoon.state")
 local diff = require("raccoon.diff")
 local comments = require("raccoon.comments")
+local ui = require("raccoon.ui")
 
 -- Mock PR data
 local mock_pr = {
@@ -144,6 +145,27 @@ describe("E2E: PR review workflow", function()
 
       local readme_comments = state.get_comments("README.md")
       assert.equals(0, #readme_comments)
+    end)
+
+    it("cleans up commit mode and session before opening another PR", function()
+      state.start({
+        owner = "test",
+        repo = "repo",
+        number = 42,
+        url = "https://github.com/test/repo/pull/42",
+        clone_path = "/tmp/test/repo/pr-42",
+      })
+      state.set_commit_mode(true)
+
+      local original_notify = vim.notify
+      vim.notify = function() end
+
+      ui._close_active_session_for_pr_switch()
+
+      vim.notify = original_notify
+
+      assert.is_false(state.is_active())
+      assert.is_false(state.is_commit_mode())
     end)
   end)
 

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -79,6 +79,16 @@ describe("raccoon.ui", function()
 
       vim.api.nvim_win_close(win, true)
     end)
+
+    it("respects enter = false", function()
+      local original_win = vim.api.nvim_get_current_win()
+      local win, _ = ui.create_floating_window({ enter = false })
+
+      assert.equals(original_win, vim.api.nvim_get_current_win())
+      assert.is_true(vim.api.nvim_win_is_valid(win))
+
+      vim.api.nvim_win_close(win, true)
+    end)
   end)
 
   describe("close_pr_list", function()

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -1,5 +1,8 @@
 local ui = require("raccoon.ui")
 local commit_ui = require("raccoon.commit_ui")
+local state = require("raccoon.state")
+local open = require("raccoon.open")
+local commits = require("raccoon.commits")
 
 describe("raccoon.ui", function()
   describe("module", function()
@@ -184,8 +187,6 @@ describe("raccoon.ui", function()
   end)
 
   describe("show_description", function()
-    local state = require("raccoon.state")
-
     before_each(function()
       state.reset()
     end)
@@ -551,6 +552,65 @@ describe("raccoon.ui", function()
       -- 2026-01-01T00:00:00Z = epoch 1767225600
       -- now_utc = 1767225600 + 7200 = 1767232800 (exactly 2 hours later)
       assert.equals("2 hours ago", ui.relative_time("2026-01-01T00:00:00Z", 1767232800))
+    end)
+  end)
+
+  describe("close_active_session_for_pr_switch", function()
+    before_each(function()
+      state.reset()
+    end)
+
+    it("closes commit mode and active session when both are set", function()
+      state.start({
+        owner = "test",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/test/repo/pull/1",
+        clone_path = "/tmp/test/repo/pr-1",
+      })
+      state.set_commit_mode(true)
+
+      local exit_called = false
+      local close_called = false
+      local original_exit = commits.exit_commit_mode
+      local original_close = open.close_pr
+
+      commits.exit_commit_mode = function()
+        exit_called = true
+      end
+      open.close_pr = function()
+        close_called = true
+      end
+
+      ui._close_active_session_for_pr_switch()
+
+      commits.exit_commit_mode = original_exit
+      open.close_pr = original_close
+
+      assert.is_true(exit_called)
+      assert.is_true(close_called)
+    end)
+
+    it("does nothing when no commit mode or session active", function()
+      local exit_called = false
+      local close_called = false
+      local original_exit = commits.exit_commit_mode
+      local original_close = open.close_pr
+
+      commits.exit_commit_mode = function()
+        exit_called = true
+      end
+      open.close_pr = function()
+        close_called = true
+      end
+
+      ui._close_active_session_for_pr_switch()
+
+      commits.exit_commit_mode = original_exit
+      open.close_pr = original_close
+
+      assert.is_false(exit_called)
+      assert.is_false(close_called)
     end)
   end)
 end)

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -104,6 +104,15 @@ describe("raccoon.ui", function()
       -- Should not error
       ui.close_pr_list()
     end)
+
+    it("clears commit-mode popup window", function()
+      state.set_commit_mode(true)
+      commits.set_popup_win(42)
+
+      ui.close_pr_list()
+
+      assert.is_nil(commits._get_state().popup_win)
+    end)
   end)
 
   describe("state", function()


### PR DESCRIPTION
## Summary
- close commit mode and active session before opening a PR from the picker
- add safe commit-mode exit API with resume-sync control
- add unit and E2E coverage for PR switch cleanup

## Testing
- make test