### PR TITLE
feat: add human edit mode for maximized diff view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-
-### Changed
-- **BREAKING**: `parallel_agents.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.dispatch_agent` instead.
-- **BREAKING**: `human_edit.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.human_edit` instead.
-- All keybindings are now unified under the `shortcuts` config block. Legacy `*.shortcut` fields emit a one-time deprecation warning per session.
-
 ## [0.12.0] - 2026-05-01
 
 ### Removed
@@ -24,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `:Raccoon config` auto-fix for missing/invalid `shortcuts.close` (writes `<leader>q`).
 
 ### Changed
+- **BREAKING**: `parallel_agents.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.dispatch_agent` instead.
+- **BREAKING**: `human_edit.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.human_edit` instead.
+- All keybindings are now unified under the `shortcuts` config block. Legacy `*.shortcut` fields emit a one-time deprecation warning per session.
 - **BREAKING**: `shortcuts.close` is now mandatory and must be a non-empty string.
 - Most `:Raccoon` subcommands are blocked when `shortcuts.close` is invalid; only `:Raccoon config` and `:Raccoon exit` remain available.
 - `:Raccoon config` now warns when auto-fix cannot be safely applied (e.g. invalid JSON).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-01
+
 ### Removed
 - **BREAKING**: Removed `:Raccoon close` command alias.
 - **BREAKING**: Removed `Esc` and bare `q` close behavior from raccoon popups/maximized windows. Window close is now only `shortcuts.close` (default `<leader>q`). The `<leader>?` shortcuts help window also no longer closes on any keystroke — use `shortcuts.close` to dismiss.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 - **BREAKING**: Removed `:Raccoon close` command alias.
-- **BREAKING**: Removed `Esc` and bare `q` close behavior from raccoon popups/maximized windows. Window close is now only `shortcuts.close` (default `<leader>q`).
+- **BREAKING**: Removed `Esc` and bare `q` close behavior from raccoon popups/maximized windows. Window close is now only `shortcuts.close` (default `<leader>q`). The `<leader>?` shortcuts help window also no longer closes on any keystroke — use `shortcuts.close` to dismiss.
 
 ### Added
 - Added `:Raccoon exit` as global raccoon teardown: exits PR/local/commit modes, closes raccoon popups, and stops running parallel-agent jobs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Removed
+- **BREAKING**: Removed `:Raccoon close` command alias.
+- **BREAKING**: Removed `Esc` and bare `q` close behavior from raccoon popups/maximized windows. Window close is now only `shortcuts.close` (default `<leader>q`).
+
+### Added
+- Added `:Raccoon exit` as global raccoon teardown: exits PR/local/commit modes, closes raccoon popups, and stops running parallel-agent jobs.
+- Added warning when `:Raccoon exit` is called with nothing active (instead of silent no-op).
+- Added one-time startup warning when `shortcuts.close` is missing/invalid.
+- Added `:Raccoon config` auto-fix for missing/invalid `shortcuts.close` (writes `<leader>q`).
+
+### Changed
+- **BREAKING**: `shortcuts.close` is now mandatory and must be a non-empty string.
+- Most `:Raccoon` subcommands are blocked when `shortcuts.close` is invalid; only `:Raccoon config` and `:Raccoon exit` remain available.
+- `:Raccoon config` now warns when auto-fix cannot be safely applied (e.g. invalid JSON).
+- Documentation now distinguishes window-level `close` shortcut behavior from global `:Raccoon exit`.
+
 ## [0.11.1] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: `parallel_agents.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.dispatch_agent` instead.
+- **BREAKING**: `human_edit.shortcut` is deprecated and ignored; use `shortcuts.commit_mode.human_edit` instead.
+- All keybindings are now unified under the `shortcuts` config block. Legacy `*.shortcut` fields emit a one-time deprecation warning per session.
+
 ## [0.12.0] - 2026-05-01
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `commit_viewer.commit_message_max_lines` | number | `3` | Max lines shown in the commit message header (1–50) |
 | `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized diff view (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
 | `human_edit.shortcut` | string/false | `"<leader>ee"` | Shortcut to open file for editing from maximized diff view (set to `false` to disable) |
-| `human_edit.command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Post-edit command template (`<FILE>` = relative path, `<TIMESTAMP>` = ISO timestamp; set to `""` to disable) |
+| `human_edit.command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Post-edit command template (`<FILE>` = shell-escaped relative path, `<TIMESTAMP>` = current timestamp; set to `""` to disable) |
 
 Each key in `tokens` is the **owner or org name from the repo URL** — the first path segment after the host. To find it, open any repo you want to review and copy the name between the host and the repo name:
 
@@ -325,7 +325,7 @@ Configure with the `parallel_agents` block in `config.json`. Set `command` to yo
 
 ## Human Edit
 
-Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, LSP support, and undo history. The cursor maps from your position in the diff to the corresponding line in the real file.
+Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
 
 Use `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
 
@@ -335,7 +335,7 @@ After closing the edit window, a configurable post-edit command runs automatical
 git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push
 ```
 
-The `<FILE>` placeholder is replaced with the relative file path and `<TIMESTAMP>` with the current ISO timestamp (e.g. `2026-03-22_14:30:05`). Set `command` to `""` to disable post-edit execution.
+The `<FILE>` placeholder is replaced with the relative file path and `<TIMESTAMP>` with the current timestamp (e.g. `2026-03-22_14:30:05`). Set `command` to `""` to disable post-edit execution.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
 - Merge, squash, or rebase PRs
 - Auto-sync to detect new commits pushed to the branch
 - Local commit viewer (`:Raccoon local`) for browsing any git repo's history with live "Current changes" view
-- Dispatch CLI agents (claude, amp, aider) from local commit viewer diffs with context injection
+- Dispatch CLI agents (claude, amp, aider) from maximized `Current changes` diffs in local commit viewer
 - Statusline integration showing file position and sync status
 
 ## Requirements
@@ -95,7 +95,7 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `commit_viewer.base_commits_count` | number | `20` | Number of recent base branch commits shown in the sidebar |
 | `commit_viewer.sidebar_width` | number | `50` | Width of commit list and file tree sidebars (1–500) |
 | `commit_viewer.commit_message_max_lines` | number | `3` | Max lines shown in the commit message header (1–50) |
-| `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized diff view (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
+| `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized `Current changes` diffs in local commit viewer (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
 | `human_edit.shortcut` | string/false | `"<leader>ee"` | Shortcut to open file for editing from maximized diff view (set to `false` to disable) |
 | `human_edit.command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Post-edit command template (`<FILE>` = shell-escaped relative path, `<TIMESTAMP>` = current timestamp; set to `""` to disable) |
 
@@ -138,7 +138,7 @@ The plugin auto-detects the correct API endpoints (`https://<host>/api/v3` for R
 
 ### Shortcut defaults
 
-See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 configurable shortcuts, grouped by context, with descriptions of what each one does and examples of custom configurations.
+See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all configurable shortcuts, grouped by context, with descriptions of what each one does and examples of custom configurations.
 
 ### Full config example
 
@@ -157,7 +157,7 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 co
   },
   "parallel_agents": {
     "enabled": true,
-    "command": "claude -p <PROMPT>",
+    "command": "claude --dangerously-skip-permissions -p <PROMPT>",
     "suffix_prompt": "Commit and push when done."
   },
   "human_edit": {
@@ -196,7 +196,9 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 co
 
 ### Disabling shortcuts
 
-Set any shortcut to `false` to prevent it from being registered as a keymap. The feature remains available via `:Raccoon` commands. Every floating window always responds to `Esc`, so disabling `close` won't lock you out.
+Set any shortcut (except `shortcuts.close`) to `false` to prevent it from being registered as a keymap. For shortcuts that have command equivalents, the corresponding `:Raccoon` command still works.
+
+`shortcuts.close` is required and must be a non-empty string (default: `<leader>q`). If it is missing or invalid, most `:Raccoon` subcommands are blocked until fixed. `:Raccoon config` auto-fixes it to `<leader>q`.
 
 ```json
 {
@@ -243,12 +245,12 @@ One review session is active at a time. Opening a second PR closes the first.
 | `:Raccoon commits` | Toggle commit viewer mode |
 | `:Raccoon local` | Toggle local commit viewer for the current repo |
 | `:Raccoon shortcuts` | Show all keyboard shortcuts in a floating window |
-| `:Raccoon close` | Close the review session |
-| `:Raccoon config` | Open the config file (creates default if missing) |
+| `:Raccoon exit` | Global teardown: exits PR/local/commit modes, closes raccoon popups, and stops running parallel agents |
+| `:Raccoon config` | Open the config file (creates default if missing, auto-fixes invalid `shortcuts.close` when safe) |
 
 ## Keymaps
 
-All keymaps are configurable via the `shortcuts` field in `config.json`. The values below are the defaults. Override any key by adding it to your config — only the keys you specify are changed, the rest keep their defaults. Set any shortcut to `false` to disable it entirely — the keymap won't be registered, but the underlying `:Raccoon` command still works. Run `:Raccoon shortcuts` to see your active bindings.
+Most keymaps are configurable via the `shortcuts` field in `config.json` (feature-specific shortcuts: `parallel_agents.shortcut`, `human_edit.shortcut`). The values below are the defaults. Override any key by adding it to your config — only the keys you specify are changed, the rest keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it entirely — the keymap won't be registered. For shortcuts that have command equivalents, the corresponding `:Raccoon` command still works. Run `:Raccoon shortcuts` to see your active bindings.
 
 | Key | Config key | Action |
 |-----|------------|--------|
@@ -265,7 +267,7 @@ All keymaps are configurable via the `shortcuts` field in `config.json`. The val
 | `<leader>?` | `show_shortcuts` | Show shortcuts help |
 | `<leader>rr` | `merge` | Merge PR (pick method) |
 | `<leader>cm` | `commit_viewer` | Toggle commit viewer mode |
-| `<leader>q` | `close` | Close window / exit session |
+| `<leader>q` | `close` | Close floating/maximized window (`:Raccoon exit` ends PR session) |
 
 ## Commit Viewer Mode
 
@@ -286,14 +288,14 @@ Commit mode shortcuts live under `shortcuts.commit_mode` in config:
 | `<leader>f` | `commit_mode.browse_files` | Toggle focus between commit sidebar and file tree |
 | `<leader>m1`..`m9` | `commit_mode.maximize_prefix` | Maximize a grid cell (full file diff) |
 | `<leader>ee` | `human_edit.shortcut` | Edit the file from maximized view (local mode only) |
-| `<leader>q` / `q` | `close` | Exit maximized view |
+| `<leader>q` | `close` | Exit maximized view |
 | `<leader>cm` | `commit_mode.exit` | Exit commit viewer mode |
 
 Each grid cell shows one diff hunk with syntax highlighting and `+`/`-` gutter signs. The filename and cell number are shown in the winbar. A header bar displays the current commit message and page indicator. Navigation crosses seamlessly from PR branch commits into base branch commits. If a file has multiple hunks, each gets its own cell.
 
 Most vim keybindings are disabled in commit mode to prevent breaking the layout. Only the keys listed above work. Exit with `<leader>cm`. Auto-sync is paused while commit viewer mode is active and resumes automatically when you exit.
 
-Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. In local mode (working-directory diffs), press `<leader>ee` to edit the file directly, or `<leader>aa` to dispatch an agent. Close with `q` or `<leader>q`.
+Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. In local mode (working-directory diffs), press `<leader>ee` to edit the file directly, or `<leader>aa` to dispatch an agent. Close with `<leader>q` (or your configured `shortcuts.close`).
 
 ### File tree browsing
 
@@ -327,7 +329,7 @@ Configure with the `parallel_agents` block in `config.json`. Set `command` to yo
 
 Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. This feature is only available in **local mode** (working-directory diffs) where the file exists on disk. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
 
-Use `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
+Use `<leader>s` to save and `<leader>q` to close (or your configured `shortcuts.close`). Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
 
 After closing the edit window, if any edits were made and saved successfully, a configurable post-edit command runs automatically. By default it stages the edited file, commits with a "human edit" timestamp message, and pushes:
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Commit mode shortcuts live under `shortcuts.commit_mode` in config:
 | `<leader>l` | `commit_mode.next_page_alt` | Next page of diff hunks (alias) |
 | `<leader>f` | `commit_mode.browse_files` | Toggle focus between commit sidebar and file tree |
 | `<leader>m1`..`m9` | `commit_mode.maximize_prefix` | Maximize a grid cell (full file diff) |
-| `<leader>ee` | `human_edit.shortcut` | Edit the file from maximized view |
+| `<leader>ee` | `human_edit.shortcut` | Edit the file from maximized view (local mode only) |
 | `<leader>q` / `q` | `close` | Exit maximized view |
 | `<leader>cm` | `commit_mode.exit` | Exit commit viewer mode |
 
@@ -293,7 +293,7 @@ Each grid cell shows one diff hunk with syntax highlighting and `+`/`-` gutter s
 
 Most vim keybindings are disabled in commit mode to prevent breaking the layout. Only the keys listed above work. Exit with `<leader>cm`. Auto-sync is paused while commit viewer mode is active and resumes automatically when you exit.
 
-Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. Press `<leader>ee` to edit the file directly, or `<leader>aa` to dispatch an agent. Close with `q` or `<leader>q`.
+Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. In local mode (working-directory diffs), press `<leader>ee` to edit the file directly, or `<leader>aa` to dispatch an agent. Close with `q` or `<leader>q`.
 
 ### File tree browsing
 
@@ -319,13 +319,13 @@ Local mode works alongside an active PR review — entering `:Raccoon local` pau
 
 ## Parallel Agents
 
-Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. Review a commit, optionally select code lines, and press `<leader>aa` to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.
+Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. This feature is only available in **local mode** (working-directory diffs) where files exist on disk. Review a diff, optionally select code lines, and press `<leader>aa` to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.
 
 Configure with the `parallel_agents` block in `config.json`. Set `command` to your CLI agent template (e.g. `claude --dangerously-skip-permissions -p <PROMPT>`, `amp -x <PROMPT>`). See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
 
 ## Human Edit
 
-Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
+Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. This feature is only available in **local mode** (working-directory diffs) where the file exists on disk. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
 
 Use `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
 

--- a/README.md
+++ b/README.md
@@ -329,13 +329,13 @@ Press `<leader>ee` in a maximized diff view to open the actual file in an editab
 
 Use `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
 
-After closing the edit window, a configurable post-edit command runs automatically. By default it stages the edited file, commits with a "human edit" timestamp message, and pushes:
+After closing the edit window, if any edits were made and saved successfully, a configurable post-edit command runs automatically. By default it stages the edited file, commits with a "human edit" timestamp message, and pushes:
 
 ```
 git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push
 ```
 
-The `<FILE>` placeholder is replaced with the relative file path and `<TIMESTAMP>` with the current timestamp (e.g. `2026-03-22_14:30:05`). Set `command` to `""` to disable post-edit execution.
+The `<FILE>` placeholder is replaced with the shell-escaped relative file path and `<TIMESTAMP>` with the current timestamp (e.g. `2026-03-22_14:30:05`). Set `command` to `""` to disable post-edit execution.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
 - Merge, squash, or rebase PRs
 - Auto-sync to detect new commits pushed to the branch
 - Local commit viewer (`:Raccoon local`) for browsing any git repo's history with live "Current changes" view
-- Dispatch CLI agents (claude, amp, aider) from commit viewer diffs with context injection
+- Dispatch CLI agents (claude, amp, aider) from local commit viewer diffs with context injection
 - Statusline integration showing file position and sync status
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `commit_viewer.base_commits_count` | number | `20` | Number of recent base branch commits shown in the sidebar |
 | `commit_viewer.sidebar_width` | number | `50` | Width of commit list and file tree sidebars (1–500) |
 | `commit_viewer.commit_message_max_lines` | number | `3` | Max lines shown in the commit message header (1–50) |
-| `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized `Current changes` diffs in local commit viewer (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
-| `human_edit.shortcut` | string/false | `"<leader>ee"` | Shortcut to open file for editing from maximized diff view (set to `false` to disable) |
+| `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized `Current changes` diffs in local commit viewer (`enabled`, `command`, `suffix_prompt`, `popup_width`) |
 | `human_edit.command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Post-edit command template (`<FILE>` = shell-escaped relative path, `<TIMESTAMP>` = current timestamp; set to `""` to disable) |
 
 Each key in `tokens` is the **owner or org name from the repo URL** — the first path segment after the host. To find it, open any repo you want to review and copy the name between the host and the repo name:
@@ -161,7 +160,6 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all confi
     "suffix_prompt": "Commit and push when done."
   },
   "human_edit": {
-    "shortcut": "<leader>ee",
     "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
   },
   "shortcuts": {
@@ -188,7 +186,9 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all confi
       "next_page_alt": "<leader>l",
       "exit": "<leader>cm",
       "maximize_prefix": "<leader>m",
-      "browse_files": "<leader>f"
+      "browse_files": "<leader>f",
+      "dispatch_agent": "<leader>aa",
+      "human_edit": "<leader>ee"
     }
   }
 }
@@ -250,7 +250,7 @@ One review session is active at a time. Opening a second PR closes the first.
 
 ## Keymaps
 
-Most keymaps are configurable via the `shortcuts` field in `config.json` (feature-specific shortcuts: `parallel_agents.shortcut`, `human_edit.shortcut`). The values below are the defaults. Override any key by adding it to your config — only the keys you specify are changed, the rest keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it entirely — the keymap won't be registered. For shortcuts that have command equivalents, the corresponding `:Raccoon` command still works. Run `:Raccoon shortcuts` to see your active bindings.
+Most keymaps are configurable via the `shortcuts` field in `config.json`. The values below are the defaults. Override any key by adding it to your config — only the keys you specify are changed, the rest keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it entirely — the keymap won't be registered. For shortcuts that have command equivalents, the corresponding `:Raccoon` command still works. Run `:Raccoon shortcuts` to see your active bindings.
 
 | Key | Config key | Action |
 |-----|------------|--------|
@@ -287,7 +287,8 @@ Commit mode shortcuts live under `shortcuts.commit_mode` in config:
 | `<leader>l` | `commit_mode.next_page_alt` | Next page of diff hunks (alias) |
 | `<leader>f` | `commit_mode.browse_files` | Toggle focus between commit sidebar and file tree |
 | `<leader>m1`..`m9` | `commit_mode.maximize_prefix` | Maximize a grid cell (full file diff) |
-| `<leader>ee` | `human_edit.shortcut` | Edit the file from maximized view (local mode only) |
+| `<leader>aa` | `commit_mode.dispatch_agent` | Dispatch agent from maximized diff view (requires `parallel_agents.enabled`) |
+| `<leader>ee` | `commit_mode.human_edit` | Edit the file from maximized view (local mode only) |
 | `<leader>q` | `close` | Exit maximized view |
 | `<leader>cm` | `commit_mode.exit` | Exit commit viewer mode |
 
@@ -321,13 +322,13 @@ Local mode works alongside an active PR review — entering `:Raccoon local` pau
 
 ## Parallel Agents
 
-Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. This feature is only available in **local mode** (working-directory diffs) where files exist on disk. Review a diff, optionally select code lines, and press `<leader>aa` to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.
+Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. This feature is only available in **local mode** (working-directory diffs) where files exist on disk. Review a diff, optionally select code lines, and press `<leader>aa` (default `shortcuts.commit_mode.dispatch_agent`) to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.
 
-Configure with the `parallel_agents` block in `config.json`. Set `command` to your CLI agent template (e.g. `claude --dangerously-skip-permissions -p <PROMPT>`, `amp -x <PROMPT>`). See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
+Configure the runner with the `parallel_agents` block in `config.json`, and configure the keybinding under `shortcuts.commit_mode.dispatch_agent`. Set `command` to your CLI agent template (e.g. `claude --dangerously-skip-permissions -p <PROMPT>`, `amp -x <PROMPT>`). See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
 
 ## Human Edit
 
-Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. This feature is only available in **local mode** (working-directory diffs) where the file exists on disk. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
+Press `<leader>ee` (default `shortcuts.commit_mode.human_edit`) in a maximized diff view to open the actual file in an editable floating window. This feature is only available in **local mode** (working-directory diffs) where the file exists on disk. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, and undo history. If your LSP is configured to auto-attach, it will work in the edit window since it opens the real file buffer. The cursor maps from your position in the diff to the corresponding line in the real file.
 
 Use `<leader>s` to save and `<leader>q` to close (or your configured `shortcuts.close`). Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
 
@@ -342,7 +343,6 @@ The `<FILE>` placeholder is replaced with the shell-escaped relative file path a
 ```json
 {
   "human_edit": {
-    "shortcut": "<leader>ee",
     "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
   }
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `commit_viewer.sidebar_width` | number | `50` | Width of commit list and file tree sidebars (1–500) |
 | `commit_viewer.commit_message_max_lines` | number | `3` | Max lines shown in the commit message header (1–50) |
 | `parallel_agents` | object | see [docs](parallel_agents_docs.md) | Dispatch CLI agents from maximized diff view (`enabled`, `command`, `suffix_prompt`, `shortcut`) |
+| `human_edit.shortcut` | string/false | `"<leader>ee"` | Shortcut to open file for editing from maximized diff view (set to `false` to disable) |
+| `human_edit.command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Post-edit command template (`<FILE>` = relative path, `<TIMESTAMP>` = ISO timestamp; set to `""` to disable) |
 
 Each key in `tokens` is the **owner or org name from the repo URL** — the first path segment after the host. To find it, open any repo you want to review and copy the name between the host and the repo name:
 
@@ -157,6 +159,10 @@ See [shortcuts_docs.md](shortcuts_docs.md) for a detailed reference of all 23 co
     "enabled": true,
     "command": "claude -p <PROMPT>",
     "suffix_prompt": "Commit and push when done."
+  },
+  "human_edit": {
+    "shortcut": "<leader>ee",
+    "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
   },
   "shortcuts": {
     "pr_list": "<leader>pr",
@@ -279,6 +285,7 @@ Commit mode shortcuts live under `shortcuts.commit_mode` in config:
 | `<leader>l` | `commit_mode.next_page_alt` | Next page of diff hunks (alias) |
 | `<leader>f` | `commit_mode.browse_files` | Toggle focus between commit sidebar and file tree |
 | `<leader>m1`..`m9` | `commit_mode.maximize_prefix` | Maximize a grid cell (full file diff) |
+| `<leader>ee` | `human_edit.shortcut` | Edit the file from maximized view |
 | `<leader>q` / `q` | `close` | Exit maximized view |
 | `<leader>cm` | `commit_mode.exit` | Exit commit viewer mode |
 
@@ -286,7 +293,7 @@ Each grid cell shows one diff hunk with syntax highlighting and `+`/`-` gutter s
 
 Most vim keybindings are disabled in commit mode to prevent breaking the layout. Only the keys listed above work. Exit with `<leader>cm`. Auto-sync is paused while commit viewer mode is active and resumes automatically when you exit.
 
-Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. Close with `q` or `<leader>q`.
+Press `<leader>m<N>` to maximize a cell — this opens a floating window with the full file diff. Normal vim navigation works inside (scrolling, search), but page/cell switching is blocked. Press `<leader>ee` to edit the file directly, or `<leader>aa` to dispatch an agent. Close with `q` or `<leader>q`.
 
 ### File tree browsing
 
@@ -315,6 +322,29 @@ Local mode works alongside an active PR review — entering `:Raccoon local` pau
 Dispatch fire-and-forget CLI agents directly from the commit viewer's maximized diff view. Review a commit, optionally select code lines, and press `<leader>aa` to send an agent off with your task description, visual selection, and commit context automatically injected. Multiple agents can run simultaneously — the statusline shows a running count.
 
 Configure with the `parallel_agents` block in `config.json`. Set `command` to your CLI agent template (e.g. `claude --dangerously-skip-permissions -p <PROMPT>`, `amp -x <PROMPT>`). See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
+
+## Human Edit
+
+Press `<leader>ee` in a maximized diff view to open the actual file in an editable floating window. Unlike the read-only maximize view, this gives you full Vim editing capabilities — insert mode, all editing keys, LSP support, and undo history. The cursor maps from your position in the diff to the corresponding line in the real file.
+
+Use `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. When viewing working-directory changes, the maximize diff refreshes automatically after edits to show your updated diff.
+
+After closing the edit window, a configurable post-edit command runs automatically. By default it stages the edited file, commits with a "human edit" timestamp message, and pushes:
+
+```
+git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push
+```
+
+The `<FILE>` placeholder is replaced with the relative file path and `<TIMESTAMP>` with the current ISO timestamp (e.g. `2026-03-22_14:30:05`). Set `command` to `""` to disable post-edit execution.
+
+```json
+{
+  "human_edit": {
+    "shortcut": "<leader>ee",
+    "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
+  }
+}
+```
 
 ## Statusline
 

--- a/config_docs.md
+++ b/config_docs.md
@@ -233,7 +233,7 @@ Maximum number of lines displayed in the commit message header bar. The header s
 |------|---------|
 | object | see below |
 
-Configure fire-and-forget CLI agent dispatch from the commit viewer's maximized diff view. See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
+Configure fire-and-forget CLI agent dispatch from maximized `Current changes` diffs in local mode. See [parallel_agents_docs.md](parallel_agents_docs.md) for the full reference.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -278,7 +278,7 @@ Configure the human edit feature for the commit viewer's maximized diff view. On
 }
 ```
 
-The edit window provides full Vim editing capabilities — insert mode, all editing keys, undo history, and LSP support. Press `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. If the file was modified externally (e.g. by a parallel agent) while editing, a 3-way merge is attempted automatically — clean merges are applied silently, conflicts show standard conflict markers.
+The edit window provides full Vim editing capabilities — insert mode, all editing keys, undo history, and LSP support. Press `<leader>s` to save and `<leader>q` to close (or your configured `shortcuts.close`). Modified files are auto-saved on close. If the file was modified externally (e.g. by a parallel agent) while editing, a 3-way merge is attempted automatically — clean merges are applied silently, conflicts show standard conflict markers.
 
 ### `shortcuts`
 
@@ -286,9 +286,11 @@ The edit window provides full Vim editing capabilities — insert mode, all edit
 |------|---------|
 | object | see [shortcuts_docs.md](shortcuts_docs.md) |
 
-Custom keyboard shortcuts. See [shortcuts_docs.md](shortcuts_docs.md) for the full reference of all 23 configurable shortcuts with descriptions and examples.
+Custom keyboard shortcuts. See [shortcuts_docs.md](shortcuts_docs.md) for the full reference of all configurable shortcuts with descriptions and examples.
 
-Partial overrides are merged with defaults — you only need to specify keys you want to change. Set any shortcut to `false` to disable it.
+Partial overrides are merged with defaults — you only need to specify keys you want to change. Set any shortcut except `shortcuts.close` to `false` to disable it.
+
+`shortcuts.close` is required and must be a non-empty string (default: `<leader>q`). If it is missing or invalid, most `:Raccoon` subcommands are blocked until fixed. `:Raccoon config` auto-fixes it to `<leader>q`.
 
 ```json
 {
@@ -349,6 +351,6 @@ The config file is always at `~/.config/raccoon/config.json`. This path is not c
 
 | Command | What it does |
 |---------|-------------|
-| `:Raccoon config` | Creates the file with defaults (if missing) and opens it in a buffer |
+| `:Raccoon config` | Creates the file with defaults (if missing), auto-fixes missing/invalid `shortcuts.close` to `<leader>q` when safe, and opens it in a buffer |
 
 The file is plain JSON — edit it with any editor. Changes take effect on the next PR operation (no restart needed).

--- a/config_docs.md
+++ b/config_docs.md
@@ -254,7 +254,31 @@ Configure fire-and-forget CLI agent dispatch from the commit viewer's maximized 
 }
 ```
 
-In **PR commit viewer** mode, agents run inside the shallow clone checked out to the PR branch (`{clone_root}/{owner}/{repo}/pr-{number}`), so "commit and push" pushes directly to the PR. In **local commit viewer** mode, agents run in your working directory.
+Agents run in your working directory. This feature is only available in **local commit viewer** mode (`:Raccoon local`) where files exist on disk.
+
+### `human_edit`
+
+| Type | Default |
+|------|---------|
+| object | see below |
+
+Configure the human edit feature for the commit viewer's maximized diff view. Only available in local mode (`:Raccoon local`).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `shortcut` | string or false | `"<leader>ee"` | Keymap to open the file for editing in maximized diff view. Set to `false` to disable. |
+| `command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Shell command run after saving edits. `<FILE>` is replaced with the shell-escaped relative file path, `<TIMESTAMP>` with the current timestamp (e.g. `2026-03-22_14:30:05`). Set to `""` to disable post-edit execution. |
+
+```json
+{
+  "human_edit": {
+    "shortcut": "<leader>ee",
+    "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
+  }
+}
+```
+
+The edit window provides full Vim editing capabilities — insert mode, all editing keys, undo history, and LSP support. Press `<leader>s` to save and `q` or `<leader>q` to close. Modified files are auto-saved on close. If the file was modified externally (e.g. by a parallel agent) while editing, a 3-way merge is attempted automatically — clean merges are applied silently, conflicts show standard conflict markers.
 
 ### `shortcuts`
 

--- a/config_docs.md
+++ b/config_docs.md
@@ -240,7 +240,6 @@ Configure fire-and-forget CLI agent dispatch from maximized `Current changes` di
 | `enabled` | boolean | `false` | Enable the feature |
 | `command` | string | `""` | Shell command template containing `<PROMPT>` placeholder |
 | `suffix_prompt` | string | `""` | Text appended to every agent prompt |
-| `shortcut` | string or false | `"<leader>aa"` | Keymap to trigger dispatch. Set to `false` to disable. |
 | `popup_width` | number | `70` | Width of the task input popup (clamped to terminal width). |
 
 ```json
@@ -248,11 +247,12 @@ Configure fire-and-forget CLI agent dispatch from maximized `Current changes` di
   "parallel_agents": {
     "enabled": true,
     "command": "claude --dangerously-skip-permissions -p <PROMPT>",
-    "suffix_prompt": "When done, create a commit with a description of the changes and how they address the original request.",
-    "shortcut": "<leader>aa"
+    "suffix_prompt": "When done, create a commit with a description of the changes and how they address the original request."
   }
 }
 ```
+
+The shortcut for dispatch lives in `shortcuts.commit_mode.dispatch_agent`, not in the `parallel_agents` block.
 
 Agents run in your working directory. This feature is only available in **local commit viewer** mode (`:Raccoon local`) where files exist on disk.
 
@@ -266,17 +266,17 @@ Configure the human edit feature for the commit viewer's maximized diff view. On
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `shortcut` | string or false | `"<leader>ee"` | Keymap to open the file for editing in maximized diff view. Set to `false` to disable. |
 | `command` | string | `"git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"` | Shell command run after saving edits. `<FILE>` is replaced with the shell-escaped relative file path, `<TIMESTAMP>` with the current timestamp (e.g. `2026-03-22_14:30:05`). Set to `""` to disable post-edit execution. |
 
 ```json
 {
   "human_edit": {
-    "shortcut": "<leader>ee",
     "command": "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push"
   }
 }
 ```
+
+The shortcut for human edit lives in `shortcuts.commit_mode.human_edit`, not in the `human_edit` block.
 
 The edit window provides full Vim editing capabilities — insert mode, all editing keys, undo history, and LSP support. Press `<leader>s` to save and `<leader>q` to close (or your configured `shortcuts.close`). Modified files are auto-saved on close. If the file was modified externally (e.g. by a parallel agent) while editing, a 3-way merge is attempted automatically — clean merges are applied silently, conflicts show standard conflict markers.
 
@@ -296,7 +296,10 @@ Partial overrides are merged with defaults — you only need to specify keys you
 {
   "shortcuts": {
     "pr_list": "<leader>gp",
-    "merge": false
+    "merge": false,
+    "commit_mode": {
+      "dispatch_agent": "<leader>ag"
+    }
   }
 }
 ```
@@ -325,7 +328,10 @@ Partial overrides are merged with defaults — you only need to specify keys you
   "shortcuts": {
     "pr_list": "<leader>pr",
     "next_point": "<C-n>",
-    "prev_point": "<C-p>"
+    "prev_point": "<C-p>",
+    "commit_mode": {
+      "dispatch_agent": "<leader>aa"
+    }
   }
 }
 ```

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -6,6 +6,7 @@ local api = require("raccoon.api")
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local state = require("raccoon.state")
+local windows = require("raccoon.windows")
 
 --- Get a valid line number from a comment, handling vim.NIL from JSON null
 ---@param comment table
@@ -301,16 +302,11 @@ function M.show_comment_popup(comment)
     title = " Comment ",
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Close keymaps
   local shortcuts = config.load_shortcuts()
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
-
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
   end, { buffer = buf, noremap = true, silent = true })
 end
@@ -373,17 +369,13 @@ function M.show_readonly_thread(opts)
     title = opts.title or " Thread ",
     title_pos = "center",
   })
+  windows.mark(win)
 
   vim.wo[win].wrap = true
 
   local shortcuts = config.load_shortcuts()
   local keymap_opts = { buffer = buf, noremap = true, silent = true }
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-    end, keymap_opts)
-  end
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
   end, keymap_opts)
 end
@@ -484,6 +476,7 @@ function M.show_comment_thread()
     title = M._build_thread_title(current_line, shortcuts),
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Helper to find which comment section cursor is in
   local function get_cursor_section()
@@ -801,12 +794,7 @@ function M.show_comment_thread()
   if config.is_enabled(shortcuts.comment_unresolve) then
     vim.keymap.set(NORMAL_MODE, shortcuts.comment_unresolve, unresolve_thread, km_opts)
   end
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
   end, { buffer = buf, noremap = true, silent = true })
 
@@ -852,6 +840,7 @@ function M.create_comment()
     title = M._build_comment_title("New Comment", shortcuts),
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Start in insert mode
   vim.cmd("startinsert")
@@ -979,17 +968,7 @@ function M.create_comment()
   end
 
   -- Keymap: close/cancel
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      if not submitted then
-        vim.notify("Comment cancelled", vim.log.levels.INFO)
-      end
-      vim.api.nvim_win_close(win, true)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
-
-  -- Also allow Escape to cancel
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     if not submitted then
       vim.notify("Comment cancelled", vim.log.levels.INFO)
     end
@@ -1113,6 +1092,7 @@ function M.list_comments()
     title = " All PR Comments (" .. total_count .. ") ",
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Track window for toggle behavior
   comment_list_win = win
@@ -1165,10 +1145,7 @@ function M.list_comments()
   end, { buffer = buf, noremap = true, silent = true })
 
   -- Close keymaps
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, close_list, { buffer = buf, noremap = true, silent = true })
-  end
-  vim.keymap.set(NORMAL_MODE, "<Esc>", close_list, { buffer = buf, noremap = true, silent = true })
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, close_list, { buffer = buf, noremap = true, silent = true })
 end
 
 --- Toggle resolved status of comment at current line

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -373,7 +373,7 @@ local function setup_human_edit_keymap(buf, opts)
   local buf_opts = { buffer = buf, noremap = true, silent = true }
 
   vim.keymap.set(NORMAL_MODE, he_cfg.shortcut, function()
-    local filepath = opts.repo_path .. "/" .. opts.filename
+    local filepath = vim.fs.joinpath(opts.repo_path, opts.filename)
     if vim.fn.filereadable(filepath) ~= 1 then
       vim.notify("File not found: " .. filepath, vim.log.levels.WARN)
       return
@@ -422,12 +422,13 @@ local function setup_human_edit_keymap(buf, opts)
       local cmd = he_cfg.command
       if not cmd or cmd == "" then return end
 
-      -- Replace <FILE> placeholder with the relative filename
+      -- Replace <FILE> placeholder with the shell-escaped relative filename
       local escaped_file = vim.fn.shellescape(opts.filename)
-      cmd = cmd:gsub("<FILE>", escaped_file)
+      cmd = cmd:gsub("<FILE>", function() return escaped_file end)
 
-      -- Replace <TIMESTAMP> placeholder with ISO 8601 timestamp
-      cmd = cmd:gsub("<TIMESTAMP>", os.date("%%Y-%%m-%%d_%%H:%%M:%%S"))
+      -- Replace <TIMESTAMP> placeholder with timestamp
+      local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
+      cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
 
       local stderr_lines = {}
       local job_id = vim.fn.jobstart({ "sh", "-c", cmd .. " </dev/null" }, {
@@ -455,13 +456,27 @@ local function setup_human_edit_keymap(buf, opts)
       })
       if job_id > 0 then
         vim.notify("Running post-edit command...", vim.log.levels.INFO)
+      elseif job_id == 0 then
+        vim.notify("Post-edit command failed: invalid arguments", vim.log.levels.ERROR)
+      else
+        vim.notify("Post-edit command failed: command not executable", vim.log.levels.ERROR)
       end
     end
 
+    local edit_closed = false
     local function close_edit()
+      if edit_closed then return end
+      edit_closed = true
       -- Auto-save if modified
+      local save_ok = true
       if vim.bo[edit_buf].modified then
-        vim.api.nvim_buf_call(edit_buf, function() vim.cmd("silent! write") end)
+        local ok, err = pcall(function()
+          vim.api.nvim_buf_call(edit_buf, function() vim.cmd("write") end)
+        end)
+        if not ok then
+          vim.notify("Failed to save " .. opts.filename .. ": " .. tostring(err), vim.log.levels.ERROR)
+          save_ok = false
+        end
       end
       opts.state.popup_win = nil
       if vim.api.nvim_win_is_valid(edit_win) then
@@ -471,14 +486,20 @@ local function setup_human_edit_keymap(buf, opts)
       if opts.state.maximize_workdir_opts then
         M.refresh_maximize(opts.state)
       end
-      run_post_command()
+      if save_ok then
+        run_post_command()
+      end
     end
 
     local edit_km = { buffer = edit_buf, noremap = true, silent = true }
     if config.is_enabled(shortcuts.comment_save) then
       vim.keymap.set(NORMAL_MODE, shortcuts.comment_save, function()
-        vim.cmd("silent! write")
-        vim.notify("Saved " .. opts.filename, vim.log.levels.INFO)
+        local ok, err = pcall(vim.cmd, "write")
+        if ok then
+          vim.notify("Saved " .. opts.filename, vim.log.levels.INFO)
+        else
+          vim.notify("Failed to save " .. opts.filename .. ": " .. tostring(err), vim.log.levels.ERROR)
+        end
       end, edit_km)
     end
     if config.is_enabled(shortcuts.close) then
@@ -1286,7 +1307,7 @@ function M.open_maximize(opts)
     end
 
     setup_parallel_agent_keymap(buf, opts, pa_cfg)
-    setup_human_edit_keymap(buf, opts)
+    setup_human_edit_keymap(buf, opts, shortcuts)
   end)
 end
 
@@ -1520,7 +1541,6 @@ function M.open_file_content(opts)
     vim.keymap.set(NORMAL_MODE, "q", close_fn, buf_opts)
 
     setup_parallel_agent_keymap(buf, opts, pa_cfg)
-    setup_human_edit_keymap(buf, opts)
   end)
 end
 
@@ -2142,5 +2162,7 @@ function M.split_sidebar_cursor_to_index(cursor_line, section1_count)
 
   return line_0 - 2 -- subtract blank + header to get combined index
 end
+
+M.diff_line_to_file_line = diff_line_to_file_line
 
 return M

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -313,9 +313,8 @@ end
 --- Set up the parallel agent dispatch keymap on a maximize buffer.
 ---@param buf number Buffer to bind the keymap on
 ---@param opts table {repo_path, sha, commit_message, filename, state}
----@param pa_cfg? table Pre-loaded parallel_agents config (avoids re-reading disk)
-local function setup_parallel_agent_keymap(buf, opts, pa_cfg)
-  pa_cfg = pa_cfg or config.load_parallel_agents()
+local function setup_parallel_agent_keymap(buf, opts)
+  local pa_cfg = config.load_parallel_agents()
   if not pa_cfg.enabled or not config.is_enabled(pa_cfg.shortcut) then return end
   local pa = require("raccoon.parallel_agents")
   local buf_opts = { buffer = buf, noremap = true, silent = true }
@@ -374,7 +373,7 @@ local function diff_line_to_file_line(hl_lines, cursor_line)
 end
 
 --- Run the configured post-edit shell command asynchronously.
----@param command string Command template with <FILE> and <TIMESTAMP> placeholders
+---@param command string|nil Command template with <FILE> and <TIMESTAMP> placeholders; nil or "" to skip
 ---@param filename string Relative file path
 ---@param repo_path string Repository root directory
 local function run_post_command(command, filename, repo_path)
@@ -499,19 +498,31 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     -- Register as popup_win so the focus-lock system keeps this window focusable
     opts.state.popup_win = edit_win
 
+    -- Track whether the buffer was ever modified (survives intermediate saves)
+    local was_ever_modified = false
+    vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+      buffer = edit_buf,
+      callback = function() was_ever_modified = true end,
+    })
+
     local edit_closed = false
     local function close_edit()
       if edit_closed then return end
       edit_closed = true
       -- Auto-save if modified
-      local save_ok = true
-      if vim.api.nvim_buf_is_valid(edit_buf) and vim.bo[edit_buf].modified then
-        local ok, err = pcall(function()
-          vim.api.nvim_buf_call(edit_buf, function() vim.cmd("write") end)
-        end)
-        if not ok then
-          vim.notify("Failed to save " .. opts.filename .. ": " .. tostring(err), vim.log.levels.ERROR)
-          save_ok = false
+      local save_ok = false
+      if vim.api.nvim_buf_is_valid(edit_buf) then
+        if vim.bo[edit_buf].modified then
+          local ok, err = pcall(function()
+            vim.api.nvim_buf_call(edit_buf, function() vim.cmd("write") end)
+          end)
+          if ok then
+            save_ok = true
+          else
+            vim.notify("Failed to save " .. opts.filename .. ": " .. tostring(err), vim.log.levels.ERROR)
+          end
+        else
+          save_ok = true -- not modified, no save needed
         end
       end
       opts.state.popup_win = nil
@@ -530,7 +541,7 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       if opts.state.maximize_workdir_opts then
         M.refresh_maximize(opts.state)
       end
-      if save_ok then
+      if was_ever_modified and save_ok then
         run_post_command(he_cfg.command, opts.filename, opts.repo_path)
       end
     end
@@ -1461,7 +1472,10 @@ function M.start_maximize_watcher(s)
 
   local filepath = vim.fs.joinpath(mopts.repo_path, mopts.filename)
   local handle = vim.uv.new_fs_event()
-  if not handle then return end
+  if not handle then
+    vim.notify("Raccoon: could not start file watcher (resource limit?)", vim.log.levels.WARN)
+    return
+  end
 
   s.maximize_fs_event = handle
   local start_ok, start_err = pcall(handle.start, handle, filepath, {}, vim.schedule_wrap(function(err)
@@ -1496,10 +1510,16 @@ function M.refresh_maximize(s)
     if not s.maximize_workdir_opts then return end
     if not vim.api.nvim_buf_is_valid(buf) then return end
 
-    if err or not patch or patch == "" then
+    if err then
+      vim.notify("Raccoon: diff refresh failed: " .. tostring(err), vim.log.levels.WARN)
+      return
+    end
+
+    if not patch or patch == "" then
       vim.bo[buf].modifiable = true
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
       vim.bo[buf].modifiable = false
+      s.maximize_hl_lines = nil
       return
     end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -344,6 +344,150 @@ local function setup_parallel_agent_keymap(buf, opts, pa_cfg)
   vim.keymap.set({ "n", "v" }, pa_cfg.shortcut, dispatch_fn, buf_opts)
 end
 
+--- Map a diff buffer line to the corresponding real file line number.
+--- Walks hl_lines to find the nearest add/ctx entry at or before cursor_line.
+---@param hl_lines table[] Array of {type, line_num} from parsed diff
+---@param cursor_line number 1-based cursor line in the maximize buffer
+---@return number file_line 1-based line in the real file (fallback: 1)
+local function diff_line_to_file_line(hl_lines, cursor_line)
+  if not hl_lines or #hl_lines == 0 then return 1 end
+  -- Try exact line first, then search backward for nearest add/ctx
+  for i = math.min(cursor_line, #hl_lines), 1, -1 do
+    local entry = hl_lines[i]
+    if entry.line_num and entry.type ~= "del" then
+      return entry.line_num
+    end
+  end
+  return 1
+end
+
+--- Set up the human edit keymap on a maximize buffer.
+--- Opens the actual file in an editable floating window.
+---@param buf number Buffer to bind the keymap on
+---@param opts table {repo_path, filename, state}
+local function setup_human_edit_keymap(buf, opts)
+  local he_cfg = config.load_human_edit()
+  if not config.is_enabled(he_cfg.shortcut) then return end
+
+  local shortcuts = config.load_shortcuts()
+  local buf_opts = { buffer = buf, noremap = true, silent = true }
+
+  vim.keymap.set(NORMAL_MODE, he_cfg.shortcut, function()
+    local filepath = opts.repo_path .. "/" .. opts.filename
+    if vim.fn.filereadable(filepath) ~= 1 then
+      vim.notify("File not found: " .. filepath, vim.log.levels.WARN)
+      return
+    end
+
+    -- Map diff cursor position to real file line
+    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+    local file_line = diff_line_to_file_line(opts.state.maximize_hl_lines, cursor_line)
+
+    local edit_buf = vim.fn.bufadd(filepath)
+    vim.fn.bufload(edit_buf)
+
+    local width = math.floor(vim.o.columns * 0.85)
+    local height = math.floor(vim.o.lines * 0.85)
+    local row = math.floor((vim.o.lines - height) / 2)
+    local col = math.floor((vim.o.columns - width) / 2)
+
+    local save_key = config.is_enabled(shortcuts.comment_save) and shortcuts.comment_save or "<leader>s"
+    local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "q"
+
+    local edit_win = vim.api.nvim_open_win(edit_buf, true, {
+      relative = "editor",
+      width = width,
+      height = height,
+      row = row,
+      col = col,
+      border = "rounded",
+      zindex = 60,
+    })
+
+    vim.wo[edit_win].winbar = " Edit: " .. opts.filename
+      .. "%=%#Comment# " .. save_key .. "=save  " .. close_key .. " or q to close %*"
+    vim.wo[edit_win].number = true
+    vim.wo[edit_win].wrap = true
+    vim.wo[edit_win].signcolumn = "yes:1"
+
+    -- Jump to mapped line
+    local line_count = vim.api.nvim_buf_line_count(edit_buf)
+    file_line = math.min(file_line, line_count)
+    vim.api.nvim_win_set_cursor(edit_win, { file_line, 0 })
+
+    -- Track popup on state for focus lock
+    opts.state.popup_win = edit_win
+
+    local function run_post_command()
+      local cmd = he_cfg.command
+      if not cmd or cmd == "" then return end
+
+      -- Replace <FILE> placeholder with the relative filename
+      local escaped_file = vim.fn.shellescape(opts.filename)
+      cmd = cmd:gsub("<FILE>", escaped_file)
+
+      -- Replace <TIMESTAMP> placeholder with ISO 8601 timestamp
+      cmd = cmd:gsub("<TIMESTAMP>", os.date("%%Y-%%m-%%d_%%H:%%M:%%S"))
+
+      local stderr_lines = {}
+      local job_id = vim.fn.jobstart({ "sh", "-c", cmd .. " </dev/null" }, {
+        cwd = opts.repo_path,
+        on_stderr = function(_, data)
+          if data then
+            for _, line in ipairs(data) do
+              if line ~= "" then table.insert(stderr_lines, line) end
+            end
+          end
+        end,
+        on_exit = function(_, exit_code)
+          vim.schedule(function()
+            if exit_code == 0 then
+              vim.notify("Post-edit command finished: " .. opts.filename, vim.log.levels.INFO)
+            else
+              local msg = string.format("Post-edit command failed (exit %d)", exit_code)
+              if #stderr_lines > 0 then
+                msg = msg .. "\n" .. table.concat(stderr_lines, "\n")
+              end
+              vim.notify(msg, vim.log.levels.WARN)
+            end
+          end)
+        end,
+      })
+      if job_id > 0 then
+        vim.notify("Running post-edit command...", vim.log.levels.INFO)
+      end
+    end
+
+    local function close_edit()
+      -- Auto-save if modified
+      if vim.bo[edit_buf].modified then
+        vim.api.nvim_buf_call(edit_buf, function() vim.cmd("silent! write") end)
+      end
+      opts.state.popup_win = nil
+      if vim.api.nvim_win_is_valid(edit_win) then
+        vim.api.nvim_win_close(edit_win, true)
+      end
+      -- Refresh maximize diff for working-dir views
+      if opts.state.maximize_workdir_opts then
+        M.refresh_maximize(opts.state)
+      end
+      run_post_command()
+    end
+
+    local edit_km = { buffer = edit_buf, noremap = true, silent = true }
+    if config.is_enabled(shortcuts.comment_save) then
+      vim.keymap.set(NORMAL_MODE, shortcuts.comment_save, function()
+        vim.cmd("silent! write")
+        vim.notify("Saved " .. opts.filename, vim.log.levels.INFO)
+      end, edit_km)
+    end
+    if config.is_enabled(shortcuts.close) then
+      vim.keymap.set(NORMAL_MODE, shortcuts.close, close_edit, edit_km)
+    end
+    vim.keymap.set(NORMAL_MODE, "q", close_edit, edit_km)
+  end, buf_opts)
+end
+
 --- Block editing and commit-mode navigation keys in a maximize floating window.
 --- Global normal-mode mappings are shadowed so only explicit maximize bindings remain active.
 ---@param buf number Buffer ID
@@ -786,6 +930,7 @@ function M.close_win_pair(s, win_key, buf_key)
   if win_key == "maximize_win" then
     M.stop_maximize_watcher(s)
     s.maximize_workdir_opts = nil
+    s.maximize_hl_lines = nil
   end
 end
 
@@ -1030,7 +1175,7 @@ function M.open_maximize(opts)
     for _, hunk in ipairs(hunks) do
       for _, line_data in ipairs(hunk.lines) do
         table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type })
+        table.insert(hl_lines, { type = line_data.type, line_num = line_data.line_num })
       end
     end
 
@@ -1077,6 +1222,7 @@ function M.open_maximize(opts)
 
     opts.state.maximize_win = win
     opts.state.maximize_buf = buf
+    opts.state.maximize_hl_lines = hl_lines
     M.stop_maximize_watcher(opts.state)
     if opts.is_working_dir then
       opts.state.maximize_workdir_opts = {
@@ -1140,6 +1286,7 @@ function M.open_maximize(opts)
     end
 
     setup_parallel_agent_keymap(buf, opts, pa_cfg)
+    setup_human_edit_keymap(buf, opts)
   end)
 end
 
@@ -1289,9 +1436,10 @@ function M.refresh_maximize(s)
     for _, hunk in ipairs(hunks) do
       for _, line_data in ipairs(hunk.lines) do
         table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type })
+        table.insert(hl_lines, { type = line_data.type, line_num = line_data.line_num })
       end
     end
+    s.maximize_hl_lines = hl_lines
 
     local cursor = vim.api.nvim_win_get_cursor(win)
 
@@ -1352,6 +1500,7 @@ function M.open_file_content(opts)
 
     opts.state.maximize_win = win
     opts.state.maximize_buf = buf
+    opts.state.maximize_hl_lines = nil
 
     local shortcuts = config.load_shortcuts()
     local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. " or q") or "q"
@@ -1371,6 +1520,7 @@ function M.open_file_content(opts)
     vim.keymap.set(NORMAL_MODE, "q", close_fn, buf_opts)
 
     setup_parallel_agent_keymap(buf, opts, pa_cfg)
+    setup_human_edit_keymap(buf, opts)
   end)
 end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -468,11 +468,19 @@ local function three_way_merge(base_lines, ours_lines, theirs_lines)
   local base_file = vim.fn.tempname()
   local ours_file = vim.fn.tempname()
   local theirs_file = vim.fn.tempname()
+  local max_conflict_exit = 127
 
   if vim.fn.writefile(base_lines, base_file) ~= 0
     or vim.fn.writefile(ours_lines, ours_file) ~= 0
     or vim.fn.writefile(theirs_lines, theirs_file) ~= 0
   then
+    os.remove(base_file)
+    os.remove(ours_file)
+    os.remove(theirs_file)
+    return {}, -1
+  end
+
+  if vim.fn.executable("git") ~= 1 then
     os.remove(base_file)
     os.remove(ours_file)
     os.remove(theirs_file)
@@ -492,9 +500,9 @@ local function three_way_merge(base_lines, ours_lines, theirs_lines)
   os.remove(ours_file)
   os.remove(theirs_file)
 
-  -- Exit codes > 100 indicate command execution failure (e.g. 127 = git not found),
-  -- not merge conflict counts.
-  if exit_code > 100 then
+  -- git-merge-file returns the number of conflicts (truncated to 127) on success.
+  -- Values outside [0, 127] indicate execution/runtime errors.
+  if exit_code < 0 or exit_code > max_conflict_exit then
     return {}, -1
   end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -314,9 +314,11 @@ end
 --- Set up the parallel agent dispatch keymap on a maximize buffer.
 ---@param buf number Buffer to bind the keymap on
 ---@param opts table {repo_path, sha, commit_message, filename, state}
-local function setup_parallel_agent_keymap(buf, opts)
+---@param shortcuts table Pre-loaded shortcuts config
+local function setup_parallel_agent_keymap(buf, opts, shortcuts)
+  local dispatch_key = shortcuts.commit_mode and shortcuts.commit_mode.dispatch_agent
   local pa_cfg = config.load_parallel_agents()
-  if not pa_cfg.enabled or not config.is_enabled(pa_cfg.shortcut) then return end
+  if not pa_cfg.enabled or not config.is_enabled(dispatch_key) then return end
   local pa = require("raccoon.parallel_agents")
   local buf_opts = { buffer = buf, noremap = true, silent = true }
   local function dispatch_fn()
@@ -341,7 +343,7 @@ local function setup_parallel_agent_keymap(buf, opts)
       view_state = opts.state,
     })
   end
-  vim.keymap.set({ "n", "v" }, pa_cfg.shortcut, dispatch_fn, buf_opts)
+  vim.keymap.set({ "n", "v" }, dispatch_key, dispatch_fn, buf_opts)
 end
 
 --- Compute centered floating window dimensions.
@@ -520,12 +522,13 @@ end
 ---@param opts table {repo_path, filename, state}
 ---@param shortcuts table Pre-loaded shortcuts config (avoids redundant disk read)
 local function setup_human_edit_keymap(buf, opts, shortcuts)
+  local human_edit_key = shortcuts.commit_mode and shortcuts.commit_mode.human_edit
+  if not config.is_enabled(human_edit_key) then return end
   local he_cfg = config.load_human_edit()
-  if not config.is_enabled(he_cfg.shortcut) then return end
 
   local buf_opts = { buffer = buf, noremap = true, silent = true }
 
-  vim.keymap.set(NORMAL_MODE, he_cfg.shortcut, function()
+  vim.keymap.set(NORMAL_MODE, human_edit_key, function()
     -- Prevent opening multiple edit windows
     if opts.state.popup_win and vim.api.nvim_win_is_valid(opts.state.popup_win) then
       vim.api.nvim_set_current_win(opts.state.popup_win)
@@ -1520,7 +1523,7 @@ function M.open_maximize(opts)
     -- Parallel agents and human edit are only available in local (working-dir) mode
     -- where the files exist on disk and edits/agents are meaningful.
     if opts.is_working_dir then
-      setup_parallel_agent_keymap(buf, opts)
+      setup_parallel_agent_keymap(buf, opts, shortcuts)
       setup_human_edit_keymap(buf, opts, shortcuts)
     end
   end)

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -538,7 +538,6 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     local function close_edit()
       if edit_closed then return end
       edit_closed = true
-      -- Auto-save if modified
       local save_ok = false
       if vim.api.nvim_buf_is_valid(edit_buf) then
         if vim.bo[edit_buf].modified then
@@ -558,7 +557,7 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       if vim.api.nvim_win_is_valid(edit_win) then
         vim.api.nvim_win_close(edit_win, true)
       end
-      -- Clean up buffer-local keymaps and autocmds to avoid corrupting the real file buffer
+      -- Remove buffer-local keymaps/autocmds so they don't persist on the real file buffer
       pcall(vim.api.nvim_del_autocmd, text_changed_au)
       pcall(vim.keymap.del, NORMAL_MODE, "q", { buffer = edit_buf })
       if config.is_enabled(shortcuts.close) then
@@ -567,7 +566,6 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       if config.is_enabled(shortcuts.comment_save) then
         pcall(vim.keymap.del, NORMAL_MODE, shortcuts.comment_save, { buffer = edit_buf })
       end
-      -- Refresh maximize diff for working-dir views
       if opts.state.maximize_workdir_opts then
         M.refresh_maximize(opts.state)
       end
@@ -576,7 +574,6 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       end
     end
 
-    -- Clean up on any window close method (:q, :close, <C-w>c, etc.)
     vim.api.nvim_create_autocmd("WinClosed", {
       pattern = tostring(edit_win),
       once = true,
@@ -607,9 +604,10 @@ end
 ---@param grid_rows number Grid row count (for maximize prefix blocking)
 ---@param grid_cols number Grid column count
 ---@param skip_keys? table<string, boolean> Keys to exclude from blocking
-function M.lock_maximize_buf(buf, grid_rows, grid_cols, skip_keys)
+---@param shortcuts? table Pre-loaded shortcuts (avoids redundant config read)
+function M.lock_maximize_buf(buf, grid_rows, grid_cols, skip_keys, shortcuts)
   if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
-  local shortcuts = config.load_shortcuts()
+  shortcuts = shortcuts or config.load_shortcuts()
   local opts = { buffer = buf, noremap = true, silent = true }
   local nop = function() end
   shadow_global_keymaps(buf, NORMAL_MODE)
@@ -1044,6 +1042,7 @@ function M.close_win_pair(s, win_key, buf_key)
     M.stop_maximize_watcher(s)
     s.maximize_workdir_opts = nil
     s.maximize_hl_lines = nil
+    s.maximize_last_patch = nil
   end
 end
 
@@ -1329,6 +1328,7 @@ function M.open_maximize(opts)
     opts.state.maximize_win = win
     opts.state.maximize_buf = buf
     opts.state.maximize_hl_lines = hl_lines
+    opts.state.maximize_last_patch = patch
     M.stop_maximize_watcher(opts.state)
     if opts.is_working_dir then
       opts.state.maximize_workdir_opts = {
@@ -1356,7 +1356,7 @@ function M.open_maximize(opts)
         [shortcuts.commit_mode.prev_page] = true,
       }
     end
-    M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols, skip_keys)
+    M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols, skip_keys, shortcuts)
 
     local buf_opts = { buffer = buf, noremap = true, silent = true }
     local function close_fn()
@@ -1539,12 +1539,19 @@ function M.refresh_maximize(s)
     end
 
     if not patch or patch == "" then
-      vim.bo[buf].modifiable = true
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
-      vim.bo[buf].modifiable = false
-      s.maximize_hl_lines = nil
+      if s.maximize_last_patch ~= "" then
+        vim.bo[buf].modifiable = true
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
+        vim.bo[buf].modifiable = false
+        s.maximize_hl_lines = nil
+        s.maximize_last_patch = ""
+      end
       return
     end
+
+    -- Skip buffer update when diff is unchanged (fs events can fire on metadata changes)
+    if patch == s.maximize_last_patch then return end
+    s.maximize_last_patch = patch
 
     local hunks = diff.parse_patch(patch)
     if #hunks == 0 then return end
@@ -1618,7 +1625,7 @@ function M.open_file_content(opts)
     vim.wo[win].winbar = " " .. opts.filename .. "%=%#Comment# " .. close_hint .. " to exit %*"
     vim.wo[win].wrap = true
 
-    M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols)
+    M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols, nil, shortcuts)
 
     local buf_opts = { buffer = buf, noremap = true, silent = true }
     local function close_fn()

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -447,6 +447,43 @@ local function run_post_command(command, filename, repo_path)
   end
 end
 
+--- Perform a 3-way merge using git merge-file.
+--- Compares the user's edits against external changes using the original file as the common ancestor.
+---@param base_lines string[] Original file content when edit window opened
+---@param ours_lines string[] User's buffer content
+---@param theirs_lines string[] Current file content on disk (external changes)
+---@return string[] merged_lines Merged result (may contain conflict markers)
+---@return number exit_code 0=clean, >0=conflict count, <0=git error
+local function three_way_merge(base_lines, ours_lines, theirs_lines)
+  local base_file = vim.fn.tempname()
+  local ours_file = vim.fn.tempname()
+  local theirs_file = vim.fn.tempname()
+
+  vim.fn.writefile(base_lines, base_file)
+  vim.fn.writefile(ours_lines, ours_file)
+  vim.fn.writefile(theirs_lines, theirs_file)
+
+  local merged = vim.fn.system({
+    "git", "merge-file", "--stdout",
+    "-L", "your changes",
+    "-L", "original",
+    "-L", "external changes",
+    ours_file, base_file, theirs_file,
+  })
+  local exit_code = vim.v.shell_error
+
+  os.remove(base_file)
+  os.remove(ours_file)
+  os.remove(theirs_file)
+
+  local merged_lines = vim.split(merged, "\n", { plain = true })
+  if #merged_lines > 0 and merged_lines[#merged_lines] == "" then
+    table.remove(merged_lines)
+  end
+
+  return merged_lines, exit_code
+end
+
 --- Set up the human edit keymap on a maximize buffer.
 --- Opens the actual file in an editable floating window.
 ---@param buf number Buffer to bind the keymap on
@@ -485,6 +522,9 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       vim.notify("Failed to load buffer for: " .. filepath, vim.log.levels.ERROR)
       return
     end
+
+    -- Snapshot file content for 3-way merge on close (detects external changes by agents)
+    local original_lines = vim.fn.readfile(filepath)
 
     local width, height, row, col = float_dimensions()
 
@@ -535,8 +575,58 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     })
 
     local edit_closed = false
+    local merge_attempted = false
+
+    -- Check for external file changes and 3-way merge if needed.
+    -- Returns: "ok" (proceed), "conflict" (user must resolve), "error" (git failed)
+    local function check_merge_external()
+      if not was_ever_modified or merge_attempted then return "ok" end
+      if not vim.api.nvim_buf_is_valid(edit_buf) then return "ok" end
+
+      local disk_ok, current_disk_lines = pcall(vim.fn.readfile, filepath)
+      if not disk_ok then return "ok" end
+      if table.concat(current_disk_lines, "\n") == table.concat(original_lines, "\n") then return "ok" end
+
+      local buffer_lines = vim.api.nvim_buf_get_lines(edit_buf, 0, -1, false)
+      if table.concat(buffer_lines, "\n") == table.concat(current_disk_lines, "\n") then
+        -- Buffer already matches disk (e.g. autoread), just update baseline
+        original_lines = current_disk_lines
+        return "ok"
+      end
+
+      local merged_lines, exit_code = three_way_merge(original_lines, buffer_lines, current_disk_lines)
+      if exit_code < 0 then
+        vim.notify("Merge failed (git error). Save your changes manually.", vim.log.levels.ERROR)
+        return "error"
+      elseif exit_code > 0 then
+        vim.api.nvim_buf_set_lines(edit_buf, 0, -1, false, merged_lines)
+        merge_attempted = true
+        return "conflict", exit_code
+      else
+        vim.api.nvim_buf_set_lines(edit_buf, 0, -1, false, merged_lines)
+        original_lines = current_disk_lines
+        vim.notify("File modified externally — changes merged automatically.", vim.log.levels.INFO)
+        return "ok"
+      end
+    end
+
     local function close_edit()
       if edit_closed then return end
+
+      local status, conflict_count = check_merge_external()
+      if status == "error" then
+        if vim.api.nvim_win_is_valid(edit_win) then return end
+      elseif status == "conflict" then
+        if vim.api.nvim_win_is_valid(edit_win) then
+          vim.notify(
+            string.format("File modified externally. %d conflict(s) — resolve markers and close again.", conflict_count),
+            vim.log.levels.WARN
+          )
+          return
+        end
+        vim.notify("File modified externally with conflicts — saved with conflict markers.", vim.log.levels.WARN)
+      end
+
       edit_closed = true
       local save_ok = false
       if vim.api.nvim_buf_is_valid(edit_buf) then
@@ -583,8 +673,19 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     local edit_km = { buffer = edit_buf, noremap = true, silent = true }
     if config.is_enabled(shortcuts.comment_save) then
       vim.keymap.set(NORMAL_MODE, shortcuts.comment_save, function()
+        local status, conflict_count = check_merge_external()
+        if status == "error" then return end
+        if status == "conflict" then
+          vim.notify(
+            string.format("File modified externally. %d conflict(s) — resolve markers before saving.", conflict_count),
+            vim.log.levels.WARN
+          )
+          return
+        end
         local ok, err = pcall(vim.cmd, "write")
         if ok then
+          original_lines = vim.api.nvim_buf_get_lines(edit_buf, 0, -1, false)
+          merge_attempted = false
           vim.notify("Saved " .. opts.filename, vim.log.levels.INFO)
         else
           vim.notify("Failed to save " .. opts.filename .. ": " .. tostring(err), vim.log.levels.ERROR)
@@ -2258,5 +2359,6 @@ function M.split_sidebar_cursor_to_index(cursor_line, section1_count)
 end
 
 M.diff_line_to_file_line = diff_line_to_file_line
+M.three_way_merge = three_way_merge
 
 return M

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -355,9 +355,26 @@ local function float_dimensions(scale)
   return width, height, row, col
 end
 
+--- Flatten parsed hunks into display lines and highlight metadata.
+---@param hunks table[] Parsed diff hunks from diff.parse_patch
+---@return string[] lines Display lines for the buffer
+---@return table[] hl_lines Highlight metadata ({type, line_num} per line)
+local function flatten_hunks(hunks)
+  local lines = {}
+  local hl_lines = {}
+  for _, hunk in ipairs(hunks) do
+    for _, line_data in ipairs(hunk.lines) do
+      table.insert(lines, line_data.content or "")
+      table.insert(hl_lines, { type = line_data.type, line_num = line_data.line_num })
+    end
+  end
+  return lines, hl_lines
+end
+
 --- Map a diff buffer line to the corresponding real file line number.
---- Walks hl_lines backward to find the nearest non-deletion entry with a line_num
---- at or before cursor_line.
+--- Walks hl_lines backward from cursor_line to find the nearest context or addition
+--- entry (skipping deletions), returning its line_num. Deletions are skipped because
+--- their line_num refers to the old file, not the new file.
 ---@param hl_lines table[] Array of {type, line_num} from parsed diff
 ---@param cursor_line number 1-based cursor line in the maximize buffer
 ---@return number file_line 1-based line in the real file (fallback: 1)
@@ -389,9 +406,17 @@ local function run_post_command(command, filename, repo_path)
   local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
   cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
 
+  local stdout_lines = {}
   local stderr_lines = {}
   local job_id = vim.fn.jobstart({ "sh", "-c", cmd .. " </dev/null" }, {
     cwd = repo_path,
+    on_stdout = function(_, data)
+      if data then
+        for _, line in ipairs(data) do
+          if line ~= "" then table.insert(stdout_lines, line) end
+        end
+      end
+    end,
     on_stderr = function(_, data)
       if data then
         for _, line in ipairs(data) do
@@ -405,8 +430,9 @@ local function run_post_command(command, filename, repo_path)
           vim.notify("Post-edit command finished: " .. filename, vim.log.levels.INFO)
         else
           local msg = string.format("Post-edit command failed (exit %d)", exit_code)
-          if #stderr_lines > 0 then
-            msg = msg .. "\n" .. table.concat(stderr_lines, "\n")
+          local output = vim.list_extend(vim.list_extend({}, stderr_lines), stdout_lines)
+          if #output > 0 then
+            msg = msg .. "\n" .. table.concat(output, "\n")
           end
           vim.notify(msg, vim.log.levels.ERROR)
         end
@@ -498,9 +524,12 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     -- Register as popup_win so the focus-lock system keeps this window focusable
     opts.state.popup_win = edit_win
 
-    -- Track whether the buffer was ever modified (survives intermediate saves)
+    -- Track whether the buffer was ever modified (survives intermediate saves).
+    -- This gates the post-edit command -- if the user opens and closes without
+    -- editing, no command runs. We cannot rely on bo.modified alone because it
+    -- resets to false after each :write.
     local was_ever_modified = false
-    vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+    local text_changed_au = vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
       buffer = edit_buf,
       callback = function() was_ever_modified = true end,
     })
@@ -529,7 +558,8 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       if vim.api.nvim_win_is_valid(edit_win) then
         vim.api.nvim_win_close(edit_win, true)
       end
-      -- Clean up buffer-local keymaps to avoid corrupting the real file buffer
+      -- Clean up buffer-local keymaps and autocmds to avoid corrupting the real file buffer
+      pcall(vim.api.nvim_del_autocmd, text_changed_au)
       pcall(vim.keymap.del, NORMAL_MODE, "q", { buffer = edit_buf })
       if config.is_enabled(shortcuts.close) then
         pcall(vim.keymap.del, NORMAL_MODE, shortcuts.close, { buffer = edit_buf })
@@ -1253,14 +1283,7 @@ function M.open_maximize(opts)
     local hunks = diff.parse_patch(patch)
     if #hunks == 0 then return end
 
-    local lines = {}
-    local hl_lines = {}
-    for _, hunk in ipairs(hunks) do
-      for _, line_data in ipairs(hunk.lines) do
-        table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type, line_num = line_data.line_num })
-      end
-    end
+    local lines, hl_lines = flatten_hunks(hunks)
 
     -- Find the start of each change group (consecutive add/del lines)
     local change_starts = {}
@@ -1526,14 +1549,7 @@ function M.refresh_maximize(s)
     local hunks = diff.parse_patch(patch)
     if #hunks == 0 then return end
 
-    local lines = {}
-    local hl_lines = {}
-    for _, hunk in ipairs(hunks) do
-      for _, line_data in ipairs(hunk.lines) do
-        table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type, line_num = line_data.line_num })
-      end
-    end
+    local lines, hl_lines = flatten_hunks(hunks)
     s.maximize_hl_lines = hl_lines
 
     local cursor = vim.api.nvim_win_get_cursor(win)

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -390,6 +390,18 @@ local function diff_line_to_file_line(hl_lines, cursor_line)
   return 1
 end
 
+--- Substitute <FILE> and <TIMESTAMP> placeholders in a command template.
+---@param command string Command template
+---@param filename string Relative file path
+---@return string formatted_command
+function M.format_post_command(command, filename)
+  local escaped_file = vim.fn.shellescape(filename)
+  local cmd = command:gsub("<FILE>", function() return escaped_file end)
+  local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
+  cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
+  return cmd
+end
+
 --- Run the configured post-edit shell command asynchronously.
 ---@param command string|nil Command template with <FILE> and <TIMESTAMP> placeholders; nil or "" to skip
 ---@param filename string Relative file path
@@ -402,10 +414,7 @@ local function run_post_command(command, filename, repo_path)
     return
   end
 
-  local escaped_file = vim.fn.shellescape(filename)
-  local cmd = command:gsub("<FILE>", function() return escaped_file end)
-  local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
-  cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
+  local cmd = M.format_post_command(command, filename)
 
   local stdout_lines = {}
   local stderr_lines = {}
@@ -454,15 +463,21 @@ end
 ---@param ours_lines string[] User's buffer content
 ---@param theirs_lines string[] Current file content on disk (external changes)
 ---@return string[] merged_lines Merged result (may contain conflict markers)
----@return number exit_code 0=clean, >0=conflict count, <0=git error
+---@return number exit_code 0=clean, >0=conflict count, <0=error (write failure or git not found)
 local function three_way_merge(base_lines, ours_lines, theirs_lines)
   local base_file = vim.fn.tempname()
   local ours_file = vim.fn.tempname()
   local theirs_file = vim.fn.tempname()
 
-  vim.fn.writefile(base_lines, base_file)
-  vim.fn.writefile(ours_lines, ours_file)
-  vim.fn.writefile(theirs_lines, theirs_file)
+  if vim.fn.writefile(base_lines, base_file) ~= 0
+    or vim.fn.writefile(ours_lines, ours_file) ~= 0
+    or vim.fn.writefile(theirs_lines, theirs_file) ~= 0
+  then
+    os.remove(base_file)
+    os.remove(ours_file)
+    os.remove(theirs_file)
+    return {}, -1
+  end
 
   local merged = vim.fn.system({
     "git", "merge-file", "--stdout",
@@ -476,6 +491,12 @@ local function three_way_merge(base_lines, ours_lines, theirs_lines)
   os.remove(base_file)
   os.remove(ours_file)
   os.remove(theirs_file)
+
+  -- Exit codes > 100 indicate command execution failure (e.g. 127 = git not found),
+  -- not merge conflict counts.
+  if exit_code > 100 then
+    return {}, -1
+  end
 
   local merged_lines = vim.split(merged, "\n", { plain = true })
   if #merged_lines > 0 and merged_lines[#merged_lines] == "" then
@@ -586,7 +607,10 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       if not vim.api.nvim_buf_is_valid(edit_buf) then return "ok" end
 
       local disk_ok, current_disk_lines = pcall(vim.fn.readfile, filepath)
-      if not disk_ok then return "ok" end
+      if not disk_ok then
+        vim.notify("Could not read file for merge check: " .. tostring(current_disk_lines), vim.log.levels.WARN)
+        return "error"
+      end
       if table.concat(current_disk_lines, "\n") == table.concat(original_lines, "\n") then return "ok" end
 
       local buffer_lines = vim.api.nvim_buf_get_lines(edit_buf, 0, -1, false)
@@ -2348,6 +2372,73 @@ function M.split_sidebar_cursor_to_index(cursor_line, section1_count)
   if line_0 <= section1_end + 2 then return nil end -- on separator or header
 
   return line_0 - 2 -- subtract blank + header to get combined index
+end
+
+--- Open a picker list in a floating window (file picker, commit picker).
+---@param opts table {title, items, state, on_select}
+function M.open_maximize_list(opts)
+  local items = opts.items or {}
+  if #items == 0 then return end
+
+  local lines = {}
+  for _, item in ipairs(items) do
+    table.insert(lines, item.display)
+  end
+
+  local width = math.max(1, math.floor(vim.o.columns * 0.6))
+  local height = math.max(1, math.min(#lines, math.floor(vim.o.lines * 0.7)))
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local buf = M.create_scratch_buf()
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+
+  local ok, win = pcall(vim.api.nvim_open_win, buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    zindex = 50,
+  })
+  if not ok then
+    vim.notify("Failed to open picker window: " .. tostring(win), vim.log.levels.WARN)
+    pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    return
+  end
+
+  windows.mark(win)
+  opts.state.maximize_win = win
+  opts.state.maximize_buf = buf
+
+  local shortcuts = config.load_shortcuts()
+  vim.wo[win].winbar = " " .. opts.title .. "%=%#Comment# " .. (shortcuts.close or "<leader>q") .. " to exit %*"
+  vim.wo[win].cursorline = true
+
+  M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols, nil, shortcuts)
+
+  local buf_opts = { buffer = buf, noremap = true, silent = true }
+  local function close_fn()
+    M.close_win_pair(opts.state, "maximize_win", "maximize_buf")
+  end
+  local function select_fn()
+    if not vim.api.nvim_win_is_valid(win) then return end
+    local cursor = vim.api.nvim_win_get_cursor(win)
+    local idx = cursor[1]
+    if idx >= 1 and idx <= #items then
+      close_fn()
+      opts.on_select(items[idx].value)
+    end
+  end
+
+  if config.is_enabled(shortcuts.close) then
+    vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
+  end
+  vim.keymap.set(NORMAL_MODE, "<CR>", select_fn, buf_opts)
 end
 
 M.diff_line_to_file_line = diff_line_to_file_line

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -5,6 +5,7 @@ local M = {}
 local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local diff = require("raccoon.diff")
+local windows = require("raccoon.windows")
 
 M.SIDEBAR_WIDTH = 50
 M.STAT_BAR_MAX_WIDTH = 20
@@ -529,7 +530,7 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
     local width, height, row, col = float_dimensions()
 
     local save_key = config.is_enabled(shortcuts.comment_save) and shortcuts.comment_save or "<leader>s"
-    local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "q"
+    local close_key = shortcuts.close
 
     -- Set sentinel before open_win so the WinEnter focus lock sees it
     -- (open_win fires WinEnter synchronously before we can assign the real handle)
@@ -549,9 +550,10 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       vim.notify("Failed to open edit window: " .. tostring(edit_win), vim.log.levels.ERROR)
       return
     end
+    windows.mark(edit_win)
 
     vim.wo[edit_win].winbar = " Edit: " .. opts.filename
-      .. "%=%#Comment# " .. save_key .. "=save  " .. close_key .. " or q to close %*"
+      .. "%=%#Comment# " .. save_key .. "=save  " .. close_key .. " to close %*"
     vim.wo[edit_win].number = true
     vim.wo[edit_win].wrap = true
     vim.wo[edit_win].signcolumn = "yes:1"
@@ -649,10 +651,7 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
       end
       -- Remove buffer-local keymaps/autocmds so they don't persist on the real file buffer
       pcall(vim.api.nvim_del_autocmd, text_changed_au)
-      pcall(vim.keymap.del, NORMAL_MODE, "q", { buffer = edit_buf })
-      if config.is_enabled(shortcuts.close) then
-        pcall(vim.keymap.del, NORMAL_MODE, shortcuts.close, { buffer = edit_buf })
-      end
+      pcall(vim.keymap.del, NORMAL_MODE, shortcuts.close, { buffer = edit_buf })
       if config.is_enabled(shortcuts.comment_save) then
         pcall(vim.keymap.del, NORMAL_MODE, shortcuts.comment_save, { buffer = edit_buf })
       end
@@ -692,10 +691,7 @@ local function setup_human_edit_keymap(buf, opts, shortcuts)
         end
       end, edit_km)
     end
-    if config.is_enabled(shortcuts.close) then
-      vim.keymap.set(NORMAL_MODE, shortcuts.close, close_edit, edit_km)
-    end
-    vim.keymap.set(NORMAL_MODE, "q", close_edit, edit_km)
+    vim.keymap.set(NORMAL_MODE, shortcuts.close, close_edit, edit_km)
   end, buf_opts)
 end
 
@@ -1425,6 +1421,7 @@ function M.open_maximize(opts)
       pcall(vim.api.nvim_buf_delete, buf, { force = true })
       return
     end
+    windows.mark(win)
 
     opts.state.maximize_win = win
     opts.state.maximize_buf = buf
@@ -1445,7 +1442,7 @@ function M.open_maximize(opts)
     M.apply_diff_highlights(opts.ns_id, buf, hl_lines)
 
     local shortcuts = config.load_shortcuts()
-    local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. " or q") or "q"
+    local close_hint = shortcuts.close
     vim.wo[win].winbar = " " .. opts.filename .. "%=%#Comment# " .. close_hint .. " to exit %*"
     vim.wo[win].signcolumn = "yes:1"
     vim.wo[win].wrap = true
@@ -1463,10 +1460,7 @@ function M.open_maximize(opts)
     local function close_fn()
       M.close_win_pair(opts.state, "maximize_win", "maximize_buf")
     end
-    if config.is_enabled(shortcuts.close) then
-      vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
-    end
-    vim.keymap.set(NORMAL_MODE, "q", close_fn, buf_opts)
+    vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
 
     if #change_starts > 0 and config.is_enabled(shortcuts.commit_mode.next_page) then
       vim.keymap.set(NORMAL_MODE, shortcuts.commit_mode.next_page, function()
@@ -1716,13 +1710,14 @@ function M.open_file_content(opts)
       pcall(vim.api.nvim_buf_delete, buf, { force = true })
       return
     end
+    windows.mark(win)
 
     opts.state.maximize_win = win
     opts.state.maximize_buf = buf
     opts.state.maximize_hl_lines = nil
 
     local shortcuts = config.load_shortcuts()
-    local close_hint = config.is_enabled(shortcuts.close) and (shortcuts.close .. " or q") or "q"
+    local close_hint = shortcuts.close
     vim.wo[win].winbar = " " .. opts.filename .. "%=%#Comment# " .. close_hint .. " to exit %*"
     vim.wo[win].wrap = true
 
@@ -1732,10 +1727,7 @@ function M.open_file_content(opts)
     local function close_fn()
       M.close_win_pair(opts.state, "maximize_win", "maximize_buf")
     end
-    if config.is_enabled(shortcuts.close) then
-      vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
-    end
-    vim.keymap.set(NORMAL_MODE, "q", close_fn, buf_opts)
+    vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
   end)
 end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -344,14 +344,26 @@ local function setup_parallel_agent_keymap(buf, opts, pa_cfg)
   vim.keymap.set({ "n", "v" }, pa_cfg.shortcut, dispatch_fn, buf_opts)
 end
 
+--- Compute centered floating window dimensions.
+---@param scale? number Scale factor (default 0.85)
+---@return number width, number height, number row, number col
+local function float_dimensions(scale)
+  scale = scale or 0.85
+  local width = math.floor(vim.o.columns * scale)
+  local height = math.floor(vim.o.lines * scale)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+  return width, height, row, col
+end
+
 --- Map a diff buffer line to the corresponding real file line number.
---- Walks hl_lines to find the nearest add/ctx entry at or before cursor_line.
+--- Walks hl_lines backward to find the nearest non-deletion entry with a line_num
+--- at or before cursor_line.
 ---@param hl_lines table[] Array of {type, line_num} from parsed diff
 ---@param cursor_line number 1-based cursor line in the maximize buffer
 ---@return number file_line 1-based line in the real file (fallback: 1)
 local function diff_line_to_file_line(hl_lines, cursor_line)
   if not hl_lines or #hl_lines == 0 then return 1 end
-  -- Try exact line first, then search backward for nearest add/ctx
   for i = math.min(cursor_line, #hl_lines), 1, -1 do
     local entry = hl_lines[i]
     if entry.line_num and entry.type ~= "del" then
@@ -361,18 +373,73 @@ local function diff_line_to_file_line(hl_lines, cursor_line)
   return 1
 end
 
+--- Run the configured post-edit shell command asynchronously.
+---@param command string Command template with <FILE> and <TIMESTAMP> placeholders
+---@param filename string Relative file path
+---@param repo_path string Repository root directory
+local function run_post_command(command, filename, repo_path)
+  if not command or command == "" then return end
+
+  if vim.fn.isdirectory(repo_path) ~= 1 then
+    vim.notify("Post-edit command skipped: repo path no longer exists: " .. repo_path, vim.log.levels.ERROR)
+    return
+  end
+
+  local escaped_file = vim.fn.shellescape(filename)
+  local cmd = command:gsub("<FILE>", function() return escaped_file end)
+  local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
+  cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
+
+  local stderr_lines = {}
+  local job_id = vim.fn.jobstart({ "sh", "-c", cmd .. " </dev/null" }, {
+    cwd = repo_path,
+    on_stderr = function(_, data)
+      if data then
+        for _, line in ipairs(data) do
+          if line ~= "" then table.insert(stderr_lines, line) end
+        end
+      end
+    end,
+    on_exit = function(_, exit_code)
+      vim.schedule(function()
+        if exit_code == 0 then
+          vim.notify("Post-edit command finished: " .. filename, vim.log.levels.INFO)
+        else
+          local msg = string.format("Post-edit command failed (exit %d)", exit_code)
+          if #stderr_lines > 0 then
+            msg = msg .. "\n" .. table.concat(stderr_lines, "\n")
+          end
+          vim.notify(msg, vim.log.levels.ERROR)
+        end
+      end)
+    end,
+  })
+  if job_id > 0 then
+    vim.notify("Running post-edit command...", vim.log.levels.INFO)
+  else
+    vim.notify("Post-edit command failed: " .. (job_id == 0 and "invalid arguments" or "command not executable"),
+      vim.log.levels.ERROR)
+  end
+end
+
 --- Set up the human edit keymap on a maximize buffer.
 --- Opens the actual file in an editable floating window.
 ---@param buf number Buffer to bind the keymap on
 ---@param opts table {repo_path, filename, state}
-local function setup_human_edit_keymap(buf, opts)
+---@param shortcuts table Pre-loaded shortcuts config (avoids redundant disk read)
+local function setup_human_edit_keymap(buf, opts, shortcuts)
   local he_cfg = config.load_human_edit()
   if not config.is_enabled(he_cfg.shortcut) then return end
 
-  local shortcuts = config.load_shortcuts()
   local buf_opts = { buffer = buf, noremap = true, silent = true }
 
   vim.keymap.set(NORMAL_MODE, he_cfg.shortcut, function()
+    -- Prevent opening multiple edit windows
+    if opts.state.popup_win and vim.api.nvim_win_is_valid(opts.state.popup_win) then
+      vim.api.nvim_set_current_win(opts.state.popup_win)
+      return
+    end
+
     local filepath = vim.fs.joinpath(opts.repo_path, opts.filename)
     if vim.fn.filereadable(filepath) ~= 1 then
       vim.notify("File not found: " .. filepath, vim.log.levels.WARN)
@@ -384,17 +451,26 @@ local function setup_human_edit_keymap(buf, opts)
     local file_line = diff_line_to_file_line(opts.state.maximize_hl_lines, cursor_line)
 
     local edit_buf = vim.fn.bufadd(filepath)
+    if edit_buf == 0 then
+      vim.notify("Failed to open buffer for: " .. filepath, vim.log.levels.ERROR)
+      return
+    end
     vim.fn.bufload(edit_buf)
+    if not vim.api.nvim_buf_is_valid(edit_buf) then
+      vim.notify("Failed to load buffer for: " .. filepath, vim.log.levels.ERROR)
+      return
+    end
 
-    local width = math.floor(vim.o.columns * 0.85)
-    local height = math.floor(vim.o.lines * 0.85)
-    local row = math.floor((vim.o.lines - height) / 2)
-    local col = math.floor((vim.o.columns - width) / 2)
+    local width, height, row, col = float_dimensions()
 
     local save_key = config.is_enabled(shortcuts.comment_save) and shortcuts.comment_save or "<leader>s"
     local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "q"
 
-    local edit_win = vim.api.nvim_open_win(edit_buf, true, {
+    -- Set sentinel before open_win so the WinEnter focus lock sees it
+    -- (open_win fires WinEnter synchronously before we can assign the real handle)
+    opts.state.popup_win = -1
+
+    local ok_win, edit_win = pcall(vim.api.nvim_open_win, edit_buf, true, {
       relative = "editor",
       width = width,
       height = height,
@@ -403,6 +479,11 @@ local function setup_human_edit_keymap(buf, opts)
       border = "rounded",
       zindex = 60,
     })
+    if not ok_win then
+      opts.state.popup_win = nil
+      vim.notify("Failed to open edit window: " .. tostring(edit_win), vim.log.levels.ERROR)
+      return
+    end
 
     vim.wo[edit_win].winbar = " Edit: " .. opts.filename
       .. "%=%#Comment# " .. save_key .. "=save  " .. close_key .. " or q to close %*"
@@ -415,53 +496,8 @@ local function setup_human_edit_keymap(buf, opts)
     file_line = math.min(file_line, line_count)
     vim.api.nvim_win_set_cursor(edit_win, { file_line, 0 })
 
-    -- Track popup on state for focus lock
+    -- Register as popup_win so the focus-lock system keeps this window focusable
     opts.state.popup_win = edit_win
-
-    local function run_post_command()
-      local cmd = he_cfg.command
-      if not cmd or cmd == "" then return end
-
-      -- Replace <FILE> placeholder with the shell-escaped relative filename
-      local escaped_file = vim.fn.shellescape(opts.filename)
-      cmd = cmd:gsub("<FILE>", function() return escaped_file end)
-
-      -- Replace <TIMESTAMP> placeholder with timestamp
-      local timestamp = os.date("%Y-%m-%d_%H:%M:%S")
-      cmd = cmd:gsub("<TIMESTAMP>", function() return timestamp end)
-
-      local stderr_lines = {}
-      local job_id = vim.fn.jobstart({ "sh", "-c", cmd .. " </dev/null" }, {
-        cwd = opts.repo_path,
-        on_stderr = function(_, data)
-          if data then
-            for _, line in ipairs(data) do
-              if line ~= "" then table.insert(stderr_lines, line) end
-            end
-          end
-        end,
-        on_exit = function(_, exit_code)
-          vim.schedule(function()
-            if exit_code == 0 then
-              vim.notify("Post-edit command finished: " .. opts.filename, vim.log.levels.INFO)
-            else
-              local msg = string.format("Post-edit command failed (exit %d)", exit_code)
-              if #stderr_lines > 0 then
-                msg = msg .. "\n" .. table.concat(stderr_lines, "\n")
-              end
-              vim.notify(msg, vim.log.levels.WARN)
-            end
-          end)
-        end,
-      })
-      if job_id > 0 then
-        vim.notify("Running post-edit command...", vim.log.levels.INFO)
-      elseif job_id == 0 then
-        vim.notify("Post-edit command failed: invalid arguments", vim.log.levels.ERROR)
-      else
-        vim.notify("Post-edit command failed: command not executable", vim.log.levels.ERROR)
-      end
-    end
 
     local edit_closed = false
     local function close_edit()
@@ -469,7 +505,7 @@ local function setup_human_edit_keymap(buf, opts)
       edit_closed = true
       -- Auto-save if modified
       local save_ok = true
-      if vim.bo[edit_buf].modified then
+      if vim.api.nvim_buf_is_valid(edit_buf) and vim.bo[edit_buf].modified then
         local ok, err = pcall(function()
           vim.api.nvim_buf_call(edit_buf, function() vim.cmd("write") end)
         end)
@@ -482,14 +518,29 @@ local function setup_human_edit_keymap(buf, opts)
       if vim.api.nvim_win_is_valid(edit_win) then
         vim.api.nvim_win_close(edit_win, true)
       end
+      -- Clean up buffer-local keymaps to avoid corrupting the real file buffer
+      pcall(vim.keymap.del, NORMAL_MODE, "q", { buffer = edit_buf })
+      if config.is_enabled(shortcuts.close) then
+        pcall(vim.keymap.del, NORMAL_MODE, shortcuts.close, { buffer = edit_buf })
+      end
+      if config.is_enabled(shortcuts.comment_save) then
+        pcall(vim.keymap.del, NORMAL_MODE, shortcuts.comment_save, { buffer = edit_buf })
+      end
       -- Refresh maximize diff for working-dir views
       if opts.state.maximize_workdir_opts then
         M.refresh_maximize(opts.state)
       end
       if save_ok then
-        run_post_command()
+        run_post_command(he_cfg.command, opts.filename, opts.repo_path)
       end
     end
+
+    -- Clean up on any window close method (:q, :close, <C-w>c, etc.)
+    vim.api.nvim_create_autocmd("WinClosed", {
+      pattern = tostring(edit_win),
+      once = true,
+      callback = function() close_edit() end,
+    })
 
     local edit_km = { buffer = edit_buf, noremap = true, silent = true }
     if config.is_enabled(shortcuts.comment_save) then
@@ -1264,7 +1315,6 @@ function M.open_maximize(opts)
     vim.wo[win].signcolumn = "yes:1"
     vim.wo[win].wrap = true
 
-    local pa_cfg = config.load_parallel_agents()
     local skip_keys
     if #change_starts > 0 then
       skip_keys = {
@@ -1306,8 +1356,12 @@ function M.open_maximize(opts)
       end, buf_opts)
     end
 
-    setup_parallel_agent_keymap(buf, opts, pa_cfg)
-    setup_human_edit_keymap(buf, opts, shortcuts)
+    -- Parallel agents and human edit are only available in local (working-dir) mode
+    -- where the files exist on disk and edits/agents are meaningful.
+    if opts.is_working_dir then
+      setup_parallel_agent_keymap(buf, opts)
+      setup_human_edit_keymap(buf, opts, shortcuts)
+    end
   end)
 end
 
@@ -1528,7 +1582,6 @@ function M.open_file_content(opts)
     vim.wo[win].winbar = " " .. opts.filename .. "%=%#Comment# " .. close_hint .. " to exit %*"
     vim.wo[win].wrap = true
 
-    local pa_cfg = config.load_parallel_agents()
     M.lock_maximize_buf(buf, opts.state.grid_rows, opts.state.grid_cols)
 
     local buf_opts = { buffer = buf, noremap = true, silent = true }
@@ -1539,8 +1592,6 @@ function M.open_file_content(opts)
       vim.keymap.set(NORMAL_MODE, shortcuts.close, close_fn, buf_opts)
     end
     vim.keymap.set(NORMAL_MODE, "q", close_fn, buf_opts)
-
-    setup_parallel_agent_keymap(buf, opts, pa_cfg)
   end)
 end
 

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -505,7 +505,7 @@ local function enter_commit_mode()
 end
 
 --- Exit commit viewer mode
----@param opts table|nil { resume_sync?: boolean }
+---@param opts table|nil { resume_sync?: boolean, silent?: boolean }
 local function exit_commit_mode(opts)
   opts = opts or {}
   if not commit_state.active then
@@ -546,7 +546,9 @@ local function exit_commit_mode(opts)
   end
 
   reset_state()
-  vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
+  if not opts.silent then
+    vim.notify("Exited commit viewer mode", vim.log.levels.INFO)
+  end
 end
 
 --- Toggle commit viewer mode
@@ -559,7 +561,7 @@ function M.toggle()
 end
 
 --- Exit commit viewer mode (safe to call when not active)
----@param opts table|nil { resume_sync?: boolean }
+---@param opts table|nil { resume_sync?: boolean, silent?: boolean }
 function M.exit_commit_mode(opts)
   exit_commit_mode(opts)
 end

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -280,6 +280,16 @@ local function sanitize_legacy_passthrough_keymaps(val)
   return sanitize_string_list(keys)
 end
 
+--- Resolve a shortcut field: false to disable, valid string to override, else default.
+---@param user_val any Value from user config
+---@param default_val string Default shortcut
+---@return string|false
+local function resolve_shortcut(user_val, default_val)
+  if user_val == false then return false end
+  if type(user_val) == "string" and user_val ~= "" then return user_val end
+  return default_val
+end
+
 --- Sanitize merged shortcuts against the defaults structure.
 --- Each leaf must be a non-empty string (valid binding) or false (disabled).
 --- Anything else (vim.NIL, numbers, empty strings, tables at leaf positions) falls back to the default.
@@ -353,20 +363,11 @@ function M.load_parallel_agents()
     return vim.deepcopy(defaults)
   end
 
-  local shortcut
-  if user.shortcut == false then
-    shortcut = false
-  elseif type(user.shortcut) == "string" and user.shortcut ~= "" then
-    shortcut = user.shortcut
-  else
-    shortcut = defaults.shortcut
-  end
-
   return {
     enabled = bool_field(user.enabled, defaults.enabled),
     command = type(user.command) == "string" and user.command or defaults.command,
     suffix_prompt = type(user.suffix_prompt) == "string" and user.suffix_prompt or defaults.suffix_prompt,
-    shortcut = shortcut,
+    shortcut = resolve_shortcut(user.shortcut, defaults.shortcut),
     popup_width = type(user.popup_width) == "number" and user.popup_width > 0
       and math.floor(user.popup_width) or defaults.popup_width,
   }
@@ -387,23 +388,10 @@ function M.load_human_edit()
     return vim.deepcopy(defaults)
   end
 
-  local shortcut
-  if user.shortcut == false then
-    shortcut = false
-  elseif type(user.shortcut) == "string" and user.shortcut ~= "" then
-    shortcut = user.shortcut
-  else
-    shortcut = defaults.shortcut
-  end
-
-  local command
-  if type(user.command) == "string" then
-    command = user.command
-  else
-    command = defaults.command
-  end
-
-  return { shortcut = shortcut, command = command }
+  return {
+    shortcut = resolve_shortcut(user.shortcut, defaults.shortcut),
+    command = type(user.command) == "string" and user.command or defaults.command,
+  }
 end
 
 --- Get the token and host for a given owner/org from the tokens table

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -40,6 +40,10 @@ M.defaults = {
     shortcut = "<leader>aa",
     popup_width = 70,
   },
+  human_edit = {
+    shortcut = "<leader>ee",
+    command = "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push",
+  },
   shortcuts = {
     -- Global
     pr_list = "<leader>pr",
@@ -366,6 +370,40 @@ function M.load_parallel_agents()
     popup_width = type(user.popup_width) == "number" and user.popup_width > 0
       and math.floor(user.popup_width) or defaults.popup_width,
   }
+end
+
+--- Load human_edit config, falling back to defaults gracefully.
+---@return table human_edit
+function M.load_human_edit()
+  local defaults = M.defaults.human_edit
+
+  local parsed = read_config_json()
+  if not parsed then
+    return vim.deepcopy(defaults)
+  end
+
+  local user = parsed.human_edit
+  if type(user) ~= "table" then
+    return vim.deepcopy(defaults)
+  end
+
+  local shortcut
+  if user.shortcut == false then
+    shortcut = false
+  elseif type(user.shortcut) == "string" and user.shortcut ~= "" then
+    shortcut = user.shortcut
+  else
+    shortcut = defaults.shortcut
+  end
+
+  local command
+  if type(user.command) == "string" then
+    command = user.command
+  else
+    command = defaults.command
+  end
+
+  return { shortcut = shortcut, command = command }
 end
 
 --- Get the token and host for a given owner/org from the tokens table

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -44,11 +44,9 @@ M.defaults = {
     enabled = false,
     command = "",
     suffix_prompt = "",
-    shortcut = "<leader>aa",
     popup_width = 70,
   },
   human_edit = {
-    shortcut = "<leader>ee",
     command = "git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push",
   },
   shortcuts = {
@@ -82,6 +80,8 @@ M.defaults = {
       exit = "<leader>cm",
       maximize_prefix = "<leader>m",
       browse_files = "<leader>f",
+      dispatch_agent = "<leader>aa",
+      human_edit = "<leader>ee",
     },
   },
 }
@@ -246,6 +246,42 @@ local function read_config_json(opts)
   return parsed, nil
 end
 
+--- Legacy shortcut fields that have moved to shortcuts.commit_mode.
+--- Maps feature block name to the new shortcut key name.
+local legacy_shortcut_migrations = {
+  parallel_agents = "dispatch_agent",
+  human_edit = "human_edit",
+}
+
+--- Track which legacy warnings have already fired this session.
+local warned_legacy_shortcuts = {}
+
+--- Warn once per session when a legacy *.shortcut field is present in the parsed config.
+---@param parsed table
+local function warn_legacy_shortcut(parsed)
+  if type(parsed) ~= "table" then return end
+  for feature, new_key in pairs(legacy_shortcut_migrations) do
+    if warned_legacy_shortcuts[feature] then goto continue end
+    local block = parsed[feature]
+    if type(block) ~= "table" then goto continue end
+    if block.shortcut == nil or block.shortcut == vim.NIL then goto continue end
+    warned_legacy_shortcuts[feature] = true
+    vim.notify(
+      string.format(
+        "Raccoon: %s.shortcut is deprecated and ignored; use shortcuts.commit_mode.%s",
+        feature, new_key
+      ),
+      vim.log.levels.WARN
+    )
+    ::continue::
+  end
+end
+
+--- Reset one-shot warning state for tests.
+function M._reset_warning_state_for_tests()
+  warned_legacy_shortcuts = {}
+end
+
 --- Return val if it is a boolean, otherwise return default.
 ---@param val any
 ---@param default boolean
@@ -291,16 +327,6 @@ local function sanitize_legacy_passthrough_keymaps(val)
   return sanitize_string_list(keys)
 end
 
---- Resolve a shortcut field: false to disable, valid string to override, else default.
----@param user_val any Value from user config
----@param default_val string Default shortcut
----@return string|false
-local function resolve_shortcut(user_val, default_val)
-  if user_val == false then return false end
-  if is_valid_shortcut_string(user_val) then return user_val end
-  return default_val
-end
-
 --- Sanitize merged shortcuts against the defaults structure.
 --- Each leaf must be a non-empty string (valid binding) or false (disabled).
 --- Anything else (vim.NIL, numbers, empty strings, tables at leaf positions) falls back to the default.
@@ -340,6 +366,7 @@ function M.load_shortcuts()
     return vim.deepcopy(M.defaults.shortcuts)
   end
 
+  warn_legacy_shortcut(parsed)
   local merged = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults.shortcuts), parsed.shortcuts or {})
   return sanitize_shortcuts(merged, M.defaults.shortcuts)
 end
@@ -375,6 +402,8 @@ function M.load_parallel_agents()
     return vim.deepcopy(defaults)
   end
 
+  warn_legacy_shortcut(parsed)
+
   local user = parsed.parallel_agents
   if type(user) ~= "table" then
     return vim.deepcopy(defaults)
@@ -384,7 +413,6 @@ function M.load_parallel_agents()
     enabled = bool_field(user.enabled, defaults.enabled),
     command = type(user.command) == "string" and user.command or defaults.command,
     suffix_prompt = type(user.suffix_prompt) == "string" and user.suffix_prompt or defaults.suffix_prompt,
-    shortcut = resolve_shortcut(user.shortcut, defaults.shortcut),
     popup_width = type(user.popup_width) == "number" and user.popup_width > 0
       and math.floor(user.popup_width) or defaults.popup_width,
   }
@@ -400,13 +428,14 @@ function M.load_human_edit()
     return vim.deepcopy(defaults)
   end
 
+  warn_legacy_shortcut(parsed)
+
   local user = parsed.human_edit
   if type(user) ~= "table" then
     return vim.deepcopy(defaults)
   end
 
   return {
-    shortcut = resolve_shortcut(user.shortcut, defaults.shortcut),
     command = user.command == false and ""
       or (type(user.command) == "string" and user.command or defaults.command),
   }

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -15,8 +15,15 @@ M.INSERT = "i"
 --- Users can set a shortcut to false (JSON false) or null (JSON null -> vim.NIL) to disable it.
 ---@param value any The shortcut value from config
 ---@return boolean
+local function is_valid_shortcut_string(value)
+  return type(value) == "string" and value:match("%S") ~= nil
+end
+
+--- Check whether a shortcut binding is enabled.
+---@param value any
+---@return boolean
 function M.is_enabled(value)
-  return type(value) == "string" and value ~= ""
+  return is_valid_shortcut_string(value)
 end
 
 --- Default configuration values
@@ -217,22 +224,26 @@ function M.create_default()
 end
 
 --- Read and parse the JSON config file.
---- Returns the parsed table, or nil on any failure.
----@return table?
-local function read_config_json()
+--- Returns the parsed table, or nil on failure.
+---@param opts? table { silent?: boolean }
+---@return table?, string?
+local function read_config_json(opts)
+  opts = opts or {}
   local path = M.config_path
   local stat = vim.uv.fs_stat(path)
-  if not stat then return nil end
+  if not stat then return nil, "missing" end
   local file = io.open(path, "r")
-  if not file then return nil end
+  if not file then return nil, "read_error" end
   local content = file:read("*a")
   file:close()
   local ok, parsed = pcall(vim.json.decode, content)
   if not ok or type(parsed) ~= "table" then
-    vim.notify("Raccoon: failed to parse config.json, using defaults", vim.log.levels.WARN)
-    return nil
+    if not opts.silent then
+      vim.notify("Raccoon: failed to parse config.json, using defaults", vim.log.levels.WARN)
+    end
+    return nil, "parse_error"
   end
-  return parsed
+  return parsed, nil
 end
 
 --- Return val if it is a boolean, otherwise return default.
@@ -286,7 +297,7 @@ end
 ---@return string|false
 local function resolve_shortcut(user_val, default_val)
   if user_val == false then return false end
-  if type(user_val) == "string" and user_val ~= "" then return user_val end
+  if is_valid_shortcut_string(user_val) then return user_val end
   return default_val
 end
 
@@ -303,9 +314,15 @@ local function sanitize_shortcuts(merged, defaults)
     local val = merged[key]
     if type(default_val) == "table" then
       result[key] = sanitize_shortcuts(type(val) == "table" and val or {}, default_val)
+    elseif key == "close" then
+      if is_valid_shortcut_string(val) then
+        result[key] = val
+      else
+        result[key] = default_val
+      end
     elseif val == false then
       result[key] = false
-    elseif type(val) == "string" and val ~= "" then
+    elseif is_valid_shortcut_string(val) then
       result[key] = val
     else
       result[key] = default_val
@@ -439,6 +456,178 @@ function M.get_all_tokens(config)
     end
   end
   return entries
+end
+
+--- Validate `shortcuts.close` in user config.
+--- Missing config file is treated as valid (defaults apply).
+---@return table { valid: boolean, reason?: string, value?: any }
+function M.validate_close_shortcut()
+  local parsed, read_err = read_config_json({ silent = true })
+  if read_err == "missing" then
+    return { valid = true }
+  end
+  if not parsed then
+    return { valid = true }
+  end
+
+  if type(parsed.shortcuts) ~= "table" then
+    return {
+      valid = false,
+      reason = "missing shortcuts object",
+      value = nil,
+    }
+  end
+
+  local close = parsed.shortcuts.close
+  if not is_valid_shortcut_string(close) then
+    return {
+      valid = false,
+      reason = "shortcuts.close must be a non-empty shortcut string",
+      value = close,
+    }
+  end
+
+  return { valid = true, value = close }
+end
+
+local close_warning_shown = false
+
+--- Warn once per Neovim session when shortcuts.close is invalid.
+function M.warn_invalid_close_shortcut_once()
+  if close_warning_shown then
+    return
+  end
+  local check = M.validate_close_shortcut()
+  if check.valid then
+    return
+  end
+  close_warning_shown = true
+  vim.notify(
+    "Raccoon: invalid shortcuts.close in config.json. "
+      .. "Set \"shortcuts\": { \"close\": \"<leader>q\" }. "
+      .. "Most :Raccoon commands are blocked until fixed. Run :Raccoon config.",
+    vim.log.levels.WARN
+  )
+end
+
+--- Best-effort minimal textual patch for required shortcuts.close.
+---@param content string
+---@param parsed table
+---@return string|nil patched, string? err
+local function patch_required_close_shortcut(content, parsed)
+  local desired = "\"<leader>q\""
+  local has_shortcuts = type(parsed.shortcuts) == "table"
+  local has_close_key = has_shortcuts and parsed.shortcuts.close ~= nil
+
+  if has_close_key then
+    local replaced, count = content:gsub('("close"%s*:%s*)([^,%}%]]+)', "%1" .. desired, 1)
+    if count == 1 then
+      return replaced, nil
+    end
+    return nil, "could not safely patch existing shortcuts.close value"
+  end
+
+  if has_shortcuts then
+    local start_i, end_i = content:find('"shortcuts"%s*:%s*%{')
+    if not start_i or not end_i then
+      return nil, "could not locate shortcuts object for close insertion"
+    end
+
+    local line_prefix = content:sub(1, start_i):match("([^\n]*)$") or ""
+    local indent = line_prefix:match("^(%s*)") or ""
+    local multiline = content:find("\n", end_i + 1, true) ~= nil
+    local insertion
+    if multiline then
+      insertion = "\n" .. indent .. "  \"close\": \"<leader>q\","
+    else
+      insertion = " \"close\": \"<leader>q\","
+    end
+    return content:sub(1, end_i) .. insertion .. content:sub(end_i + 1), nil
+  end
+
+  -- No shortcuts object: inject minimal path at root.
+  local close_obj_multiline = '"shortcuts": {\n  "close": "<leader>q"\n}'
+  local close_obj_inline = '"shortcuts": {"close": "<leader>q"}'
+  local insert_pos = content:match("()%s*}$")
+  if not insert_pos then
+    return nil, "could not locate root object close brace for shortcuts insertion"
+  end
+
+  local existing_keys = next(parsed) ~= nil
+  local has_newline = content:find("\n", 1, true) ~= nil
+  local prefix = content:sub(1, insert_pos - 1)
+  local suffix = content:sub(insert_pos)
+
+  local injection
+  if has_newline then
+    if existing_keys then
+      injection = ",\n  " .. close_obj_multiline
+    else
+      injection = "\n  " .. close_obj_multiline .. "\n"
+    end
+  else
+    if existing_keys then
+      injection = "," .. close_obj_inline
+    else
+      injection = close_obj_inline
+    end
+  end
+
+  return prefix .. injection .. suffix, nil
+end
+
+--- Auto-fix invalid/missing shortcuts.close in config.json.
+---@return table
+function M.autofix_close_shortcut()
+  local stat = vim.uv.fs_stat(M.config_path)
+  if not stat then
+    return { changed = false, skipped = true, reason = "missing_config" }
+  end
+
+  local file = io.open(M.config_path, "r")
+  if not file then
+    return { changed = false, skipped = true, reason = "read_error" }
+  end
+  local content = file:read("*a")
+  file:close()
+
+  local ok, parsed = pcall(vim.json.decode, content)
+  if not ok or type(parsed) ~= "table" then
+    return { changed = false, skipped = true, reason = "parse_error" }
+  end
+
+  local old_value = nil
+  if type(parsed.shortcuts) == "table" then
+    old_value = parsed.shortcuts.close
+  end
+  local check = M.validate_close_shortcut()
+  if check.valid then
+    return { changed = false, skipped = true, reason = "already_valid", old_value = old_value }
+  end
+
+  local patched, patch_err = patch_required_close_shortcut(content, parsed)
+  if not patched then
+    return {
+      changed = false,
+      skipped = true,
+      reason = "unsafe_patch",
+      error = patch_err,
+      old_value = old_value,
+    }
+  end
+
+  local out = io.open(M.config_path, "w")
+  if not out then
+    return { changed = false, skipped = true, reason = "write_error", old_value = old_value }
+  end
+  out:write(patched)
+  out:close()
+
+  return {
+    changed = true,
+    old_value = old_value,
+    new_value = "<leader>q",
+  }
 end
 
 return M

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -390,7 +390,8 @@ function M.load_human_edit()
 
   return {
     shortcut = resolve_shortcut(user.shortcut, defaults.shortcut),
-    command = type(user.command) == "string" and user.command or defaults.command,
+    command = user.command == false and ""
+      or (type(user.command) == "string" and user.command or defaults.command),
   }
 end
 

--- a/lua/raccoon/config.lua
+++ b/lua/raccoon/config.lua
@@ -471,11 +471,8 @@ function M.validate_close_shortcut()
   end
 
   if type(parsed.shortcuts) ~= "table" then
-    return {
-      valid = false,
-      reason = "missing shortcuts object",
-      value = nil,
-    }
+    -- No shortcuts object means load_shortcuts() will use defaults (which include a valid close key)
+    return { valid = true }
   end
 
   local close = parsed.shortcuts.close
@@ -520,9 +517,17 @@ local function patch_required_close_shortcut(content, parsed)
   local has_close_key = has_shortcuts and parsed.shortcuts.close ~= nil
 
   if has_close_key then
-    local replaced, count = content:gsub('("close"%s*:%s*)([^,%}%]]+)', "%1" .. desired, 1)
+    -- Scope the replacement to inside the shortcuts object to avoid matching
+    -- a "close" key elsewhere in the config.
+    local sc_start, sc_end = content:find('"shortcuts"%s*:%s*%{')
+    if not sc_start or not sc_end then
+      return nil, "could not locate shortcuts object for close replacement"
+    end
+    local before = content:sub(1, sc_end)
+    local rest = content:sub(sc_end + 1)
+    local replaced, count = rest:gsub('("close"%s*:%s*)([^,%}%]]+)', "%1" .. desired, 1)
     if count == 1 then
-      return replaced, nil
+      return before .. replaced, nil
     end
     return nil, "could not safely patch existing shortcuts.close value"
   end

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -71,6 +71,7 @@ function M.setup(opts)
 
   -- Load shortcuts from config (falls back to defaults gracefully)
   local cfg = require("raccoon.config")
+  cfg.warn_invalid_close_shortcut_once()
   local shortcuts = cfg.load_shortcuts()
   local NORMAL_MODE = cfg.NORMAL
 

--- a/lua/raccoon/keymaps.lua
+++ b/lua/raccoon/keymaps.lua
@@ -9,6 +9,7 @@ local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local diff = require("raccoon.diff")
 local state = require("raccoon.state")
+local windows = require("raccoon.windows")
 
 --- Default keymap options
 local default_opts = { noremap = true, silent = true }
@@ -388,6 +389,7 @@ function M.merge_picker()
       else
         ci_status = format_ci_status(check_runs)
       end
+      local shortcuts = config.load_shortcuts()
 
       -- Create picker buffer with CI status
       local lines = {
@@ -399,7 +401,7 @@ function M.merge_picker()
         "  [2] Squash       - Squash and merge",
         "  [3] Rebase       - Rebase and merge",
         "",
-        "  [q] Cancel",
+        string.format("  [%s] Cancel", shortcuts.close),
       }
 
       local buf = vim.api.nvim_create_buf(false, true)
@@ -420,12 +422,13 @@ function M.merge_picker()
         title = " Merge PR ",
         title_pos = "center",
       })
+      windows.mark(win)
 
       -- Highlight the title and CI status
       vim.api.nvim_buf_call(buf, function()
         vim.fn.matchadd("Title", "^Select merge method.*")
         vim.fn.matchadd("Number", "\\[1\\]\\|\\[2\\]\\|\\[3\\]")
-        vim.fn.matchadd("Comment", "\\[q\\]")
+        vim.fn.matchadd("Comment", "^  \\[.*\\] Cancel$")
         -- Highlight CI status based on content
         if ci_status:find("failed") then
           vim.fn.matchadd("ErrorMsg", "CI:.*failed.*")
@@ -453,17 +456,13 @@ function M.merge_picker()
         elseif cursor_line == 7 then do_merge("rebase")
         end
       end, { buffer = buf, noremap = true, silent = true })
-      local shortcuts = config.load_shortcuts()
       local close_win = function()
         if vim.api.nvim_win_is_valid(win) then
           vim.api.nvim_win_close(win, true)
         end
       end
       local close_opts = { buffer = buf, noremap = true, silent = true, nowait = true }
-      if config.is_enabled(shortcuts.close) then
-        vim.keymap.set(NORMAL_MODE, shortcuts.close, close_win, close_opts)
-      end
-      vim.keymap.set(NORMAL_MODE, "<Esc>", close_win, close_opts)
+      vim.keymap.set(NORMAL_MODE, shortcuts.close, close_win, close_opts)
     end)
   end)
 end

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -888,7 +888,9 @@ local function exit_local_mode(opts)
   end
 
   local_state = make_initial_state()
-  vim.notify("Exited local commit viewer", vim.log.levels.INFO)
+  if not opts.silent then
+    vim.notify("Exited local commit viewer", vim.log.levels.INFO)
+  end
 end
 
 --- Toggle local commit viewer mode
@@ -901,7 +903,7 @@ function M.toggle()
 end
 
 --- Exit local commit viewer mode (safe to call when not active)
----@param opts table|nil { resume_pr?: boolean }
+---@param opts table|nil { resume_pr?: boolean, silent?: boolean }
 function M.exit_local_mode(opts)
   if not local_state.active then
     local_state = make_initial_state()

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -667,11 +667,16 @@ function M.open_pr(url)
   end)
 end
 
---- Close the current PR review session
-function M.close_pr()
+--- Close the current PR review session.
+---@param opts? table { silent_success?: boolean, suppress_empty_warning?: boolean }
+---@return boolean closed
+function M.close_pr(opts)
+  opts = opts or {}
   if not state.is_active() then
-    vim.notify("No active PR review session", vim.log.levels.WARN)
-    return
+    if not opts.suppress_empty_warning then
+      vim.notify("No active PR review session", vim.log.levels.WARN)
+    end
+    return false
   end
 
   -- Stop sync timer
@@ -687,7 +692,65 @@ function M.close_pr()
   keymaps.clear()
 
   state.stop()
-  vim.notify("PR review session closed", vim.log.levels.INFO)
+  if not opts.silent_success then
+    vim.notify("PR review session closed", vim.log.levels.INFO)
+  end
+  return true
+end
+
+local exit_in_progress = false
+
+--- Close all active raccoon sessions and popups.
+--- This is used by :Raccoon exit.
+---@return boolean did_exit
+function M.close_all_sessions()
+  if exit_in_progress then
+    return false
+  end
+  exit_in_progress = true
+
+  local commits = require("raccoon.commits")
+  local localcommits = require("raccoon.localcommits")
+  local parallel_agents = require("raccoon.parallel_agents")
+  local ui = require("raccoon.ui")
+
+  local has_any = state.is_active()
+    or state.is_commit_mode()
+    or localcommits.is_active()
+    or parallel_agents.get_running_count() > 0
+    or ui.has_open_windows()
+
+  if not has_any then
+    vim.notify("Nothing to exit. Use :Raccoon prs or :Raccoon local.", vim.log.levels.WARN)
+    exit_in_progress = false
+    return false
+  end
+
+  local kill_summary = parallel_agents.kill_all()
+
+  if localcommits.is_active() then
+    localcommits.exit_local_mode({ resume_pr = false, silent = true })
+  end
+
+  if state.is_commit_mode() then
+    commits.exit_commit_mode({ resume_sync = false, silent = true })
+  end
+
+  if state.is_active() then
+    M.close_pr({ silent_success = true, suppress_empty_warning = true })
+  end
+
+  ui.close_all_windows()
+
+  if kill_summary and kill_summary.errors and #kill_summary.errors > 0 then
+    vim.notify(
+      "Raccoon exit: some agent jobs could not be stopped:\n" .. table.concat(kill_summary.errors, "\n"),
+      vim.log.levels.WARN
+    )
+  end
+
+  exit_in_progress = false
+  return true
 end
 
 return M

--- a/lua/raccoon/open.lua
+++ b/lua/raccoon/open.lua
@@ -709,48 +709,55 @@ function M.close_all_sessions()
   end
   exit_in_progress = true
 
-  local commits = require("raccoon.commits")
-  local localcommits = require("raccoon.localcommits")
-  local parallel_agents = require("raccoon.parallel_agents")
-  local ui = require("raccoon.ui")
+  local ok, did_exit_or_err = xpcall(function()
+    local commits = require("raccoon.commits")
+    local localcommits = require("raccoon.localcommits")
+    local parallel_agents = require("raccoon.parallel_agents")
+    local ui = require("raccoon.ui")
 
-  local has_any = state.is_active()
-    or state.is_commit_mode()
-    or localcommits.is_active()
-    or parallel_agents.get_running_count() > 0
-    or ui.has_open_windows()
+    local has_any = state.is_active()
+      or state.is_commit_mode()
+      or localcommits.is_active()
+      or parallel_agents.get_running_count() > 0
+      or ui.has_open_windows()
 
-  if not has_any then
-    vim.notify("Nothing to exit. Use :Raccoon prs or :Raccoon local.", vim.log.levels.WARN)
-    exit_in_progress = false
-    return false
-  end
+    if not has_any then
+      vim.notify("Nothing to exit. Use :Raccoon prs or :Raccoon local.", vim.log.levels.WARN)
+      return false
+    end
 
-  local kill_summary = parallel_agents.kill_all()
+    local kill_summary = parallel_agents.kill_all()
 
-  if localcommits.is_active() then
-    localcommits.exit_local_mode({ resume_pr = false, silent = true })
-  end
+    if localcommits.is_active() then
+      localcommits.exit_local_mode({ resume_pr = false, silent = true })
+    end
 
-  if state.is_commit_mode() then
-    commits.exit_commit_mode({ resume_sync = false, silent = true })
-  end
+    if state.is_commit_mode() then
+      commits.exit_commit_mode({ resume_sync = false, silent = true })
+    end
 
-  if state.is_active() then
-    M.close_pr({ silent_success = true, suppress_empty_warning = true })
-  end
+    if state.is_active() then
+      M.close_pr({ silent_success = true, suppress_empty_warning = true })
+    end
 
-  ui.close_all_windows()
+    ui.close_all_windows()
 
-  if kill_summary and kill_summary.errors and #kill_summary.errors > 0 then
-    vim.notify(
-      "Raccoon exit: some agent jobs could not be stopped:\n" .. table.concat(kill_summary.errors, "\n"),
-      vim.log.levels.WARN
-    )
-  end
+    if kill_summary and kill_summary.errors and #kill_summary.errors > 0 then
+      vim.notify(
+        "Raccoon exit: some agent jobs could not be stopped:\n" .. table.concat(kill_summary.errors, "\n"),
+        vim.log.levels.WARN
+      )
+    end
+
+    return true
+  end, debug.traceback)
 
   exit_in_progress = false
-  return true
+  if not ok then
+    vim.notify("Raccoon exit failed:\n" .. tostring(did_exit_or_err), vim.log.levels.ERROR)
+    return false
+  end
+  return did_exit_or_err
 end
 
 return M

--- a/lua/raccoon/parallel_agents.lua
+++ b/lua/raccoon/parallel_agents.lua
@@ -3,9 +3,12 @@
 local M = {}
 
 local config = require("raccoon.config")
+local windows = require("raccoon.windows")
 
 --- Active agents: array of {job_id, task_name}
 local agents = {}
+local suppress_exit_notifications = false
+local kill_in_progress = false
 
 --- Build the prompt string from dispatch opts and user task text
 ---@param opts table Dispatch context
@@ -71,7 +74,7 @@ local function open_task_input(on_submit, view_state, popup_width)
   local col = math.floor((vim.o.columns - width) / 2)
 
   local save_key = config.is_enabled(shortcuts.comment_save) and shortcuts.comment_save or "<leader>s"
-  local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "q"
+  local close_key = shortcuts.close
   local title = string.format(" Agent Task (%s=send, %s=cancel) ", save_key, close_key)
 
   -- Set truthy sentinel before open_win so the WinEnter focus lock sees it
@@ -90,6 +93,7 @@ local function open_task_input(on_submit, view_state, popup_width)
     title_pos = "center",
     zindex = 200,
   })
+  windows.mark(win)
 
   if view_state then view_state.popup_win = win end
 
@@ -118,11 +122,8 @@ local function open_task_input(on_submit, view_state, popup_width)
   if config.is_enabled(shortcuts.comment_save) then
     vim.keymap.set("n", shortcuts.comment_save, submit, buf_opts)
   end
-  vim.keymap.set("n", "q", close, buf_opts)
-  vim.keymap.set("i", "<C-c>", close, buf_opts)
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set("n", shortcuts.close, close, buf_opts)
-  end
+  vim.keymap.set("n", shortcuts.close, close, buf_opts)
+  vim.keymap.set("i", shortcuts.close, close, buf_opts)
 end
 
 --- Dispatch an agent process
@@ -193,6 +194,10 @@ function M.dispatch(opts)
             end
           end
 
+          if suppress_exit_notifications then
+            return
+          end
+
           local level = exit_code == 0 and vim.log.levels.INFO or vim.log.levels.WARN
           local msg = string.format("Agent finished (exit %d): %s", exit_code, task_text)
           if exit_code ~= 0 and #stderr_lines > 0 then
@@ -212,6 +217,44 @@ function M.dispatch(opts)
       vim.notify("Failed to start agent: command not executable", vim.log.levels.ERROR)
     end
   end, opts.view_state, pa_cfg.popup_width)
+end
+
+--- Kill all running agent jobs and clear tracker.
+--- Best effort: continues on individual failures.
+---@return table summary {requested: number, stopped: number, errors: string[], in_progress?: boolean}
+function M.kill_all()
+  if kill_in_progress then
+    return { requested = 0, stopped = 0, errors = {}, in_progress = true }
+  end
+
+  kill_in_progress = true
+  suppress_exit_notifications = true
+
+  local running = agents
+  agents = {}
+
+  local stopped = 0
+  local errors = {}
+
+  for _, agent in ipairs(running) do
+    local ok, result = pcall(vim.fn.jobstop, agent.job_id)
+    if not ok then
+      table.insert(errors, string.format("job %d: %s", agent.job_id, tostring(result)))
+    elseif result == 1 then
+      stopped = stopped + 1
+    elseif result ~= 0 and result ~= -1 then
+      table.insert(errors, string.format("job %d: unexpected jobstop result %s", agent.job_id, tostring(result)))
+    end
+  end
+
+  suppress_exit_notifications = false
+  kill_in_progress = false
+
+  return {
+    requested = #running,
+    stopped = stopped,
+    errors = errors,
+  }
 end
 
 ---@private

--- a/lua/raccoon/parallel_agents.lua
+++ b/lua/raccoon/parallel_agents.lua
@@ -236,19 +236,25 @@ function M.kill_all()
   local stopped = 0
   local errors = {}
 
-  for _, agent in ipairs(running) do
-    local ok, result = pcall(vim.fn.jobstop, agent.job_id)
-    if not ok then
-      table.insert(errors, string.format("job %d: %s", agent.job_id, tostring(result)))
-    elseif result == 1 then
-      stopped = stopped + 1
-    elseif result ~= 0 and result ~= -1 then
-      table.insert(errors, string.format("job %d: unexpected jobstop result %s", agent.job_id, tostring(result)))
+  local ok, err = xpcall(function()
+    for _, agent in ipairs(running) do
+      local stop_ok, result = pcall(vim.fn.jobstop, agent.job_id)
+      if not stop_ok then
+        table.insert(errors, string.format("job %s: %s", tostring(agent.job_id), tostring(result)))
+      elseif result == 1 then
+        stopped = stopped + 1
+      elseif result ~= 0 and result ~= -1 then
+        table.insert(errors, string.format("job %s: unexpected jobstop result %s", tostring(agent.job_id), tostring(result)))
+      end
     end
-  end
+  end, debug.traceback)
 
   suppress_exit_notifications = false
   kill_in_progress = false
+
+  if not ok then
+    table.insert(errors, "kill_all failed: " .. tostring(err))
+  end
 
   return {
     requested = #running,

--- a/lua/raccoon/review.lua
+++ b/lua/raccoon/review.lua
@@ -8,6 +8,7 @@ local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local INSERT_MODE = config.INSERT
 local state = require("raccoon.state")
+local windows = require("raccoon.windows")
 
 --- Review event types
 M.events = {
@@ -71,6 +72,7 @@ function M.show_submit_ui()
 
   local pr = state.get_pr()
   local pending = comments.get_pending_comments()
+  local shortcuts = config.load_shortcuts()
 
   -- Build prompt lines
   local lines = {
@@ -85,7 +87,7 @@ function M.show_submit_ui()
     "  [r] Request changes",
     "  [c] Comment only",
     "",
-    "  [q] Cancel",
+    string.format("  [%s] Cancel", shortcuts.close),
   }
 
   -- Create buffer
@@ -108,6 +110,7 @@ function M.show_submit_ui()
     title = " Submit Review ",
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Handle key presses
   local function handle_selection(event)
@@ -127,15 +130,7 @@ function M.show_submit_ui()
     handle_selection(M.events.COMMENT)
   end, { buffer = buf, noremap = true, silent = true })
 
-  local shortcuts = config.load_shortcuts()
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-      vim.notify("Review cancelled", vim.log.levels.INFO)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
-
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
     vim.notify("Review cancelled", vim.log.levels.INFO)
   end, { buffer = buf, noremap = true, silent = true })
@@ -166,6 +161,7 @@ function M.prompt_review_body(event)
   -- Create floating window
   local width = 70
   local height = 15
+  local shortcuts = config.load_shortcuts()
 
   local win = vim.api.nvim_open_win(buf, true, {
     relative = "editor",
@@ -175,9 +171,10 @@ function M.prompt_review_body(event)
     height = height,
     style = "minimal",
     border = "rounded",
-    title = string.format(" %s (Ctrl-S to submit, q to cancel) ", event_name),
+    title = string.format(" %s (Ctrl-S to submit, %s to cancel) ", event_name, shortcuts.close),
     title_pos = "center",
   })
+  windows.mark(win)
 
   -- Move cursor to empty line and start insert
   vim.api.nvim_win_set_cursor(win, { 5, 0 })
@@ -214,13 +211,10 @@ function M.prompt_review_body(event)
   end, { buffer = buf, noremap = true, silent = true })
 
   -- Cancel in normal mode
-  local shortcuts = config.load_shortcuts()
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-      vim.notify("Review cancelled", vim.log.levels.INFO)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
+    vim.api.nvim_win_close(win, true)
+    vim.notify("Review cancelled", vim.log.levels.INFO)
+  end, { buffer = buf, noremap = true, silent = true })
 end
 
 --- Quick approve - approve without comments
@@ -310,15 +304,10 @@ function M.show_status()
     title = " Review Status ",
     title_pos = "center",
   })
+  windows.mark(win)
 
   local shortcuts = config.load_shortcuts()
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-    end, { buffer = buf, noremap = true, silent = true })
-  end
-
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
   end, { buffer = buf, noremap = true, silent = true })
 end

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -732,6 +732,8 @@ local commit_mode_descriptions = {
   exit = "Exit commit viewer",
   maximize_prefix = "Maximize cell (+ number, f=files, c=commits)",
   browse_files = "Browse commit files",
+  dispatch_agent = "Dispatch agent (maximized diff)",
+  human_edit = "Edit file (maximized diff)",
 }
 
 --- Display groups for the shortcuts help window
@@ -748,7 +750,7 @@ local shortcut_groups = {
   { title = "Comment Editor", keys = { "comment_save", "comment_resolve", "comment_unresolve" } },
   {
     title = "Commit Viewer", nested = "commit_mode",
-    keys = { "next_page", "prev_page", "next_page_alt", "exit", "maximize_prefix", "browse_files" },
+    keys = { "next_page", "prev_page", "next_page_alt", "exit", "maximize_prefix", "browse_files", "dispatch_agent", "human_edit" },
   },
   { title = "Common", keys = { "close" } },
 }

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -7,6 +7,7 @@ local config = require("raccoon.config")
 local NORMAL_MODE = config.NORMAL
 local state = require("raccoon.state")
 local localcommits = require("raccoon.localcommits")
+local windows = require("raccoon.windows")
 
 --- Current floating window state
 M.state = {
@@ -61,6 +62,7 @@ function M.create_floating_window(opts)
   -- Create window
   local enter = opts.enter ~= false
   local win = vim.api.nvim_open_win(buf, enter, win_opts)
+  windows.mark(win)
 
   -- Set window options
   vim.wo[win].cursorline = true
@@ -154,8 +156,7 @@ local function render_pr_list(prs, buf_width, shortcuts)
     table.insert(lines, "")
     table.insert(lines, "  No open pull requests found")
     table.insert(lines, "")
-    local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "Esc"
-    table.insert(lines, string.format("  Press 'r' to refresh, '%s' to close", close_key))
+    table.insert(lines, string.format("  Press 'r' to refresh, '%s' to close", shortcuts.close))
   else
     -- Group by repo (preserve order with array)
     local by_repo = {}
@@ -211,8 +212,7 @@ local function render_pr_list(prs, buf_width, shortcuts)
 
   -- Footer separator
   table.insert(lines, string.rep("─", buf_width - 4))
-  local close_key = config.is_enabled(shortcuts.close) and shortcuts.close or "Esc"
-  table.insert(lines, string.format(" Enter: open │ %s: close │ r: refresh │ j/k: navigate", close_key))
+  table.insert(lines, string.format(" Enter: open │ %s: close │ r: refresh │ j/k: navigate", shortcuts.close))
 
   return lines, highlights
 end
@@ -388,10 +388,7 @@ function M.show_pr_list()
   end, opts)
 
   -- Close keymaps
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function() M.close_pr_list() end, opts)
-  end
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function() M.close_pr_list() end, opts)
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function() M.close_pr_list() end, opts)
 
   -- Refresh on r
   vim.keymap.set(NORMAL_MODE, "r", function() M.refresh_pr_list() end, opts)
@@ -700,13 +697,7 @@ function M.show_description()
   -- Close keymaps (also clear state)
   local shortcuts = config.load_shortcuts()
   local opts = { buffer = buf, noremap = true, silent = true }
-  if config.is_enabled(shortcuts.close) then
-    vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
-      vim.api.nvim_win_close(win, true)
-      M.state.description_win = nil
-    end, opts)
-  end
-  vim.keymap.set(NORMAL_MODE, "<Esc>", function()
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, function()
     vim.api.nvim_win_close(win, true)
     M.state.description_win = nil
   end, opts)
@@ -825,23 +816,37 @@ function M.show_shortcuts()
     pcall(vim.api.nvim_buf_add_highlight, buf, ns, hl.hl, hl.line, 0, -1)
   end
 
-  -- Close on any keystroke
+  -- Close on configured close shortcut
   local function close_win()
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_win_close(win, true)
     end
   end
 
-  local key_opts = { buffer = buf, noremap = true, silent = true, nowait = true }
-  -- Map all printable chars
-  local chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`~!@#$%^&*()-_=+[]{}|;:',.<>?/ "
-  for i = 1, #chars do
-    pcall(vim.keymap.set, NORMAL_MODE, chars:sub(i, i), close_win, key_opts)
+  local key_opts = { buffer = buf, noremap = true, silent = true }
+  vim.keymap.set(NORMAL_MODE, shortcuts.close, close_win, key_opts)
+end
+
+--- Return whether any raccoon UI window is currently open.
+---@return boolean
+function M.has_open_windows()
+  if M.state.win and vim.api.nvim_win_is_valid(M.state.win) then
+    return true
   end
-  -- Map special keys
-  for _, key in ipairs({ "<CR>", "<Esc>", "<Space>", "<BS>", "<Tab>", "<leader>" }) do
-    pcall(vim.keymap.set, NORMAL_MODE, key, close_win, key_opts)
+  if M.state.description_win and vim.api.nvim_win_is_valid(M.state.description_win) then
+    return true
   end
+  return windows.has_open()
+end
+
+--- Close all raccoon floating windows/popups.
+function M.close_all_windows()
+  M.close_pr_list()
+  if M.state.description_win and vim.api.nvim_win_is_valid(M.state.description_win) then
+    pcall(vim.api.nvim_win_close, M.state.description_win, true)
+  end
+  M.state.description_win = nil
+  windows.close_all()
 end
 
 return M

--- a/lua/raccoon/windows.lua
+++ b/lua/raccoon/windows.lua
@@ -1,0 +1,49 @@
+---@class RaccoonWindows
+---Window tracking helpers for raccoon-owned floating windows.
+local M = {}
+
+local RACCOON_WIN_VAR = "raccoon_window"
+
+---Mark a window as owned by raccoon.
+---@param win number|nil
+function M.mark(win)
+  if not win or not vim.api.nvim_win_is_valid(win) then return end
+  pcall(vim.api.nvim_win_set_var, win, RACCOON_WIN_VAR, true)
+end
+
+---Check whether a window is marked as raccoon-owned.
+---@param win number
+---@return boolean
+function M.is_marked(win)
+  if not win or not vim.api.nvim_win_is_valid(win) then return false end
+  local ok, val = pcall(vim.api.nvim_win_get_var, win, RACCOON_WIN_VAR)
+  return ok and val == true
+end
+
+---Return whether any raccoon-owned floating windows are open.
+---@return boolean
+function M.has_open()
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if M.is_marked(win) then
+      return true
+    end
+  end
+  return false
+end
+
+---Close all raccoon-owned floating windows.
+---@return number closed_count
+function M.close_all()
+  local closed = 0
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if M.is_marked(win) then
+      local ok = pcall(vim.api.nvim_win_close, win, true)
+      if ok then
+        closed = closed + 1
+      end
+    end
+  end
+  return closed
+end
+
+return M

--- a/parallel_agents_docs.md
+++ b/parallel_agents_docs.md
@@ -11,8 +11,12 @@ Add a `parallel_agents` section to `~/.config/raccoon/config.json`:
   "parallel_agents": {
     "enabled": true,
     "command": "claude --dangerously-skip-permissions -p <PROMPT>",
-    "suffix_prompt": "When done, create a commit with a description of the changes and how they address the original request.",
-    "shortcut": "<leader>aa"
+    "suffix_prompt": "When done, create a commit with a description of the changes and how they address the original request."
+  },
+  "shortcuts": {
+    "commit_mode": {
+      "dispatch_agent": "<leader>aa"
+    }
   }
 }
 ```
@@ -22,10 +26,10 @@ Add a `parallel_agents` section to `~/.config/raccoon/config.json`:
 | `enabled` | boolean | `false` | Enable the feature. When false, no keymaps are registered. |
 | `command` | string | `""` | Shell command template. Must contain `<PROMPT>` as a placeholder — it will be replaced with the assembled prompt (shell-escaped). |
 | `suffix_prompt` | string | `""` | Text appended to every agent prompt. Use this for instructions like "always commit and push when done". |
-| `shortcut` | string or false | `"<leader>aa"` | Keymap to trigger agent dispatch in maximized diff view. Set to `false` to disable. |
 | `popup_width` | number | `70` | Width of the task input popup in columns. Clamped to terminal width minus 4. |
 
 The `command` field is a shell string executed via `sh -c`. The `<PROMPT>` placeholder is replaced with a shell-escaped prompt containing the user's task description, commit context, and optionally the visual selection.
+The keybinding is configured separately under `shortcuts.commit_mode.dispatch_agent`. Set it to `false` to disable the maximize-view shortcut while keeping the feature available in config.
 
 ### Command template examples
 
@@ -43,8 +47,8 @@ For `claude`, use either `--dangerously-skip-permissions` or `--allowedTools <to
 1. Open local commit viewer (`:Raccoon local`)
 2. Select **Current changes** in the sidebar and maximize a diff cell (`<leader>m1`, `<leader>m2`, etc.) or browse files and press Enter
 3. In the maximized diff view:
-   - **Normal mode**: Press the shortcut (default `<leader>aa`), type your task, press `<leader>s` to send
-   - **Visual mode**: Select lines of interest, press the shortcut, type your task, press `<leader>s` to send
+   - **Normal mode**: Press the dispatch shortcut (default `shortcuts.commit_mode.dispatch_agent = <leader>aa`), type your task, press `<leader>s` to send
+   - **Visual mode**: Select lines of interest, press the dispatch shortcut, type your task, press `<leader>s` to send
 
 The agent receives:
 - Your task description

--- a/parallel_agents_docs.md
+++ b/parallel_agents_docs.md
@@ -1,6 +1,6 @@
 # Parallel Agents
 
-Dispatch fire-and-forget CLI agent processes (e.g. `claude -p`, `amp -x`) directly from the commit viewer's maximized diff view. Review a commit diff, optionally select code, and fire off an agent with context automatically injected. Multiple agents can run in parallel.
+Dispatch fire-and-forget CLI agent processes (e.g. `claude -p`, `amp -x`) directly from maximized **`Current changes`** diffs in local commit viewer mode. Review a diff, optionally select code, and fire off an agent with context automatically injected. Multiple agents can run in parallel.
 
 ## Configuration
 
@@ -40,8 +40,8 @@ For `claude`, use either `--dangerously-skip-permissions` or `--allowedTools <to
 
 ## Usage
 
-1. Open the commit viewer (`:Raccoon commits` or `:Raccoon local`)
-2. Navigate to a commit and maximize a diff cell (`<leader>m1`, `<leader>m2`, etc.) or browse files and press Enter
+1. Open local commit viewer (`:Raccoon local`)
+2. Select **Current changes** in the sidebar and maximize a diff cell (`<leader>m1`, `<leader>m2`, etc.) or browse files and press Enter
 3. In the maximized diff view:
    - **Normal mode**: Press the shortcut (default `<leader>aa`), type your task, press `<leader>s` to send
    - **Visual mode**: Select lines of interest, press the shortcut, type your task, press `<leader>s` to send
@@ -91,5 +91,6 @@ Multiple agents can run simultaneously on the same repo. Since they share the wo
 
 - The feature is completely inert when `enabled` is `false` (the default) — no keymaps are registered and no agent processes are spawned
 - Agents run as child processes of Neovim — closing Neovim will terminate running agents, so ensure agents complete before exiting
+- `:Raccoon exit` hard-stops all running parallel-agent jobs as part of global teardown
 - The shortcut works in both normal and visual mode, making it the first visual-mode keymap in the commit viewer
 - The feature is only available in local commit viewer mode (`:Raccoon local`), not in PR commit viewer mode

--- a/parallel_agents_docs.md
+++ b/parallel_agents_docs.md
@@ -81,9 +81,7 @@ The `is_active()` function returns `true` while agents are running, even without
 
 ## Where agents run
 
-**PR mode**: Agents run in the shallow clone at `{clone_root}/{owner}/{repo}/pr-{number}`, checked out to the PR branch. Pushing from here updates the PR directly — making a commit-focused `suffix_prompt` a natural fit for review-driven fixes.
-
-**Local mode**: Agents run in your working directory (the git root). Changes happen in place.
+Agents run in your working directory (the git root). Changes happen in place. This feature is only available in **local mode** (`:Raccoon local`) where files exist on disk.
 
 ## Concurrent access
 
@@ -94,4 +92,4 @@ Multiple agents can run simultaneously on the same repo. Since they share the wo
 - The feature is completely inert when `enabled` is `false` (the default) — no keymaps are registered and no agent processes are spawned
 - Agents run as child processes of Neovim — closing Neovim will terminate running agents, so ensure agents complete before exiting
 - The shortcut works in both normal and visual mode, making it the first visual-mode keymap in the commit viewer
-- The feature works in both PR commit viewer and local commit viewer modes
+- The feature is only available in local commit viewer mode (`:Raccoon local`), not in PR commit viewer mode

--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -4,13 +4,175 @@ if vim.g.loaded_raccoon then
 end
 vim.g.loaded_raccoon = 1
 
+local function format_config_value(value)
+  if value == nil or value == vim.NIL then
+    return "null"
+  end
+  if type(value) == "string" then
+    return string.format("%q", value)
+  end
+  return tostring(value)
+end
+
+local function create_default_config(config_path)
+  local clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos")
+  local home = vim.fn.expand("~")
+  clone_root = clone_root:gsub("^" .. vim.pesc(home), "~")
+  local default_config = string.format([[{
+  "github_host": "github.com",
+  "tokens": {
+    "your-username": "ghp_xxxxxxxxxxxxxxxxxxxx"
+  },
+  "clone_root": "%s",
+  "pull_changes_interval": 300,
+  "commit_viewer": {
+    "grid": { "rows": 2, "cols": 2 },
+    "base_commits_count": 20
+  },
+  "shortcuts": {
+    "pr_list": "<leader>pr",
+    "show_shortcuts": "<leader>?",
+    "next_point": "<leader>j",
+    "prev_point": "<leader>k",
+    "next_file": "<leader>nf",
+    "prev_file": "<leader>pf",
+    "next_thread": "<leader>nt",
+    "prev_thread": "<leader>pt",
+    "comment": "<leader>c",
+    "description": "<leader>dd",
+    "list_comments": "<leader>ll",
+    "merge": "<leader>rr",
+    "commit_viewer": "<leader>cm",
+    "comment_save": "<leader>s",
+    "comment_resolve": "<leader>r",
+    "comment_unresolve": "<leader>u",
+    "close": "<leader>q",
+    "commit_mode": {
+      "next_page": "<leader>j",
+      "prev_page": "<leader>k",
+      "next_page_alt": "<leader>l",
+      "exit": "<leader>cm",
+      "maximize_prefix": "<leader>m",
+      "browse_files": "<leader>f"
+    }
+  }
+}]], clone_root)
+  local file = io.open(config_path, "w")
+  if file then
+    file:write(default_config)
+    file:close()
+  end
+end
+
+local function open_config_with_autofix()
+  local cfg = require("raccoon.config")
+  local config_path = cfg.config_path
+  local config_dir = vim.fn.fnamemodify(config_path, ":h")
+  if vim.fn.isdirectory(config_dir) == 0 then
+    vim.fn.mkdir(config_dir, "p")
+  end
+
+  if vim.fn.filereadable(config_path) == 0 then
+    create_default_config(config_path)
+    vim.cmd("edit " .. config_path)
+    return
+  end
+
+  local fix = cfg.autofix_close_shortcut()
+  if fix.changed then
+    vim.notify(
+      string.format(
+        "Raccoon config auto-fix: shortcuts.close %s -> %q",
+        format_config_value(fix.old_value),
+        fix.new_value
+      ),
+      vim.log.levels.WARN
+    )
+  elseif fix.reason == "parse_error" then
+    vim.notify(
+      "Raccoon: config.json has invalid JSON; skipped auto-fix for shortcuts.close",
+      vim.log.levels.WARN
+    )
+  elseif fix.reason == "unsafe_patch" then
+    vim.notify(
+      "Raccoon: could not safely auto-fix shortcuts.close in-place; open and update it manually.",
+      vim.log.levels.WARN
+    )
+  end
+
+  vim.cmd("edit " .. config_path)
+end
+
+local known_subcommands = {
+  open = true,
+  prs = true,
+  list = true,
+  description = true,
+  desc = true,
+  sync = true,
+  update = true,
+  refresh = true,
+  exit = true,
+  merge = true,
+  squash = true,
+  rebase = true,
+  shortcuts = true,
+  commits = true,
+  ["local"] = true,
+  config = true,
+}
+
+local function validate_required_close_or_warn(subcommand)
+  if subcommand == "config" or subcommand == "exit" then
+    return true
+  end
+
+  local cfg = require("raccoon.config")
+  local check = cfg.validate_close_shortcut()
+  if check.valid then
+    return true
+  end
+
+  local msg = string.format(
+    "Cannot run :Raccoon %s because shortcuts.close is invalid (%s).\n"
+      .. "Current value: %s\n"
+      .. "Fix config to include: \"shortcuts\": { \"close\": \"<leader>q\" }\n"
+      .. "Run :Raccoon config to auto-fix.",
+    subcommand,
+    check.reason or "invalid value",
+    format_config_value(check.value)
+  )
+  vim.notify(msg, vim.log.levels.ERROR)
+  return false
+end
+
 -- Create the Raccoon command
 vim.api.nvim_create_user_command("Raccoon", function(opts)
   local args = opts.fargs
   local subcommand = args[1]
 
   if not subcommand then
-    vim.notify("Usage: :Raccoon <prs|list|description|sync|merge|local|close>", vim.log.levels.WARN)
+    vim.notify("Usage: :Raccoon <prs|list|description|sync|merge|local|exit>", vim.log.levels.WARN)
+    return
+  end
+
+  if not known_subcommands[subcommand] then
+    vim.notify("Unknown subcommand: " .. subcommand, vim.log.levels.ERROR)
+    return
+  end
+
+  if subcommand == "config" then
+    open_config_with_autofix()
+    return
+  end
+
+  if subcommand == "exit" then
+    local pr_open = require("raccoon.open")
+    pr_open.close_all_sessions()
+    return
+  end
+
+  if not validate_required_close_or_warn(subcommand) then
     return
   end
 
@@ -45,9 +207,6 @@ vim.api.nvim_create_user_command("Raccoon", function(opts)
   elseif subcommand == "sync" or subcommand == "update" or subcommand == "refresh" then
     local pr_open = require("raccoon.open")
     pr_open.sync()
-  elseif subcommand == "close" then
-    local pr_open = require("raccoon.open")
-    pr_open.close_pr()
   elseif subcommand == "merge" or subcommand == "squash" or subcommand == "rebase" then
     local state = require("raccoon.state")
     local api = require("raccoon.api")
@@ -123,67 +282,6 @@ vim.api.nvim_create_user_command("Raccoon", function(opts)
   elseif subcommand == "local" then
     local localcommits = require("raccoon.localcommits")
     localcommits.toggle()
-  elseif subcommand == "config" then
-    -- Open config file in current buffer
-    local config_path = require("raccoon.config").config_path
-    -- Create directory if it doesn't exist
-    local config_dir = vim.fn.fnamemodify(config_path, ":h")
-    if vim.fn.isdirectory(config_dir) == 0 then
-      vim.fn.mkdir(config_dir, "p")
-    end
-    -- Create default config if file doesn't exist
-    if vim.fn.filereadable(config_path) == 0 then
-      local clone_root = vim.fs.joinpath(vim.fn.stdpath("data"), "raccoon", "repos")
-      local home = vim.fn.expand("~")
-      clone_root = clone_root:gsub("^" .. vim.pesc(home), "~")
-      local default_config = string.format([[{
-  "github_host": "github.com",
-  "tokens": {
-    "your-username": "ghp_xxxxxxxxxxxxxxxxxxxx"
-  },
-  "clone_root": "%s",
-  "pull_changes_interval": 300,
-  "commit_viewer": {
-    "grid": { "rows": 2, "cols": 2 },
-    "base_commits_count": 20
-  },
-  "shortcuts": {
-    "pr_list": "<leader>pr",
-    "show_shortcuts": "<leader>?",
-    "next_point": "<leader>j",
-    "prev_point": "<leader>k",
-    "next_file": "<leader>nf",
-    "prev_file": "<leader>pf",
-    "next_thread": "<leader>nt",
-    "prev_thread": "<leader>pt",
-    "comment": "<leader>c",
-    "description": "<leader>dd",
-    "list_comments": "<leader>ll",
-    "merge": "<leader>rr",
-    "commit_viewer": "<leader>cm",
-    "comment_save": "<leader>s",
-    "comment_resolve": "<leader>r",
-    "comment_unresolve": "<leader>u",
-    "close": "<leader>q",
-    "commit_mode": {
-      "next_page": "<leader>j",
-      "prev_page": "<leader>k",
-      "next_page_alt": "<leader>l",
-      "exit": "<leader>cm",
-      "maximize_prefix": "<leader>m",
-      "browse_files": "<leader>f"
-    }
-  }
-}]], clone_root)
-      local file = io.open(config_path, "w")
-      if file then
-        file:write(default_config)
-        file:close()
-      end
-    end
-    vim.cmd("edit " .. config_path)
-  else
-    vim.notify("Unknown subcommand: " .. subcommand, vim.log.levels.ERROR)
   end
 end, {
   nargs = "*",
@@ -192,8 +290,8 @@ end, {
     if #args == 2 then
       -- Complete subcommands
       return {
-        "prs", "list", "description", "sync", "merge", "squash",
-        "rebase", "commits", "local", "shortcuts", "close", "config",
+        "open", "prs", "list", "description", "desc", "sync", "update", "refresh",
+        "merge", "squash", "rebase", "commits", "local", "shortcuts", "exit", "config",
       }
     end
     return {}

--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -57,11 +57,14 @@ local function create_default_config(config_path)
     }
   }
 }]], clone_root)
-  local file = io.open(config_path, "w")
-  if file then
-    file:write(default_config)
-    file:close()
+  local file, err = io.open(config_path, "w")
+  if not file then
+    vim.notify("Raccoon: failed to create config: " .. (err or "unknown error"), vim.log.levels.ERROR)
+    return false
   end
+  file:write(default_config)
+  file:close()
+  return true
 end
 
 local function open_config_with_autofix()
@@ -73,8 +76,8 @@ local function open_config_with_autofix()
   end
 
   if vim.fn.filereadable(config_path) == 0 then
-    create_default_config(config_path)
-    vim.cmd("edit " .. config_path)
+    if not create_default_config(config_path) then return end
+    vim.cmd("edit " .. vim.fn.fnameescape(config_path))
     return
   end
 
@@ -100,7 +103,7 @@ local function open_config_with_autofix()
     )
   end
 
-  vim.cmd("edit " .. config_path)
+  vim.cmd("edit " .. vim.fn.fnameescape(config_path))
 end
 
 local known_subcommands = {

--- a/plugin/raccoon.lua
+++ b/plugin/raccoon.lua
@@ -53,7 +53,9 @@ local function create_default_config(config_path)
       "next_page_alt": "<leader>l",
       "exit": "<leader>cm",
       "maximize_prefix": "<leader>m",
-      "browse_files": "<leader>f"
+      "browse_files": "<leader>f",
+      "dispatch_agent": "<leader>aa",
+      "human_edit": "<leader>ee"
     }
   }
 }]], clone_root)

--- a/shortcuts_docs.md
+++ b/shortcuts_docs.md
@@ -1,6 +1,6 @@
 # Keyboard Shortcuts Reference
 
-Most keyboard shortcuts in raccoon.nvim are configurable via the `shortcuts` field in `~/.config/raccoon/config.json` (feature-specific shortcuts: `parallel_agents.shortcut`, `human_edit.shortcut`). You only need to specify the keys you want to change — unspecified keys keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it.
+Most keyboard shortcuts in raccoon.nvim are configurable via the `shortcuts` field in `~/.config/raccoon/config.json`. You only need to specify the keys you want to change — unspecified keys keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it.
 
 Run `:Raccoon shortcuts` (or press `<leader>?` by default) to see your active bindings in a floating window.
 
@@ -26,6 +26,8 @@ Values are validated on load:
     "...": "...",
     "commit_mode": {
       "next_page": "<leader>j",
+      "dispatch_agent": "<leader>aa",
+      "human_edit": "<leader>ee",
       "...": "..."
     }
   }
@@ -98,24 +100,10 @@ These shortcuts are nested under `shortcuts.commit_mode` in config and are only 
 | `exit` | `<leader>cm` | Exit commit viewer mode and return to the normal PR review view. |
 | `maximize_prefix` | `<leader>m` | Prefix for maximizing a grid cell. Followed by a cell number from `1..rows*cols` (for example `<leader>m1`). In local mode it also supports `<leader>mf` (file picker) and `<leader>mc` (commit picker). Inside maximized view, normal vim navigation works (scrolling, search). Close with `close`. |
 | `browse_files` | `<leader>f` | Toggle focus between the commit sidebar and the file tree. While in file tree mode, navigate with j/k, jump with gg/G, search with `/`, and press Enter to view a file's content at the current commit state. |
-
-## Parallel agents (maximized diff view)
-
-Active inside maximized **`Current changes`** diff floating windows in local mode (`:Raccoon local`) when `parallel_agents.enabled` is `true` in config. Works in both normal and visual mode.
-
-| Config key | Default | Description |
-|------------|---------|-------------|
-| `parallel_agents.shortcut` | `<leader>aa` | Dispatch an agent with commit context. In visual mode, the selected lines are included in the prompt. Set to `false` to disable. See [parallel_agents_docs.md](parallel_agents_docs.md). |
+| `dispatch_agent` | `<leader>aa` | Dispatch an agent with commit context from the maximized diff view. In visual mode, the selected lines are included in the prompt. Only active when `parallel_agents.enabled` is `true`. Set to `false` to disable. See [parallel_agents_docs.md](parallel_agents_docs.md). |
+| `human_edit` | `<leader>ee` | Open the file in an editable floating window from maximized diff view. Full Vim editing capabilities, LSP support, and undo history. Set to `false` to disable. See [Human Edit in README](README.md#human-edit). |
 
 Note: `j`/`k` for navigating commits in the sidebar and `Enter` for selecting a commit are hardcoded and not configurable.
-
-## Human edit (maximized diff view)
-
-Active inside the maximized diff floating window in local mode (`:Raccoon local`). Opens the actual file for editing.
-
-| Config key | Default | Description |
-|------------|---------|-------------|
-| `human_edit.shortcut` | `<leader>ee` | Open the file in an editable floating window from maximized diff view. Full Vim editing capabilities, LSP support, and undo history. Set to `false` to disable. See [Human Edit in README](README.md#human-edit). |
 
 ## Example: custom config
 

--- a/shortcuts_docs.md
+++ b/shortcuts_docs.md
@@ -109,6 +109,14 @@ Active inside the maximized diff floating window when `parallel_agents.enabled` 
 
 Note: `j`/`k` for navigating commits in the sidebar and `Enter` for selecting a commit are hardcoded and not configurable.
 
+## Human edit (maximized diff view)
+
+Active inside the maximized diff floating window in local mode (`:Raccoon local`). Opens the actual file for editing.
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `human_edit.shortcut` | `<leader>ee` | Open the file in an editable floating window from maximized diff view. Full Vim editing capabilities, LSP support, and undo history. Set to `false` to disable. See [Human Edit in README](README.md#human-edit). |
+
 ## Example: custom config
 
 Override only the keys you want to change:
@@ -144,7 +152,7 @@ Disabled shortcuts show as `(disabled)` in the `:Raccoon shortcuts` window.
 
 ## Corresponding commands
 
-Every shortcut has a `:Raccoon` command equivalent that works regardless of whether the shortcut is enabled:
+Some shortcuts have `:Raccoon` command equivalents that work regardless of whether the shortcut is enabled:
 
 | Shortcut | Command |
 |----------|---------|

--- a/shortcuts_docs.md
+++ b/shortcuts_docs.md
@@ -1,6 +1,6 @@
 # Keyboard Shortcuts Reference
 
-All keyboard shortcuts in raccoon.nvim are configurable via the `shortcuts` field in `~/.config/raccoon/config.json`. You only need to specify the keys you want to change — unspecified keys keep their defaults. Set any shortcut to `false` to disable it entirely.
+Most keyboard shortcuts in raccoon.nvim are configurable via the `shortcuts` field in `~/.config/raccoon/config.json` (feature-specific shortcuts: `parallel_agents.shortcut`, `human_edit.shortcut`). You only need to specify the keys you want to change — unspecified keys keep their defaults. Set any shortcut except `shortcuts.close` to `false` to disable it.
 
 Run `:Raccoon shortcuts` (or press `<leader>?` by default) to see your active bindings in a floating window.
 
@@ -10,10 +10,10 @@ Shortcuts are loaded from `config.json` at startup and whenever a floating windo
 
 Values are validated on load:
 - **Strings** are accepted as keybindings (e.g. `"<leader>j"`, `"<C-n>"`, `"gj"`)
-- **`false`** disables the shortcut — the keymap is not registered, but the feature remains available via `:Raccoon` commands
+- **`false`** disables the shortcut — the keymap is not registered. For shortcuts that have command equivalents, the corresponding `:Raccoon` command still works. (`shortcuts.close` is the exception and cannot be disabled.)
 - **Invalid values** (numbers, `null`, empty strings) are silently replaced with the default
 
-Every floating window always responds to `Esc`, so disabling `close` won't lock you out.
+`shortcuts.close` is mandatory and must be a non-empty string (default: `<leader>q`). If it is missing or invalid, most `:Raccoon` subcommands are blocked until fixed. Run `:Raccoon config` to auto-fix it.
 
 ## Config structure
 
@@ -41,7 +41,7 @@ These are registered at startup and work everywhere in Neovim while the plugin i
 | Config key | Default | Description |
 |------------|---------|-------------|
 | `pr_list` | `<leader>pr` | Open the PR list floating picker. Shows all open PRs across your configured repos, grouped by repository. Use `j`/`k` to navigate and `Enter` to open a PR for review. |
-| `show_shortcuts` | `<leader>?` | Open a floating window listing all active shortcuts grouped by category. Disabled shortcuts appear as `(disabled)`. The window closes on any keystroke. |
+| `show_shortcuts` | `<leader>?` | Open a floating window listing all active shortcuts grouped by category. Disabled shortcuts appear as `(disabled)`. Close it with `close`. |
 
 ## Review navigation
 
@@ -84,7 +84,7 @@ Used across multiple contexts.
 
 | Config key | Default | Description |
 |------------|---------|-------------|
-| `close` | `<leader>q` | Close the current floating window or exit the review session. Used in the PR list, comment windows, description window, merge picker, and other floating UI. `Esc` always works as a fallback. |
+| `close` | `<leader>q` | Close the current floating/maximized window. Used in the PR list, comment windows, description window, merge picker, and other floating UI. Use `:Raccoon exit` to end a PR review session. |
 
 ## Commit viewer mode
 
@@ -96,12 +96,12 @@ These shortcuts are nested under `shortcuts.commit_mode` in config and are only 
 | `prev_page` | `<leader>k` | Show the previous page of diff hunks. |
 | `next_page_alt` | `<leader>l` | Alias for `next_page`. Provides an alternative key for forward navigation. |
 | `exit` | `<leader>cm` | Exit commit viewer mode and return to the normal PR review view. |
-| `maximize_prefix` | `<leader>m` | Prefix for maximizing a grid cell. Followed by a cell number (1-9), e.g. `<leader>m1` maximizes cell 1 into a full floating window with the complete file diff. Inside the maximized view, normal vim navigation works (scrolling, search). Close with `q` or the `close` shortcut. |
+| `maximize_prefix` | `<leader>m` | Prefix for maximizing a grid cell. Followed by a cell number from `1..rows*cols` (for example `<leader>m1`). In local mode it also supports `<leader>mf` (file picker) and `<leader>mc` (commit picker). Inside maximized view, normal vim navigation works (scrolling, search). Close with `close`. |
 | `browse_files` | `<leader>f` | Toggle focus between the commit sidebar and the file tree. While in file tree mode, navigate with j/k, jump with gg/G, search with `/`, and press Enter to view a file's content at the current commit state. |
 
 ## Parallel agents (maximized diff view)
 
-Active inside the maximized diff floating window when `parallel_agents.enabled` is `true` in config. Works in both normal and visual mode.
+Active inside maximized **`Current changes`** diff floating windows in local mode (`:Raccoon local`) when `parallel_agents.enabled` is `true` in config. Works in both normal and visual mode.
 
 | Config key | Default | Description |
 |------------|---------|-------------|
@@ -162,4 +162,6 @@ Some shortcuts have `:Raccoon` command equivalents that work regardless of wheth
 | `list_comments` | `:Raccoon list` |
 | `merge` | `:Raccoon merge` / `:Raccoon squash` / `:Raccoon rebase` |
 | `commit_viewer` | `:Raccoon commits` |
-| `close` | `:Raccoon close` |
+| `close` | *(none; window-level only)* |
+
+`close` and `:Raccoon exit` are related but not equivalent: `close` dismisses the current window, while `:Raccoon exit` ends the active PR review session.

--- a/tests/command_spec.lua
+++ b/tests/command_spec.lua
@@ -1,0 +1,171 @@
+describe(":Raccoon command", function()
+  local notifications
+  local original_notify
+  local original_open_module
+  local original_ui_module
+  local original_config_module
+
+  before_each(function()
+    if vim.fn.exists(":Raccoon") == 0 then
+      vim.cmd("runtime plugin/raccoon.lua")
+    end
+
+    notifications = {}
+    original_notify = vim.notify
+    vim.notify = function(msg, level, opts)
+      table.insert(notifications, { msg = msg, level = level, opts = opts })
+    end
+    original_open_module = package.loaded["raccoon.open"]
+    original_ui_module = package.loaded["raccoon.ui"]
+    original_config_module = package.loaded["raccoon.config"]
+    package.loaded["raccoon.config"] = {
+      validate_close_shortcut = function()
+        return { valid = true }
+      end,
+      config_path = "/tmp/claude/raccoon-tests/command-spec-config.json",
+      autofix_close_shortcut = function()
+        return { changed = false, skipped = true, reason = "already_valid" }
+      end,
+    }
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+    package.loaded["raccoon.open"] = original_open_module
+    package.loaded["raccoon.ui"] = original_ui_module
+    package.loaded["raccoon.config"] = original_config_module
+  end)
+
+  it("registers the user command", function()
+    assert.equals(2, vim.fn.exists(":Raccoon"))
+  end)
+
+  it("dispatches :Raccoon exit to raccoon.open.close_all_sessions", function()
+    local close_calls = 0
+    package.loaded["raccoon.open"] = {
+      close_all_sessions = function()
+        close_calls = close_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon exit")
+
+    assert.equals(1, close_calls)
+  end)
+
+  it("does not block :Raccoon exit when shortcuts.close is invalid", function()
+    local exit_calls = 0
+    package.loaded["raccoon.config"] = {
+      validate_close_shortcut = function()
+        return { valid = false, reason = "shortcuts.close must be a non-empty shortcut string", value = false }
+      end,
+    }
+    package.loaded["raccoon.open"] = {
+      close_all_sessions = function()
+        exit_calls = exit_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon exit")
+
+    assert.equals(1, exit_calls)
+  end)
+
+  it("dispatches :Raccoon description to raccoon.ui.show_description", function()
+    local show_calls = 0
+    package.loaded["raccoon.ui"] = {
+      show_description = function()
+        show_calls = show_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon description")
+
+    assert.equals(1, show_calls)
+  end)
+
+  it("blocks subcommands when shortcuts.close is invalid", function()
+    local show_calls = 0
+    package.loaded["raccoon.config"] = {
+      validate_close_shortcut = function()
+        return { valid = false, reason = "shortcuts.close must be a non-empty shortcut string", value = false }
+      end,
+    }
+    package.loaded["raccoon.ui"] = {
+      show_description = function()
+        show_calls = show_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon description")
+
+    assert.equals(0, show_calls)
+    assert.equals(1, #notifications)
+    assert.equals(vim.log.levels.ERROR, notifications[1].level)
+    assert.truthy(notifications[1].msg:find("Cannot run :Raccoon description", 1, true))
+    assert.truthy(notifications[1].msg:find("Run :Raccoon config", 1, true))
+  end)
+
+  it("dispatches :Raccoon sync to raccoon.open.sync", function()
+    local sync_calls = 0
+    package.loaded["raccoon.open"] = {
+      sync = function()
+        sync_calls = sync_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon sync")
+
+    assert.equals(1, sync_calls)
+  end)
+
+  it("rejects removed :Raccoon close subcommand", function()
+    vim.cmd("Raccoon close")
+
+    assert.equals(1, #notifications)
+    assert.equals(vim.log.levels.ERROR, notifications[1].level)
+    assert.equals("Unknown subcommand: close", notifications[1].msg)
+  end)
+
+  it("dispatches :Raccoon desc alias to raccoon.ui.show_description", function()
+    local show_calls = 0
+    package.loaded["raccoon.ui"] = {
+      show_description = function()
+        show_calls = show_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon desc")
+
+    assert.equals(1, show_calls)
+    assert.equals(0, #notifications)
+  end)
+
+  it("dispatches :Raccoon update alias to raccoon.open.sync", function()
+    local sync_calls = 0
+    package.loaded["raccoon.open"] = {
+      sync = function()
+        sync_calls = sync_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon update")
+
+    assert.equals(1, sync_calls)
+    assert.equals(0, #notifications)
+  end)
+
+  it("dispatches :Raccoon refresh alias to raccoon.open.sync", function()
+    local sync_calls = 0
+    package.loaded["raccoon.open"] = {
+      sync = function()
+        sync_calls = sync_calls + 1
+      end,
+    }
+
+    vim.cmd("Raccoon refresh")
+
+    assert.equals(1, sync_calls)
+    assert.equals(0, #notifications)
+  end)
+end)

--- a/tests/comments_spec.lua
+++ b/tests/comments_spec.lua
@@ -662,7 +662,7 @@ describe("raccoon.comments show_readonly_thread", function()
     assert.equals(" Thread ", config.title[1][1])
   end)
 
-  it("closes on q keypress", function()
+  it("closes on close shortcut keypress", function()
     comments.show_readonly_thread({
       comments = {
         { body = "Test", user = { login = "alice" } },

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -452,4 +452,39 @@ describe("raccoon.commit_ui", function()
       assert.equals(2, commit_ui.diff_line_to_file_line(hl_lines, 4))
     end)
   end)
+
+  describe("three_way_merge", function()
+    it("returns clean merge when changes don't overlap", function()
+      local base   = { "line1", "line2", "line3", "line4", "line5" }
+      local ours   = { "line1", "OURS",  "line3", "line4", "line5" }
+      local theirs = { "line1", "line2", "line3", "line4", "THEIRS" }
+      local merged, exit_code = commit_ui.three_way_merge(base, ours, theirs)
+      assert.equals(0, exit_code)
+      assert.same({ "line1", "OURS", "line3", "line4", "THEIRS" }, merged)
+    end)
+
+    it("reports conflicts when changes overlap on same line", function()
+      local base   = { "line1", "line2", "line3" }
+      local ours   = { "line1", "OURS",  "line3" }
+      local theirs = { "line1", "THEIRS", "line3" }
+      local merged, exit_code = commit_ui.three_way_merge(base, ours, theirs)
+      assert.is_true(exit_code > 0)
+      local content = table.concat(merged, "\n")
+      assert.truthy(content:find("<<<<<<<"))
+      assert.truthy(content:find(">>>>>>>"))
+    end)
+
+    it("returns identical content when no changes", function()
+      local base = { "a", "b", "c" }
+      local merged, exit_code = commit_ui.three_way_merge(base, base, base)
+      assert.equals(0, exit_code)
+      assert.same(base, merged)
+    end)
+
+    it("handles empty files", function()
+      local merged, exit_code = commit_ui.three_way_merge({}, { "new line" }, {})
+      assert.equals(0, exit_code)
+      assert.same({ "new line" }, merged)
+    end)
+  end)
 end)

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -474,6 +474,33 @@ describe("raccoon.commit_ui", function()
       assert.truthy(content:find(">>>>>>>"))
     end)
 
+    it("treats 127 as a valid conflict count, not an execution error", function()
+      local base = {}
+      local ours = {}
+      local theirs = {}
+
+      for i = 1, 5000 do
+        local line = "line" .. i
+        base[i] = line
+        ours[i] = line
+        theirs[i] = line
+      end
+
+      -- Create 130 isolated conflicts so git-merge-file truncates exit to 127.
+      local pos = 10
+      for _ = 1, 130 do
+        ours[pos] = "ours" .. pos
+        theirs[pos] = "theirs" .. pos
+        pos = pos + 35
+      end
+
+      local merged, exit_code = commit_ui.three_way_merge(base, ours, theirs)
+      assert.equals(127, exit_code)
+      local content = table.concat(merged, "\n")
+      assert.truthy(content:find("<<<<<<<"))
+      assert.truthy(content:find(">>>>>>>"))
+    end)
+
     it("returns identical content when no changes", function()
       local base = { "a", "b", "c" }
       local merged, exit_code = commit_ui.three_way_merge(base, base, base)

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -1,4 +1,5 @@
-local commit_ui = require("raccoon.commit_ui")
+local loader = require("tests.helpers.loader")
+local commit_ui = loader.reload_from_cwd("raccoon.commit_ui")
 
 describe("raccoon.commit_ui", function()
   -- Shared header window helper

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -487,4 +487,38 @@ describe("raccoon.commit_ui", function()
       assert.same({ "new line" }, merged)
     end)
   end)
+
+  describe("format_post_command", function()
+    it("replaces <FILE> with shell-escaped filename", function()
+      local result = commit_ui.format_post_command("git add <FILE>", "src/my file.lua")
+      assert.truthy(result:find("git add"))
+      assert.truthy(result:find("my file"))
+      -- Should not contain raw <FILE> placeholder
+      assert.falsy(result:find("<FILE>"))
+    end)
+
+    it("replaces <TIMESTAMP> with a date string", function()
+      local result = commit_ui.format_post_command("git commit -m '<TIMESTAMP>'", "test.lua")
+      assert.falsy(result:find("<TIMESTAMP>"))
+      -- Timestamp format: YYYY-MM-DD_HH:MM:SS
+      assert.truthy(result:match("%d%d%d%d%-%d%d%-%d%d_%d%d:%d%d:%d%d"))
+    end)
+
+    it("replaces both placeholders in one command", function()
+      local result = commit_ui.format_post_command("git add <FILE> && git commit -m 'edit <TIMESTAMP>'", "foo.lua")
+      assert.falsy(result:find("<FILE>"))
+      assert.falsy(result:find("<TIMESTAMP>"))
+    end)
+
+    it("returns command unchanged when no placeholders present", function()
+      local cmd = "echo hello"
+      assert.equals(cmd, commit_ui.format_post_command(cmd, "test.lua"))
+    end)
+
+    it("handles multiple <FILE> placeholders", function()
+      local result = commit_ui.format_post_command("git add <FILE> && echo <FILE>", "test.lua")
+      -- Both should be replaced
+      assert.falsy(result:find("<FILE>"))
+    end)
+  end)
 end)

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -380,4 +380,75 @@ describe("raccoon.commit_ui", function()
     -- A small width that fits should pass through unchanged
     assert.equals(10, commit_ui.compute_effective_sidebar_width(cols, 10))
   end)
+
+  describe("diff_line_to_file_line", function()
+    it("returns 1 for nil hl_lines", function()
+      assert.equals(1, commit_ui.diff_line_to_file_line(nil, 5))
+    end)
+
+    it("returns 1 for empty hl_lines", function()
+      assert.equals(1, commit_ui.diff_line_to_file_line({}, 5))
+    end)
+
+    it("returns exact match for add line", function()
+      local hl_lines = {
+        { type = "ctx", line_num = 10 },
+        { type = "add", line_num = 11 },
+        { type = "ctx", line_num = 12 },
+      }
+      assert.equals(11, commit_ui.diff_line_to_file_line(hl_lines, 2))
+    end)
+
+    it("returns exact match for ctx line", function()
+      local hl_lines = {
+        { type = "ctx", line_num = 5 },
+        { type = "ctx", line_num = 6 },
+      }
+      assert.equals(6, commit_ui.diff_line_to_file_line(hl_lines, 2))
+    end)
+
+    it("skips del lines and searches backward", function()
+      local hl_lines = {
+        { type = "ctx", line_num = 10 },
+        { type = "del" },
+        { type = "del" },
+      }
+      assert.equals(10, commit_ui.diff_line_to_file_line(hl_lines, 3))
+    end)
+
+    it("clamps cursor beyond hl_lines length", function()
+      local hl_lines = {
+        { type = "ctx", line_num = 7 },
+        { type = "add", line_num = 8 },
+      }
+      assert.equals(8, commit_ui.diff_line_to_file_line(hl_lines, 100))
+    end)
+
+    it("returns 1 when all entries are del lines", function()
+      local hl_lines = {
+        { type = "del" },
+        { type = "del" },
+      }
+      assert.equals(1, commit_ui.diff_line_to_file_line(hl_lines, 2))
+    end)
+
+    it("returns 1 when entries have no line_num", function()
+      local hl_lines = {
+        { type = "ctx" },
+        { type = "add" },
+      }
+      assert.equals(1, commit_ui.diff_line_to_file_line(hl_lines, 2))
+    end)
+
+    it("finds nearest add/ctx backward from cursor", function()
+      local hl_lines = {
+        { type = "add", line_num = 1 },
+        { type = "add", line_num = 2 },
+        { type = "del" },
+        { type = "del" },
+        { type = "ctx", line_num = 3 },
+      }
+      assert.equals(2, commit_ui.diff_line_to_file_line(hl_lines, 4))
+    end)
+  end)
 end)

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -467,7 +467,7 @@ describe("raccoon.commits keybinding lockdown", function()
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("does not block q (used for close)", function()
+    it("does not block q", function()
       local buf = create_scratch_buf()
       commits._lock_maximize_buf(buf)
       assert.is_false(has_buf_keymap(buf, "n", "q"))

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,4 +1,16 @@
-local config = require("raccoon.config")
+-- Force-load from CWD to shadow any installed plugin copies
+local function reload_from_cwd(mod)
+  package.loaded[mod] = nil
+  local cwd = vim.fn.getcwd()
+  local path = cwd .. "/lua/" .. mod:gsub("%.", "/") .. ".lua"
+  local fn, err = loadfile(path)
+  if not fn then error("Failed to load " .. path .. ": " .. tostring(err)) end
+  local result = fn()
+  package.loaded[mod] = result
+  return result
+end
+
+local config = reload_from_cwd("raccoon.config")
 
 -- Use /tmp/claude/ for temp files (sandbox-safe)
 local test_tmp_dir = "/tmp/claude/raccoon-tests"

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -747,7 +747,7 @@ describe("raccoon.config", function()
       assert.is_true(result.valid)
     end)
 
-    it("is invalid when shortcuts object is missing", function()
+    it("is valid when shortcuts object is missing (defaults apply)", function()
       local tmpfile = test_tmp_dir .. "/missing_shortcuts_for_close.json"
       local f = io.open(tmpfile, "w")
       f:write([[{
@@ -757,8 +757,7 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local result = config.validate_close_shortcut()
-      assert.is_false(result.valid)
-      assert.truthy(result.reason:find("missing shortcuts object", 1, true))
+      assert.is_true(result.valid)
 
       os.remove(tmpfile)
     end)
@@ -869,7 +868,7 @@ describe("raccoon.config", function()
       os.remove(tmpfile)
     end)
 
-    it("adds minimal shortcuts object when missing", function()
+    it("skips when shortcuts object is missing (defaults apply)", function()
       local tmpfile = test_tmp_dir .. "/autofix_add_shortcuts.json"
       local f = io.open(tmpfile, "w")
       f:write([[{
@@ -879,13 +878,9 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local result = config.autofix_close_shortcut()
-      assert.is_true(result.changed)
-
-      local out = io.open(tmpfile, "r")
-      local content = out:read("*a")
-      out:close()
-      assert.truthy(content:find('"shortcuts"%s*:%s*%{'))
-      assert.truthy(content:find('"close"%s*:%s*"<leader>q"'))
+      assert.is_false(result.changed)
+      assert.is_true(result.skipped)
+      assert.equals("already_valid", result.reason)
 
       os.remove(tmpfile)
     end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -496,6 +496,11 @@ describe("raccoon.config", function()
       assert.is_false(config.is_enabled(""))
     end)
 
+    it("returns false for whitespace-only strings", function()
+      assert.is_false(config.is_enabled(" "))
+      assert.is_false(config.is_enabled("\t"))
+    end)
+
     it("returns false for non-string types", function()
       assert.is_false(config.is_enabled(42))
       assert.is_false(config.is_enabled({}))
@@ -712,6 +717,189 @@ describe("raccoon.config", function()
       local shortcuts = config.load_shortcuts()
       assert.is_nil(shortcuts.nonexistent_key)
       assert.equals("<leader>pp", shortcuts.pr_list)
+
+      os.remove(tmpfile)
+    end)
+
+    it("forces shortcuts.close to default when user disables it", function()
+      local tmpfile = test_tmp_dir .. "/close_disabled_shortcuts.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "shortcuts": {
+          "close": false
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local shortcuts = config.load_shortcuts()
+      assert.equals(config.defaults.shortcuts.close, shortcuts.close)
+
+      os.remove(tmpfile)
+    end)
+  end)
+
+  describe("validate_close_shortcut", function()
+    it("is valid when config file is missing", function()
+      config.config_path = "/nonexistent/path/config.json"
+      local result = config.validate_close_shortcut()
+      assert.is_true(result.valid)
+    end)
+
+    it("is invalid when shortcuts object is missing", function()
+      local tmpfile = test_tmp_dir .. "/missing_shortcuts_for_close.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"}
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.validate_close_shortcut()
+      assert.is_false(result.valid)
+      assert.truthy(result.reason:find("missing shortcuts object", 1, true))
+
+      os.remove(tmpfile)
+    end)
+
+    it("is invalid when shortcuts.close is false", function()
+      local tmpfile = test_tmp_dir .. "/invalid_close_false.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "shortcuts": {
+          "close": false
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.validate_close_shortcut()
+      assert.is_false(result.valid)
+      assert.equals(false, result.value)
+
+      os.remove(tmpfile)
+    end)
+
+    it("is invalid when shortcuts.close is whitespace", function()
+      local tmpfile = test_tmp_dir .. "/invalid_close_whitespace.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "shortcuts": {
+          "close": "   "
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.validate_close_shortcut()
+      assert.is_false(result.valid)
+
+      os.remove(tmpfile)
+    end)
+
+    it("is valid when shortcuts.close is a non-empty binding", function()
+      local tmpfile = test_tmp_dir .. "/valid_close_shortcut.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "shortcuts": {
+          "close": "<leader>x"
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.validate_close_shortcut()
+      assert.is_true(result.valid)
+      assert.equals("<leader>x", result.value)
+
+      os.remove(tmpfile)
+    end)
+  end)
+
+  describe("autofix_close_shortcut", function()
+    it("inserts missing shortcuts.close into an existing shortcuts object", function()
+      local tmpfile = test_tmp_dir .. "/autofix_insert_close.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+  "tokens": {"user": "ghp_xxx"},
+  "shortcuts": {
+    "pr_list": "<leader>pr"
+  }
+}]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.autofix_close_shortcut()
+      assert.is_true(result.changed)
+
+      local out = io.open(tmpfile, "r")
+      local content = out:read("*a")
+      out:close()
+      assert.truthy(content:find('"close"%s*:%s*"<leader>q"'))
+
+      os.remove(tmpfile)
+    end)
+
+    it("replaces invalid shortcuts.close value", function()
+      local tmpfile = test_tmp_dir .. "/autofix_replace_close.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+  "tokens": {"user": "ghp_xxx"},
+  "shortcuts": {
+    "close": false
+  }
+}]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.autofix_close_shortcut()
+      assert.is_true(result.changed)
+      assert.equals(false, result.old_value)
+      assert.equals("<leader>q", result.new_value)
+
+      local out = io.open(tmpfile, "r")
+      local content = out:read("*a")
+      out:close()
+      assert.truthy(content:find('"close"%s*:%s*"<leader>q"'))
+
+      os.remove(tmpfile)
+    end)
+
+    it("adds minimal shortcuts object when missing", function()
+      local tmpfile = test_tmp_dir .. "/autofix_add_shortcuts.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+  "tokens": {"user": "ghp_xxx"}
+}]])
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.autofix_close_shortcut()
+      assert.is_true(result.changed)
+
+      local out = io.open(tmpfile, "r")
+      local content = out:read("*a")
+      out:close()
+      assert.truthy(content:find('"shortcuts"%s*:%s*%{'))
+      assert.truthy(content:find('"close"%s*:%s*"<leader>q"'))
+
+      os.remove(tmpfile)
+    end)
+
+    it("skips when JSON is invalid", function()
+      local tmpfile = test_tmp_dir .. "/autofix_invalid_json.json"
+      local f = io.open(tmpfile, "w")
+      f:write("{ invalid json }")
+      f:close()
+
+      config.config_path = tmpfile
+      local result = config.autofix_close_shortcut()
+      assert.is_false(result.changed)
+      assert.equals("parse_error", result.reason)
 
       os.remove(tmpfile)
     end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -865,6 +865,140 @@ describe("raccoon.config", function()
     end)
   end)
 
+  describe("load_human_edit", function()
+    it("returns defaults when config file does not exist", function()
+      config.config_path = "/nonexistent/path/config.json"
+      local he = config.load_human_edit()
+      assert.is_table(he)
+      assert.equals("<leader>ee", he.shortcut)
+      assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
+    end)
+
+    it("returns defaults for invalid JSON", function()
+      local tmpfile = test_tmp_dir .. "/he_invalid.json"
+      local f = io.open(tmpfile, "w")
+      f:write("{ bad json }")
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("<leader>ee", he.shortcut)
+
+      os.remove(tmpfile)
+    end)
+
+    it("merges user overrides correctly", function()
+      local tmpfile = test_tmp_dir .. "/he_override.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "human_edit": {
+          "shortcut": "<leader>he",
+          "command": "git add <FILE>"
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("<leader>he", he.shortcut)
+      assert.equals("git add <FILE>", he.command)
+
+      os.remove(tmpfile)
+    end)
+
+    it("handles invalid types gracefully", function()
+      local tmpfile = test_tmp_dir .. "/he_bad_types.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "human_edit": {
+          "shortcut": 99,
+          "command": 42
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("<leader>ee", he.shortcut)
+      assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
+
+      os.remove(tmpfile)
+    end)
+
+    it("shortcut false disables shortcut", function()
+      local tmpfile = test_tmp_dir .. "/he_no_shortcut.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "human_edit": {
+          "shortcut": false
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.is_false(he.shortcut)
+      assert.is_false(config.is_enabled(he.shortcut))
+
+      os.remove(tmpfile)
+    end)
+
+    it("command false disables command", function()
+      local tmpfile = test_tmp_dir .. "/he_no_command.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "human_edit": {
+          "command": false
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("", he.command)
+
+      os.remove(tmpfile)
+    end)
+
+    it("empty command string is preserved", function()
+      local tmpfile = test_tmp_dir .. "/he_empty_cmd.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "human_edit": {
+          "command": ""
+        }
+      }]])
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("", he.command)
+
+      os.remove(tmpfile)
+    end)
+
+    it("returns defaults when human_edit is not a table", function()
+      local tmpfile = test_tmp_dir .. "/he_scalar.json"
+      local f = io.open(tmpfile, "w")
+      f:write('{"human_edit": "invalid"}')
+      f:close()
+
+      config.config_path = tmpfile
+      local he = config.load_human_edit()
+      assert.equals("<leader>ee", he.shortcut)
+
+      os.remove(tmpfile)
+    end)
+
+    it("returns independent copies (no mutation)", function()
+      config.config_path = "/nonexistent/path/config.json"
+      local h1 = config.load_human_edit()
+      local h2 = config.load_human_edit()
+      h1.command = "MUTATED"
+      assert.is_not_equal("MUTATED", h2.command)
+    end)
+  end)
+
   describe("multi-host tokens", function()
     it("get_token_for_owner returns token and default host for string token", function()
       local cfg = {

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,16 +1,5 @@
--- Force-load from CWD to shadow any installed plugin copies
-local function reload_from_cwd(mod)
-  package.loaded[mod] = nil
-  local cwd = vim.fn.getcwd()
-  local path = cwd .. "/lua/" .. mod:gsub("%.", "/") .. ".lua"
-  local fn, err = loadfile(path)
-  if not fn then error("Failed to load " .. path .. ": " .. tostring(err)) end
-  local result = fn()
-  package.loaded[mod] = result
-  return result
-end
-
-local config = reload_from_cwd("raccoon.config")
+local loader = require("tests.helpers.loader")
+local config = loader.reload_from_cwd("raccoon.config")
 
 -- Use /tmp/claude/ for temp files (sandbox-safe)
 local test_tmp_dir = "/tmp/claude/raccoon-tests"

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -453,7 +453,11 @@ describe("raccoon.config", function()
 
     it("has commit_mode subsection with expected keys", function()
       assert.is_table(config.defaults.shortcuts.commit_mode)
-      local expected = { "next_page", "prev_page", "next_page_alt", "exit", "maximize_prefix" }
+      local expected = {
+        "next_page", "prev_page", "next_page_alt",
+        "exit", "maximize_prefix", "browse_files",
+        "dispatch_agent", "human_edit",
+      }
       for _, key in ipairs(expected) do
         assert.is_string(config.defaults.shortcuts.commit_mode[key],
           "Missing commit_mode shortcut default: " .. key)
@@ -738,6 +742,89 @@ describe("raccoon.config", function()
 
       os.remove(tmpfile)
     end)
+
+    it("warns when legacy parallel_agents.shortcut is present", function()
+      local tmpfile = test_tmp_dir .. "/legacy_pa_shortcut.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "parallel_agents": {
+          "enabled": true,
+          "command": "echo <PROMPT>",
+          "shortcut": "<leader>az"
+        }
+      }]])
+      f:close()
+
+      local original_notify = vim.notify
+      local notifications = {}
+      local ok_case, err_case = pcall(function()
+        config._reset_warning_state_for_tests()
+        config.config_path = tmpfile
+        vim.notify = function(msg, level)
+          table.insert(notifications, { msg = msg, level = level })
+        end
+
+        local shortcuts = config.load_shortcuts()
+        -- Legacy field should NOT affect shortcuts.commit_mode.dispatch_agent
+        assert.equals(config.defaults.shortcuts.commit_mode.dispatch_agent, shortcuts.commit_mode.dispatch_agent)
+      end)
+      vim.notify = original_notify
+      if not ok_case then error(err_case) end
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if n.level == vim.log.levels.WARN
+          and n.msg:find("parallel_agents%.shortcut")
+          and n.msg:find("shortcuts%.commit_mode%.dispatch_agent") then
+          warned = true
+          break
+        end
+      end
+      assert.is_true(warned)
+
+      os.remove(tmpfile)
+    end)
+
+    it("warns when legacy human_edit.shortcut is present", function()
+      local tmpfile = test_tmp_dir .. "/legacy_he_shortcut.json"
+      local f = io.open(tmpfile, "w")
+      f:write([[{
+        "tokens": {"user": "ghp_xxx"},
+        "human_edit": {
+          "shortcut": "<leader>he"
+        }
+      }]])
+      f:close()
+
+      local original_notify = vim.notify
+      local notifications = {}
+      local ok_case, err_case = pcall(function()
+        config._reset_warning_state_for_tests()
+        config.config_path = tmpfile
+        vim.notify = function(msg, level)
+          table.insert(notifications, { msg = msg, level = level })
+        end
+
+        local shortcuts = config.load_shortcuts()
+        assert.equals(config.defaults.shortcuts.commit_mode.human_edit, shortcuts.commit_mode.human_edit)
+      end)
+      vim.notify = original_notify
+      if not ok_case then error(err_case) end
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if n.level == vim.log.levels.WARN
+          and n.msg:find("human_edit%.shortcut")
+          and n.msg:find("shortcuts%.commit_mode%.human_edit") then
+          warned = true
+          break
+        end
+      end
+      assert.is_true(warned)
+
+      os.remove(tmpfile)
+    end)
   end)
 
   describe("validate_close_shortcut", function()
@@ -908,7 +995,7 @@ describe("raccoon.config", function()
       assert.is_false(pa.enabled)
       assert.equals("", pa.command)
       assert.equals("", pa.suffix_prompt)
-      assert.equals("<leader>aa", pa.shortcut)
+      assert.equals(70, pa.popup_width)
     end)
 
     it("returns defaults for invalid JSON", function()
@@ -920,7 +1007,7 @@ describe("raccoon.config", function()
       config.config_path = tmpfile
       local pa = config.load_parallel_agents()
       assert.is_false(pa.enabled)
-      assert.equals("<leader>aa", pa.shortcut)
+      assert.equals(70, pa.popup_width)
 
       os.remove(tmpfile)
     end)
@@ -942,7 +1029,7 @@ describe("raccoon.config", function()
       assert.is_true(pa.enabled)
       assert.equals('claude -p <PROMPT>', pa.command)
       assert.equals("Always push.", pa.suffix_prompt)
-      assert.equals("<leader>aa", pa.shortcut) -- default kept
+      assert.equals(70, pa.popup_width) -- default kept
 
       os.remove(tmpfile)
     end)
@@ -954,8 +1041,7 @@ describe("raccoon.config", function()
         "parallel_agents": {
           "enabled": "yes",
           "command": 42,
-          "suffix_prompt": true,
-          "shortcut": 99
+          "suffix_prompt": true
         }
       }]])
       f:close()
@@ -965,27 +1051,48 @@ describe("raccoon.config", function()
       assert.is_false(pa.enabled) -- default
       assert.equals("", pa.command) -- default
       assert.equals("", pa.suffix_prompt) -- default
-      assert.equals("<leader>aa", pa.shortcut) -- default
+      assert.equals(70, pa.popup_width) -- default
 
       os.remove(tmpfile)
     end)
 
-    it("shortcut false disables shortcut", function()
+    it("ignores legacy shortcut field and warns", function()
       local tmpfile = test_tmp_dir .. "/pa_no_shortcut.json"
       local f = io.open(tmpfile, "w")
       f:write([[{
         "parallel_agents": {
           "enabled": true,
           "command": "test",
-          "shortcut": false
+          "shortcut": "<leader>az"
         }
       }]])
       f:close()
 
-      config.config_path = tmpfile
-      local pa = config.load_parallel_agents()
-      assert.is_false(pa.shortcut)
-      assert.is_false(config.is_enabled(pa.shortcut))
+      local original_notify = vim.notify
+      local notifications = {}
+      local ok_case, err_case = pcall(function()
+        config._reset_warning_state_for_tests()
+        config.config_path = tmpfile
+        vim.notify = function(msg, level)
+          table.insert(notifications, { msg = msg, level = level })
+        end
+
+        local pa = config.load_parallel_agents()
+        assert.is_true(pa.enabled)
+        assert.equals("test", pa.command)
+        assert.is_nil(pa.shortcut)
+      end)
+      vim.notify = original_notify
+      if not ok_case then error(err_case) end
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if n.level == vim.log.levels.WARN and n.msg:find("parallel_agents%.shortcut") then
+          warned = true
+          break
+        end
+      end
+      assert.is_true(warned)
 
       os.remove(tmpfile)
     end)
@@ -1054,7 +1161,6 @@ describe("raccoon.config", function()
       config.config_path = "/nonexistent/path/config.json"
       local he = config.load_human_edit()
       assert.is_table(he)
-      assert.equals("<leader>ee", he.shortcut)
       assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
     end)
 
@@ -1066,7 +1172,7 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local he = config.load_human_edit()
-      assert.equals("<leader>ee", he.shortcut)
+      assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
 
       os.remove(tmpfile)
     end)
@@ -1076,7 +1182,6 @@ describe("raccoon.config", function()
       local f = io.open(tmpfile, "w")
       f:write([[{
         "human_edit": {
-          "shortcut": "<leader>he",
           "command": "git add <FILE>"
         }
       }]])
@@ -1084,7 +1189,6 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local he = config.load_human_edit()
-      assert.equals("<leader>he", he.shortcut)
       assert.equals("git add <FILE>", he.command)
 
       os.remove(tmpfile)
@@ -1095,7 +1199,6 @@ describe("raccoon.config", function()
       local f = io.open(tmpfile, "w")
       f:write([[{
         "human_edit": {
-          "shortcut": 99,
           "command": 42
         }
       }]])
@@ -1103,26 +1206,44 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local he = config.load_human_edit()
-      assert.equals("<leader>ee", he.shortcut)
       assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
 
       os.remove(tmpfile)
     end)
 
-    it("shortcut false disables shortcut", function()
+    it("ignores legacy shortcut field and warns", function()
       local tmpfile = test_tmp_dir .. "/he_no_shortcut.json"
       local f = io.open(tmpfile, "w")
       f:write([[{
         "human_edit": {
-          "shortcut": false
+          "shortcut": "<leader>he"
         }
       }]])
       f:close()
 
-      config.config_path = tmpfile
-      local he = config.load_human_edit()
-      assert.is_false(he.shortcut)
-      assert.is_false(config.is_enabled(he.shortcut))
+      local original_notify = vim.notify
+      local notifications = {}
+      local ok_case, err_case = pcall(function()
+        config._reset_warning_state_for_tests()
+        config.config_path = tmpfile
+        vim.notify = function(msg, level)
+          table.insert(notifications, { msg = msg, level = level })
+        end
+
+        local he = config.load_human_edit()
+        assert.is_nil(he.shortcut)
+      end)
+      vim.notify = original_notify
+      if not ok_case then error(err_case) end
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if n.level == vim.log.levels.WARN and n.msg:find("human_edit%.shortcut") then
+          warned = true
+          break
+        end
+      end
+      assert.is_true(warned)
 
       os.remove(tmpfile)
     end)
@@ -1169,7 +1290,7 @@ describe("raccoon.config", function()
 
       config.config_path = tmpfile
       local he = config.load_human_edit()
-      assert.equals("<leader>ee", he.shortcut)
+      assert.equals("git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push", he.command)
 
       os.remove(tmpfile)
     end)

--- a/tests/helpers/loader.lua
+++ b/tests/helpers/loader.lua
@@ -1,0 +1,19 @@
+--- Test loader helper: force-loads modules from CWD to shadow installed plugin copies
+local M = {}
+
+--- Reload a module from the current working directory.
+--- Clears package.loaded, loads from lua/<mod>.lua, and re-registers the result.
+---@param mod string Dot-separated module name (e.g. "raccoon.config")
+---@return any result The module's return value
+function M.reload_from_cwd(mod)
+  package.loaded[mod] = nil
+  local cwd = vim.fn.getcwd()
+  local path = cwd .. "/lua/" .. mod:gsub("%.", "/") .. ".lua"
+  local fn, err = loadfile(path)
+  if not fn then error("Failed to load " .. path .. ": " .. tostring(err)) end
+  local result = fn()
+  package.loaded[mod] = result
+  return result
+end
+
+return M

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,7 +1,7 @@
 -- Minimal init for running tests with plenary.busted
 
 -- Add the plugin to runtimepath
-vim.opt.runtimepath:prepend(vim.fn.getcwd() .. "/nvim")
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 -- Add plenary to runtimepath (for CI and local dev)
 local plenary_path = vim.fn.expand("~/.local/share/nvim/site/pack/vendor/start/plenary.nvim")

--- a/tests/open_spec.lua
+++ b/tests/open_spec.lua
@@ -309,6 +309,74 @@ describe("raccoon.open", function()
       assert.equals(1, closed_pr)
       assert.equals(1, close_windows_calls)
     end)
+
+    it("resets exit guard when teardown raises", function()
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      package.loaded["raccoon.localcommits"] = {
+        is_active = function() return false end,
+        exit_local_mode = function() error("should not be called") end,
+      }
+      package.loaded["raccoon.commits"] = {
+        exit_commit_mode = function() error("should not be called") end,
+      }
+      package.loaded["raccoon.parallel_agents"] = {
+        get_running_count = function() return 0 end,
+        kill_all = function() return { requested = 0, stopped = 0, errors = {} } end,
+      }
+      package.loaded["raccoon.ui"] = {
+        has_open_windows = function() return false end,
+        close_all_windows = function()
+          error("boom")
+        end,
+      }
+
+      local original_close_pr = open.close_pr
+      open.close_pr = function()
+        state.stop()
+        return true
+      end
+
+      local first_exit = open.close_all_sessions()
+      assert.is_false(first_exit)
+
+      package.loaded["raccoon.ui"] = {
+        has_open_windows = function() return false end,
+        close_all_windows = function() end,
+      }
+
+      local second_exit = open.close_all_sessions()
+      open.close_pr = original_close_pr
+      vim.notify = original_notify
+
+      assert.is_false(second_exit)
+
+      local saw_exit_error = false
+      local saw_nothing_warning = false
+      for _, note in ipairs(notifications) do
+        if note.level == vim.log.levels.ERROR and note.msg:find("Raccoon exit failed", 1, true) then
+          saw_exit_error = true
+        end
+        if note.level == vim.log.levels.WARN and note.msg:find("Nothing to exit", 1, true) then
+          saw_nothing_warning = true
+        end
+      end
+
+      assert.is_true(saw_exit_error)
+      assert.is_true(saw_nothing_warning)
+    end)
   end)
 
   describe("sync", function()

--- a/tests/open_spec.lua
+++ b/tests/open_spec.lua
@@ -170,6 +170,145 @@ describe("raccoon.open", function()
       assert.is_not_nil(notify_msg)
       assert.truthy(notify_msg:match("closed"))
     end)
+
+    it("supports silent_success option", function()
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+
+      local notify_called = false
+      local original_notify = vim.notify
+      vim.notify = function()
+        notify_called = true
+      end
+
+      open.close_pr({ silent_success = true })
+
+      vim.notify = original_notify
+      assert.is_false(notify_called)
+    end)
+  end)
+
+  describe("close_all_sessions", function()
+    local original_localcommits
+    local original_commits
+    local original_parallel_agents
+    local original_ui
+
+    before_each(function()
+      original_localcommits = package.loaded["raccoon.localcommits"]
+      original_commits = package.loaded["raccoon.commits"]
+      original_parallel_agents = package.loaded["raccoon.parallel_agents"]
+      original_ui = package.loaded["raccoon.ui"]
+    end)
+
+    after_each(function()
+      package.loaded["raccoon.localcommits"] = original_localcommits
+      package.loaded["raccoon.commits"] = original_commits
+      package.loaded["raccoon.parallel_agents"] = original_parallel_agents
+      package.loaded["raccoon.ui"] = original_ui
+    end)
+
+    it("warns when nothing is active", function()
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+
+      package.loaded["raccoon.localcommits"] = {
+        is_active = function() return false end,
+        exit_local_mode = function() error("should not be called") end,
+      }
+      package.loaded["raccoon.commits"] = {
+        exit_commit_mode = function() error("should not be called") end,
+      }
+      package.loaded["raccoon.parallel_agents"] = {
+        get_running_count = function() return 0 end,
+        kill_all = function() return { requested = 0, stopped = 0, errors = {} } end,
+      }
+      package.loaded["raccoon.ui"] = {
+        has_open_windows = function() return false end,
+        close_all_windows = function() error("should not be called") end,
+      }
+
+      local did_exit = open.close_all_sessions()
+      vim.notify = original_notify
+
+      assert.is_false(did_exit)
+      assert.equals(1, #notifications)
+      assert.equals(vim.log.levels.WARN, notifications[1].level)
+      assert.truthy(notifications[1].msg:find("Nothing to exit", 1, true))
+    end)
+
+    it("kills agents and tears down active modes", function()
+      local local_exit_calls = 0
+      local commit_exit_calls = 0
+      local close_windows_calls = 0
+      local kill_calls = 0
+      local closed_pr = 0
+
+      state.start({
+        owner = "test",
+        repo = "test",
+        number = 1,
+        url = "https://github.com/test/test/pull/1",
+        clone_path = "/tmp/test",
+      })
+      state.set_commit_mode(true)
+
+      package.loaded["raccoon.localcommits"] = {
+        is_active = function() return true end,
+        exit_local_mode = function(opts)
+          local_exit_calls = local_exit_calls + 1
+          assert.is_false(opts.resume_pr)
+          assert.is_true(opts.silent)
+        end,
+      }
+      package.loaded["raccoon.commits"] = {
+        exit_commit_mode = function(opts)
+          commit_exit_calls = commit_exit_calls + 1
+          assert.is_false(opts.resume_sync)
+          assert.is_true(opts.silent)
+        end,
+      }
+      package.loaded["raccoon.parallel_agents"] = {
+        get_running_count = function() return 2 end,
+        kill_all = function()
+          kill_calls = kill_calls + 1
+          return { requested = 2, stopped = 2, errors = {} }
+        end,
+      }
+      package.loaded["raccoon.ui"] = {
+        has_open_windows = function() return true end,
+        close_all_windows = function()
+          close_windows_calls = close_windows_calls + 1
+        end,
+      }
+
+      local original_close_pr = open.close_pr
+      open.close_pr = function(opts)
+        closed_pr = closed_pr + 1
+        assert.is_true(opts.silent_success)
+        assert.is_true(opts.suppress_empty_warning)
+        state.stop()
+        return true
+      end
+
+      local did_exit = open.close_all_sessions()
+      open.close_pr = original_close_pr
+
+      assert.is_true(did_exit)
+      assert.equals(1, kill_calls)
+      assert.equals(1, local_exit_calls)
+      assert.equals(1, commit_exit_calls)
+      assert.equals(1, closed_pr)
+      assert.equals(1, close_windows_calls)
+    end)
   end)
 
   describe("sync", function()

--- a/tests/parallel_agents_spec.lua
+++ b/tests/parallel_agents_spec.lua
@@ -537,5 +537,28 @@ describe("raccoon.parallel_agents", function()
       assert.truthy(result.errors[1]:find("job 505", 1, true))
       assert.equals(0, pa.get_running_count())
     end)
+
+    it("always clears in-progress lock when unexpected errors occur", function()
+      local agents = pa._get_agents()
+      table.insert(agents, { job_id = 606, task_name = "a" })
+
+      local original_ipairs = ipairs
+      _G.ipairs = function()
+        error("unexpected ipairs failure")
+      end
+
+      local ok, result = pcall(pa.kill_all)
+      _G.ipairs = original_ipairs
+
+      assert.is_true(ok)
+      assert.equals(1, result.requested)
+      assert.equals(0, result.stopped)
+      assert.equals(1, #result.errors)
+      assert.truthy(result.errors[1]:find("kill_all failed", 1, true))
+
+      local second = pa.kill_all()
+      assert.equals(0, second.requested)
+      assert.is_nil(second.in_progress)
+    end)
   end)
 end)

--- a/tests/parallel_agents_spec.lua
+++ b/tests/parallel_agents_spec.lua
@@ -475,4 +475,67 @@ describe("raccoon.parallel_agents", function()
       os.remove(tmpfile)
     end)
   end)
+
+  describe("kill_all", function()
+    it("stops running jobs and clears tracking", function()
+      local agents = pa._get_agents()
+      table.insert(agents, { job_id = 101, task_name = "a" })
+      table.insert(agents, { job_id = 202, task_name = "b" })
+
+      local stopped_ids = {}
+      local original_jobstop = vim.fn.jobstop
+      vim.fn.jobstop = function(id)
+        table.insert(stopped_ids, id)
+        return 1
+      end
+
+      local result = pa.kill_all()
+      vim.fn.jobstop = original_jobstop
+
+      assert.equals(2, result.requested)
+      assert.equals(2, result.stopped)
+      assert.equals(0, #result.errors)
+      assert.equals(0, pa.get_running_count())
+      assert.same({ 101, 202 }, stopped_ids)
+    end)
+
+    it("ignores already-gone jobs", function()
+      local agents = pa._get_agents()
+      table.insert(agents, { job_id = 303, task_name = "a" })
+      table.insert(agents, { job_id = 404, task_name = "b" })
+
+      local original_jobstop = vim.fn.jobstop
+      vim.fn.jobstop = function(id)
+        if id == 303 then return 0 end
+        return -1
+      end
+
+      local result = pa.kill_all()
+      vim.fn.jobstop = original_jobstop
+
+      assert.equals(2, result.requested)
+      assert.equals(0, result.stopped)
+      assert.equals(0, #result.errors)
+      assert.equals(0, pa.get_running_count())
+    end)
+
+    it("collects hard errors from jobstop", function()
+      local agents = pa._get_agents()
+      table.insert(agents, { job_id = 505, task_name = "a" })
+
+      local original_jobstop = vim.fn.jobstop
+      vim.fn.jobstop = function()
+        error("boom")
+      end
+
+      local result = pa.kill_all()
+      vim.fn.jobstop = original_jobstop
+
+      assert.equals(1, result.requested)
+      assert.equals(0, result.stopped)
+      assert.equals(1, #result.errors)
+      assert.truthy(result.errors[1]:find("job 505", 1, true))
+      assert.equals(0, pa.get_running_count())
+    end)
+  end)
 end)

--- a/tests/windows_spec.lua
+++ b/tests/windows_spec.lua
@@ -1,0 +1,117 @@
+local loader = require("tests.helpers.loader")
+local windows = loader.reload_from_cwd("raccoon.windows")
+
+describe("raccoon.windows", function()
+  local test_wins = {}
+
+  local function open_float()
+    local buf = vim.api.nvim_create_buf(false, true)
+    local win = vim.api.nvim_open_win(buf, false, {
+      relative = "editor",
+      width = 10,
+      height = 5,
+      row = 0,
+      col = 0,
+      style = "minimal",
+    })
+    table.insert(test_wins, win)
+    return win
+  end
+
+  after_each(function()
+    for _, win in ipairs(test_wins) do
+      pcall(vim.api.nvim_win_close, win, true)
+    end
+    test_wins = {}
+  end)
+
+  describe("mark", function()
+    it("marks a valid window", function()
+      local win = open_float()
+      windows.mark(win)
+      assert.is_true(windows.is_marked(win))
+    end)
+
+    it("does not error on nil", function()
+      assert.has_no.errors(function() windows.mark(nil) end)
+    end)
+
+    it("does not error on invalid window handle", function()
+      assert.has_no.errors(function() windows.mark(99999) end)
+    end)
+  end)
+
+  describe("is_marked", function()
+    it("returns false for unmarked window", function()
+      local win = open_float()
+      assert.is_false(windows.is_marked(win))
+    end)
+
+    it("returns false for nil", function()
+      assert.is_false(windows.is_marked(nil))
+    end)
+
+    it("returns false for invalid handle", function()
+      assert.is_false(windows.is_marked(99999))
+    end)
+  end)
+
+  describe("has_open", function()
+    it("returns false when no windows are marked", function()
+      assert.is_false(windows.has_open())
+    end)
+
+    it("returns true when a marked window is open", function()
+      local win = open_float()
+      windows.mark(win)
+      assert.is_true(windows.has_open())
+    end)
+
+    it("returns false after marked window is closed", function()
+      local win = open_float()
+      windows.mark(win)
+      vim.api.nvim_win_close(win, true)
+      test_wins = {}
+      assert.is_false(windows.has_open())
+    end)
+  end)
+
+  describe("close_all", function()
+    it("closes marked windows and returns count", function()
+      local win1 = open_float()
+      local win2 = open_float()
+      windows.mark(win1)
+      windows.mark(win2)
+      local count = windows.close_all()
+      assert.equals(2, count)
+      assert.is_false(vim.api.nvim_win_is_valid(win1))
+      assert.is_false(vim.api.nvim_win_is_valid(win2))
+      test_wins = {}
+    end)
+
+    it("does not close unmarked windows", function()
+      local marked = open_float()
+      local unmarked = open_float()
+      windows.mark(marked)
+      windows.close_all()
+      assert.is_false(vim.api.nvim_win_is_valid(marked))
+      assert.is_true(vim.api.nvim_win_is_valid(unmarked))
+      test_wins = { unmarked }
+    end)
+
+    it("returns 0 when no windows are marked", function()
+      assert.equals(0, windows.close_all())
+    end)
+
+    it("handles already-closed windows gracefully", function()
+      local win = open_float()
+      windows.mark(win)
+      vim.api.nvim_win_close(win, true)
+      test_wins = {}
+      assert.has_no.errors(function()
+        local count = windows.close_all()
+        assert.equals(0, count)
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Add `<leader>ee` in maximized diff view to open the actual file in an editable floating window with full Vim editing (insert mode, LSP, undo)
- Cursor maps from diff position to the real file line number
- Configurable post-edit command runs after closing — default: `git add <FILE> && git commit -m 'human edit <TIMESTAMP>' && git push`
- `human_edit` config block with `shortcut` and `command` fields (both configurable in `config.json`)

## Test plan
- [ ] `:Raccoon local` → "Current changes" → maximize → `<leader>ee` → verify file opens at correct line with full editing
- [ ] Edit file, `<leader>s` saves, `q` closes → verify diff refreshes and post-edit command runs
- [ ] Test with committed diff (non-working-dir) → verify edit + close works
- [ ] Set `"command": ""` in config → verify no post-edit command runs
- [ ] Set `"shortcut": false` → verify keymap not bound
- [ ] `<leader>aa` still works alongside `<leader>ee`

🤖 Generated with [Claude Code](https://claude.com/claude-code)