### PR TITLE
fix: change default grid from 2x2 to 2x1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fetch base branch with explicit refspec to support shallow single-branch clones
 - Sidebar on the right listing PR branch commits and recent base branch commits
 - Seamless navigation between PR branch and base branch commits (j/k crosses the boundary)
-- Configurable grid layout via `commit_viewer.grid` in config.json (default 2x2)
+- Configurable grid layout via `commit_viewer.grid` in config.json (default 2x1)
 - j/k navigation in sidebar auto-loads the selected commit's diffs into the grid
 - `<leader>j`/`<leader>k` to page through diff hunks when there are more than the grid can show
 - `<leader>l` as alias for next page

--- a/config_docs.md
+++ b/config_docs.md
@@ -167,9 +167,9 @@ Number of rows in the commit viewer diff grid. Each cell shows one diff hunk.
 
 | Type | Default |
 |------|---------|
-| number | `2` |
+| number | `1` |
 
-Number of columns in the commit viewer diff grid. A 2x2 grid shows 4 diff hunks at once.
+Number of columns in the commit viewer diff grid. A 2x2 grid shows 4 diff hunks at once; the default 2x1 shows 2 hunks stacked vertically.
 
 ```json
 {

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -27,7 +27,7 @@ M.defaults = {
   clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos"),
   pull_changes_interval = 300,
   commit_viewer = {
-    grid = { rows = 2, cols = 2 },
+    grid = { rows = 2, cols = 1 },
     base_commits_count = 20,
     sidebar_width = 50,
   },
@@ -190,7 +190,7 @@ function M.create_default()
     clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos"),
     pull_changes_interval = 300,
     commit_viewer = {
-      grid = { rows = 2, cols = 2 },
+      grid = { rows = 2, cols = 1 },
       base_commits_count = 20,
     },
   }

--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -144,7 +144,7 @@ vim.api.nvim_create_user_command("Raccoon", function(opts)
   "clone_root": "%s",
   "pull_changes_interval": 300,
   "commit_viewer": {
-    "grid": { "rows": 2, "cols": 2 },
+    "grid": { "rows": 2, "cols": 1 },
     "base_commits_count": 20
   },
   "shortcuts": {

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -438,7 +438,7 @@ describe("raccoon.commits keybinding lockdown", function()
     it("blocks cell maximize keys", function()
       local buf = create_scratch_buf()
       commits._lock_maximize_buf(buf)
-      -- Default 2x2 grid = 4 cells
+      -- Default 2x1 grid = 2 cells; maximize keys cover up to 4
       for i = 1, 4 do
         assert.is_true(has_buf_keymap(buf, "n", " m" .. i), "expected <leader>m" .. i .. " to be blocked")
       end
@@ -623,7 +623,7 @@ describe("raccoon.config commit_viewer defaults", function()
   it("has grid config with rows and cols", function()
     assert.is_table(config.defaults.commit_viewer.grid)
     assert.equals(2, config.defaults.commit_viewer.grid.rows)
-    assert.equals(2, config.defaults.commit_viewer.grid.cols)
+    assert.equals(1, config.defaults.commit_viewer.grid.cols)
   end)
 
   it("has base_commits_count default", function()


### PR DESCRIPTION
## Summary
- Default grid layout changed from 2x2 (4 panels) to 2x1 (2 vertically-stacked panels)
- With sidebars on both sides, 4 diff panels left each cell too small to read
- 2x1 gives each diff hunk the full center width while still showing 2 hunks at once

## Test plan
- [x] All 128 existing tests pass
- [ ] Open commit viewer with default config — should show 2 stacked diff panels instead of 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)