### PR TITLE
feat: display full multiline commit messages in commit viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,29 @@ When a new commit is made (e.g. by an AI agent in another terminal), it appears 
 
 Local mode works alongside an active PR review — entering `:Raccoon local` pauses the PR session, and exiting resumes it.
 
+### Tip: detailed commit messages for better review
+
+The commit viewer header displays the **full multiline commit message** — subject line prominently at top, body text below in a dimmer style. This makes reviewing AI-generated commits much more useful when the agent writes descriptive messages explaining *what* was done and *why*.
+
+To get the most out of this, add instructions to your agent's configuration file (e.g. `CLAUDE.md` for Claude Code, `.amp/amp.md` for Amp, or `.aider.conf.yml` for Aider) telling it to write detailed, explanatory commit messages:
+
+```markdown
+## Commit style
+
+Write detailed, multiline commit messages. The first line is a short summary.
+The body explains what was changed and why, so a reviewer reading the commit
+in a diff viewer understands the full context without looking at the code.
+
+Example:
+  Fix null pointer in login validation
+
+  The email field was not checked before calling normalize(),
+  which threw when the user submitted an empty form.
+  Added an early return with a user-facing error message.
+```
+
+When you step through commits in `:Raccoon local` or the PR commit viewer, each commit's full message appears in the header bar — turning the commit history into a narrated walkthrough of the changes.
+
 ## Parallel Agents
 
 Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. Review a commit, optionally select code lines, and press `<leader>aa` to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -938,6 +938,20 @@ function M.update_header(s, commit, pages)
     end
   end
 
+  -- Cap long messages with a truncation indicator
+  if #lines > MAX_HEADER_LINES then
+    local remaining = #lines - MAX_HEADER_LINES
+    lines[MAX_HEADER_LINES] = "    ... " .. remaining .. " more line" .. (remaining > 1 and "s" or "")
+    for i = #lines, MAX_HEADER_LINES + 1, -1 do
+      table.remove(lines, i)
+    end
+    -- Rebuild body indices for the truncated set and include the indicator line
+    body_line_indices = {}
+    for i = 2, #lines do
+      table.insert(body_line_indices, i - 1) -- 0-indexed
+    end
+  end
+
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.bo[buf].modifiable = false
@@ -948,10 +962,14 @@ function M.update_header(s, commit, pages)
     pcall(vim.api.nvim_buf_add_highlight, buf, hl_ns, "Comment", 0, 0, #page_str)
   end
   for _, line_idx in ipairs(body_line_indices) do
-    pcall(vim.api.nvim_buf_add_highlight, buf, hl_ns, "Comment", line_idx, 0, -1)
+    local ok, err = pcall(vim.api.nvim_buf_add_highlight, buf, hl_ns, "Comment", line_idx, 0, -1)
+    if not ok then
+      vim.notify("[raccoon] Header highlight failed: " .. tostring(err), vim.log.levels.DEBUG)
+      break
+    end
   end
 
-  vim.api.nvim_win_set_height(win, math.min(math.max(1, #lines), MAX_HEADER_LINES))
+  vim.api.nvim_win_set_height(win, math.max(1, #lines))
 end
 
 --- Render the current page of hunks into the grid

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -11,6 +11,7 @@ M.STAT_BAR_MAX_WIDTH = 20
 
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
+local MAX_HEADER_LINES = 15 -- cap header height to avoid overwhelming the grid
 
 --- Approximate usable editor height for grid layout.
 --- Subtracts cmdheight and global chrome (statusline + header separator); intentionally omits
@@ -918,9 +919,15 @@ function M.update_header(s, commit, pages)
   if #msg_lines == 0 then msg_lines = { "" } end
 
   local lines = {}
+  local body_line_indices = {} -- 0-indexed buffer lines that belong to the body
   table.insert(lines, page_str .. " " .. msg_lines[1])
   for i = 2, #msg_lines do
-    table.insert(lines, " " .. msg_lines[i])
+    if msg_lines[i] == "" then
+      table.insert(lines, "")
+    else
+      table.insert(lines, "    " .. msg_lines[i])
+      table.insert(body_line_indices, #lines - 1) -- 0-indexed
+    end
   end
 
   vim.bo[buf].modifiable = true
@@ -932,8 +939,11 @@ function M.update_header(s, commit, pages)
   if show_pages then
     pcall(vim.api.nvim_buf_add_highlight, buf, hl_ns, "Comment", 0, 0, #page_str)
   end
+  for _, line_idx in ipairs(body_line_indices) do
+    pcall(vim.api.nvim_buf_add_highlight, buf, hl_ns, "Comment", line_idx, 0, -1)
+  end
 
-  vim.api.nvim_win_set_height(win, math.max(1, #lines))
+  vim.api.nvim_win_set_height(win, math.min(math.max(1, #lines), MAX_HEADER_LINES))
 end
 
 --- Render the current page of hunks into the grid
@@ -1187,9 +1197,11 @@ function M.render_split_sidebar(buf, opts)
   table.insert(lines, opts.section1_header)
   table.insert(highlights, { line = #lines - 1, hl = "Title" })
 
-  -- Section 1 commits
+  -- Section 1 commits (show first line only in sidebar)
   for _, commit in ipairs(opts.section1_commits) do
     local msg = commit.message
+    local nl = msg:find("\n")
+    if nl then msg = msg:sub(1, nl - 1) end
     if #msg > M.SIDEBAR_WIDTH - 2 then
       msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
     end
@@ -1207,9 +1219,11 @@ function M.render_split_sidebar(buf, opts)
   table.insert(lines, opts.section2_header)
   table.insert(highlights, { line = #lines - 1, hl = "Title" })
 
-  -- Section 2 commits (dimmed)
+  -- Section 2 commits (dimmed, first line only)
   for _, commit in ipairs(opts.section2_commits) do
     local msg = commit.message
+    local nl = msg:find("\n")
+    if nl then msg = msg:sub(1, nl - 1) end
     if #msg > M.SIDEBAR_WIDTH - 2 then
       msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
     end

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -9,6 +9,14 @@ local diff = require("raccoon.diff")
 M.SIDEBAR_WIDTH = 50
 M.STAT_BAR_MAX_WIDTH = 20
 
+--- Extract the first line (subject) from a possibly multiline commit message.
+---@param message string Full commit message
+---@return string subject First line of the message
+function M.commit_subject(message)
+  local nl = message:find("\n")
+  return nl and message:sub(1, nl - 1) or message
+end
+
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
 local MAX_HEADER_LINES = 15 -- cap header height to avoid overwhelming the grid
@@ -1199,9 +1207,7 @@ function M.render_split_sidebar(buf, opts)
 
   -- Section 1 commits (show first line only in sidebar)
   for _, commit in ipairs(opts.section1_commits) do
-    local msg = commit.message
-    local nl = msg:find("\n")
-    if nl then msg = msg:sub(1, nl - 1) end
+    local msg = M.commit_subject(commit.message or "")
     if #msg > M.SIDEBAR_WIDTH - 2 then
       msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
     end
@@ -1221,9 +1227,7 @@ function M.render_split_sidebar(buf, opts)
 
   -- Section 2 commits (dimmed, first line only)
   for _, commit in ipairs(opts.section2_commits) do
-    local msg = commit.message
-    local nl = msg:find("\n")
-    if nl then msg = msg:sub(1, nl - 1) end
+    local msg = M.commit_subject(commit.message or "")
     if #msg > M.SIDEBAR_WIDTH - 2 then
       msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
     end

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -445,24 +445,34 @@ local function enter_commit_mode()
 
   vim.notify("Entering commit viewer mode...", vim.log.levels.INFO)
 
+  local function abort(reason)
+    vim.notify("Commit viewer failed: " .. reason, vim.log.levels.ERROR)
+    if commit_state.active then
+      M.toggle()
+    end
+  end
+
   git.unshallow_if_needed(clone_path, function(_, unshallow_err)
     if unshallow_err then
-      vim.notify("Warning: repository unshallow failed", vim.log.levels.WARN)
+      abort("repository unshallow failed — cannot list commits in a shallow clone")
+      return
     end
 
     git.fetch_branch(clone_path, base_branch, function(_, fetch_err)
       if fetch_err then
-        vim.notify("Failed to fetch base branch", vim.log.levels.ERROR)
-        M.toggle()
+        abort("could not fetch base branch '" .. base_branch .. "': " .. fetch_err)
         return
       end
 
       local pending = 2
+      local log_err_detail = nil
 
       local function on_both_ready()
         if #commit_state.pr_commits == 0 then
-          vim.notify("No commits found on PR branch", vim.log.levels.WARN)
-          M.toggle()
+          local reason = log_err_detail
+            and ("git log failed: " .. log_err_detail)
+            or ("no commits in origin/" .. base_branch .. "..HEAD")
+          abort(reason)
           return
         end
 
@@ -483,7 +493,7 @@ local function enter_commit_mode()
 
       git.log_commits(clone_path, base_branch, function(commits, err)
         if err then
-          vim.notify("Failed to get PR commits", vim.log.levels.ERROR)
+          log_err_detail = err
           commit_state.pr_commits = {}
         else
           commit_state.pr_commits = commits or {}

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -261,8 +261,8 @@ function M.get_remote_url(path, callback)
   })
 end
 
-local FIELD_SEP = "\0"
-local RECORD_SEP = "\1"
+local FIELD_SEP = "\0" -- NUL byte: git forbids this in commit messages, safe as field delimiter
+local RECORD_SEP = "\1" -- SOH byte: used as record delimiter; if a message contains SOH the record may be mis-split
 local LOG_FORMAT = "--format=%H%x00%B%x01"
 
 --- Parse git log output into commit tables.

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -267,9 +267,11 @@ local LOG_FORMAT = "--format=%H%x00%B%x01"
 
 --- Parse git log output into commit tables.
 --- Expects output from --format=%H%x00%B%x01 (SHA, null byte, full message, record separator).
---- The job buffering in run_git drops empty lines, so the blank line between subject and body
---- is lost; we reconstruct it by inserting a blank line after the first line when a body exists.
----@param stdout string[] Lines from run_git (empty lines dropped by job buffering)
+--- The job buffering in run_git drops all empty lines, so blank lines within the commit message
+--- (including the conventional separator between subject and body) are lost. We reconstruct the
+--- subject/body separator by inserting a blank line after the first line when a body exists,
+--- but interior blank lines within the body are not recovered.
+---@param stdout string[] Lines from run_git (joined and re-split by record delimiter internally)
 ---@return table[] commits Array of {sha, message}
 local function parse_commit_log(stdout)
   local commits = {}
@@ -282,19 +284,24 @@ local function parse_commit_log(stdout)
     if record:byte(41) ~= FIELD_SEP:byte() then goto continue end
     if not sha:match("^%x+$") then goto continue end
     local body = vim.trim(record:sub(42))
-    if #body == 0 then goto continue end
-    local msg_lines = vim.split(body, "\n", { trimempty = true })
     local message
-    if #msg_lines > 1 then
-      message = msg_lines[1] .. "\n\n" .. table.concat(msg_lines, "\n", 2)
+    if #body == 0 then
+      message = ""
     else
-      message = msg_lines[1] or ""
+      local msg_lines = vim.split(body, "\n", { trimempty = true })
+      if #msg_lines > 1 then
+        message = msg_lines[1] .. "\n\n" .. table.concat(msg_lines, "\n", 2)
+      else
+        message = msg_lines[1]
+      end
     end
     table.insert(commits, { sha = sha, message = message })
     ::continue::
   end
   return commits
 end
+
+M._parse_commit_log = parse_commit_log
 
 --- Parse owner/repo from a git remote URL
 ---@param url string|nil Git remote URL (SSH or HTTPS)

--- a/lua/raccoon/git.lua
+++ b/lua/raccoon/git.lua
@@ -261,17 +261,37 @@ function M.get_remote_url(path, callback)
   })
 end
 
---- Parse git log output lines into commit tables
----@param stdout string[] Lines of format "%H %s"
+local FIELD_SEP = "\0"
+local RECORD_SEP = "\1"
+local LOG_FORMAT = "--format=%H%x00%B%x01"
+
+--- Parse git log output into commit tables.
+--- Expects output from --format=%H%x00%B%x01 (SHA, null byte, full message, record separator).
+--- The job buffering in run_git drops empty lines, so the blank line between subject and body
+--- is lost; we reconstruct it by inserting a blank line after the first line when a body exists.
+---@param stdout string[] Lines from run_git (empty lines dropped by job buffering)
 ---@return table[] commits Array of {sha, message}
 local function parse_commit_log(stdout)
   local commits = {}
-  for _, line in ipairs(stdout) do
-    local sha = line:sub(1, 40)
-    local message = line:sub(42)
-    if #sha == 40 then
-      table.insert(commits, { sha = sha, message = message })
+  local raw = table.concat(stdout, "\n")
+  local records = vim.split(raw, RECORD_SEP, { trimempty = true })
+  for _, record in ipairs(records) do
+    record = vim.trim(record)
+    if #record < 41 then goto continue end
+    local sha = record:sub(1, 40)
+    if record:byte(41) ~= FIELD_SEP:byte() then goto continue end
+    if not sha:match("^%x+$") then goto continue end
+    local body = vim.trim(record:sub(42))
+    if #body == 0 then goto continue end
+    local msg_lines = vim.split(body, "\n", { trimempty = true })
+    local message
+    if #msg_lines > 1 then
+      message = msg_lines[1] .. "\n\n" .. table.concat(msg_lines, "\n", 2)
+    else
+      message = msg_lines[1] or ""
     end
+    table.insert(commits, { sha = sha, message = message })
+    ::continue::
   end
   return commits
 end
@@ -521,7 +541,7 @@ end
 ---@param base_branch string Base branch (e.g., "main")
 ---@param callback fun(commits: table[]|nil, err: string|nil)
 function M.log_commits(path, base_branch, callback)
-  run_git({ "log", "--format=%H %s", "origin/" .. base_branch .. "..HEAD" }, {
+  run_git({ "log", LOG_FORMAT, "origin/" .. base_branch .. "..HEAD" }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then
@@ -539,7 +559,7 @@ end
 ---@param count number Number of commits to fetch
 ---@param callback fun(commits: table[]|nil, err: string|nil)
 function M.log_base_commits(path, base_branch, count, callback)
-  run_git({ "log", "--format=%H %s", "-n", tostring(count), "origin/" .. base_branch }, {
+  run_git({ "log", LOG_FORMAT, "-n", tostring(count), "origin/" .. base_branch }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then
@@ -638,7 +658,7 @@ end
 ---@param skip number Number of commits to skip
 ---@param callback fun(commits: table[]|nil, err: string|nil)
 function M.log_all_commits(path, count, skip, callback)
-  run_git({ "log", "--format=%H %s", "-n", tostring(count), "--skip=" .. tostring(skip) }, {
+  run_git({ "log", LOG_FORMAT, "-n", tostring(count), "--skip=" .. tostring(skip) }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then
@@ -657,7 +677,7 @@ end
 ---@param skip number Number of commits to skip
 ---@param callback fun(commits: table[]|nil, err: string|nil)
 function M.log_from_ref(path, ref, count, skip, callback)
-  run_git({ "log", "--format=%H %s", "-n", tostring(count), "--skip=" .. tostring(skip), ref }, {
+  run_git({ "log", LOG_FORMAT, "-n", tostring(count), "--skip=" .. tostring(skip), ref }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then
@@ -674,7 +694,7 @@ end
 ---@param base_ref string Base ref (SHA or branch name)
 ---@param callback fun(commits: table[]|nil, err: string|nil)
 function M.log_branch_commits(path, base_ref, callback)
-  run_git({ "log", "--format=%H %s", base_ref .. "..HEAD" }, {
+  run_git({ "log", LOG_FORMAT, base_ref .. "..HEAD" }, {
     cwd = path,
     on_exit = function(code, stdout, stderr)
       if code ~= 0 then

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -267,9 +267,7 @@ local function render_sidebar()
     table.insert(highlights, { line = #lines - 1, hl = "Title" })
 
     for i, commit in ipairs(local_state.branch_commits) do
-      local msg = commit.message
-      local nl = msg:find("\n")
-      if nl then msg = msg:sub(1, nl - 1) end
+      local msg = ui.commit_subject(commit.message or "")
       if #msg > ui.SIDEBAR_WIDTH - 2 then
         msg = msg:sub(1, ui.SIDEBAR_WIDTH - 5) .. "..."
       end
@@ -441,10 +439,7 @@ local function setup_keymaps()
         for i = 1, total_commits() do
           local c = get_commit(i)
           if c then
-            local msg = c.message
-            local nl = msg:find("\n")
-            if nl then msg = msg:sub(1, nl - 1) end
-            table.insert(items, { display = "  " .. msg, value = i })
+            table.insert(items, { display = "  " .. ui.commit_subject(c.message or ""), value = i })
           end
         end
         ui.open_maximize_list({

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -268,6 +268,8 @@ local function render_sidebar()
 
     for i, commit in ipairs(local_state.branch_commits) do
       local msg = commit.message
+      local nl = msg:find("\n")
+      if nl then msg = msg:sub(1, nl - 1) end
       if #msg > ui.SIDEBAR_WIDTH - 2 then
         msg = msg:sub(1, ui.SIDEBAR_WIDTH - 5) .. "..."
       end
@@ -438,7 +440,12 @@ local function setup_keymaps()
         local items = {}
         for i = 1, total_commits() do
           local c = get_commit(i)
-          if c then table.insert(items, { display = "  " .. c.message, value = i }) end
+          if c then
+            local msg = c.message
+            local nl = msg:find("\n")
+            if nl then msg = msg:sub(1, nl - 1) end
+            table.insert(items, { display = "  " .. msg, value = i })
+          end
         end
         ui.open_maximize_list({
           title = "Commits (" .. #items .. ")",

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -154,8 +154,8 @@ local function render_pr_list(prs, buf_width, shortcuts)
     table.insert(lines, "")
     table.insert(lines, "  No open pull requests found")
     table.insert(lines, "")
-    local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "Esc"
-    table.insert(lines, string.format("  Press 'r' to refresh, '%s' to close", close_key))
+    local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. " or q") or "q"
+    table.insert(lines, string.format("  Press 'r' to refresh, %s to close", close_hint))
   else
     -- Group by repo (preserve order with array)
     local by_repo = {}
@@ -211,8 +211,8 @@ local function render_pr_list(prs, buf_width, shortcuts)
 
   -- Footer separator
   table.insert(lines, string.rep("─", buf_width - 4))
-  local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "Esc"
-  table.insert(lines, string.format(" Enter: open │ %s: close │ r: refresh │ j/k: navigate", close_key))
+  local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. "/q/Esc") or "q/Esc"
+  table.insert(lines, string.format(" Enter: open │ %s: close │ r: refresh │ j/k: navigate", close_hint))
 
   return lines, highlights
 end
@@ -391,6 +391,7 @@ function M.show_pr_list()
   if config.is_enabled(shortcuts.close) then
     vim.keymap.set(NORMAL_MODE, shortcuts.close, function() M.close_pr_list() end, opts)
   end
+  vim.keymap.set(NORMAL_MODE, "q", function() M.close_pr_list() end, opts)
   vim.keymap.set(NORMAL_MODE, "<Esc>", function() M.close_pr_list() end, opts)
 
   -- Refresh on r

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -19,4 +19,22 @@ describe("raccoon.commit_ui", function()
       pcall(vim.api.nvim_del_augroup_by_id, augroup)
     end)
   end)
+
+  describe("commit_subject", function()
+    it("returns full message when no newline", function()
+      assert.equals("Fix login bug", commit_ui.commit_subject("Fix login bug"))
+    end)
+
+    it("returns first line from multiline message", function()
+      assert.equals("Fix login bug", commit_ui.commit_subject("Fix login bug\n\nAdded null check"))
+    end)
+
+    it("handles empty string", function()
+      assert.equals("", commit_ui.commit_subject(""))
+    end)
+
+    it("handles message with only newlines", function()
+      assert.equals("", commit_ui.commit_subject("\n\nsome body"))
+    end)
+  end)
 end)

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -593,4 +593,93 @@ describe("raccoon.git functions", function()
       assert.is_function(git.get_sync_status)
     end)
   end)
+
+  describe("_parse_commit_log", function()
+    local parse = git._parse_commit_log
+    local sha1 = "a" .. string.rep("0", 39)
+    local sha2 = "b" .. string.rep("0", 39)
+
+    it("parses single commit with subject only", function()
+      -- Simulates run_git output for a commit with no body:
+      -- git produces: <sha>\0Subject\n\1
+      -- run_git splits by \n and drops empties, yielding one line
+      local stdout = { sha1 .. "\0Subject line\1" }
+      local commits = parse(stdout)
+      assert.equals(1, #commits)
+      assert.equals(sha1, commits[1].sha)
+      assert.equals("Subject line", commits[1].message)
+    end)
+
+    it("parses single commit with subject and body", function()
+      -- git produces: <sha>\0Subject\n\nBody line 1\nBody line 2\n\1
+      -- run_git drops the empty line between subject and body
+      local stdout = {
+        sha1 .. "\0Subject",
+        "Body line 1",
+        "Body line 2",
+        "\1",
+      }
+      local commits = parse(stdout)
+      assert.equals(1, #commits)
+      assert.equals(sha1, commits[1].sha)
+      assert.equals("Subject\n\nBody line 1\nBody line 2", commits[1].message)
+    end)
+
+    it("parses multiple commits", function()
+      local stdout = {
+        sha1 .. "\0First commit\1" .. sha2 .. "\0Second commit\1",
+      }
+      local commits = parse(stdout)
+      assert.equals(2, #commits)
+      assert.equals(sha1, commits[1].sha)
+      assert.equals("First commit", commits[1].message)
+      assert.equals(sha2, commits[2].sha)
+      assert.equals("Second commit", commits[2].message)
+    end)
+
+    it("parses multiple commits with bodies across lines", function()
+      local stdout = {
+        sha1 .. "\0First subject",
+        "First body",
+        "\1" .. sha2 .. "\0Second subject\1",
+      }
+      local commits = parse(stdout)
+      assert.equals(2, #commits)
+      assert.equals("First subject\n\nFirst body", commits[1].message)
+      assert.equals("Second subject", commits[2].message)
+    end)
+
+    it("handles commit with empty message", function()
+      local stdout = { sha1 .. "\0\1" }
+      local commits = parse(stdout)
+      assert.equals(1, #commits)
+      assert.equals(sha1, commits[1].sha)
+      assert.equals("", commits[1].message)
+    end)
+
+    it("skips malformed records with short length", function()
+      local stdout = { "short\1" .. sha1 .. "\0Valid commit\1" }
+      local commits = parse(stdout)
+      assert.equals(1, #commits)
+      assert.equals("Valid commit", commits[1].message)
+    end)
+
+    it("skips records with missing field separator", function()
+      local stdout = { sha1 .. "XNo null byte here\1" }
+      local commits = parse(stdout)
+      assert.equals(0, #commits)
+    end)
+
+    it("skips records with non-hex SHA", function()
+      local bad_sha = "g" .. string.rep("0", 39)
+      local stdout = { bad_sha .. "\0Some message\1" }
+      local commits = parse(stdout)
+      assert.equals(0, #commits)
+    end)
+
+    it("handles empty input", function()
+      local commits = parse({})
+      assert.equals(0, #commits)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

- Switch git log format from `%H %s` (subject only) to `%H%x00%B%x01` (full message with record separators) so the commit viewer header displays the **entire multiline commit message** — subject line prominently at top, body text indented and dimmed below
- Sidebar and picker still show only the first line (subject) for compact display
- Header height capped at 15 lines to avoid overwhelming the diff grid
- README: added tip section about configuring AI agents (Claude, Amp, Aider) to write detailed commit messages for better review experience in commit mode

## Test plan

- [ ] Open `:Raccoon local` in a repo with multiline commit messages — verify header shows full subject + body
- [ ] Verify sidebar shows only the first line (subject) for each commit
- [ ] Verify commits with no body (subject only) display identically to before
- [ ] Verify body text appears dimmed (Comment highlight) and indented in the header
- [ ] Test with very long commit messages (>15 lines) — header should cap at 15 lines
- [ ] Verify parallel agents context injection still receives full commit message
- [ ] Open PR commit viewer (`:Raccoon commits`) and verify same behavior
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)