### PR TITLE
fix: keep commit viewer sidebars symmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.10.6] - 2026-03-22
 
 ### Fixed
+- Commit viewer sidebars (commit list and file tree) now use the same computed width in both PR and local commit modes instead of diverging
 - Commit mode now locks down only conflicting global shortcuts while preserving raccoon-specific ones (e.g. leader-pr, exit raccoon)
 - Commit mode passthrough keys now honor normalized mappings like `<leader>...`
 - Legacy top-level `passthrough_keymaps` config entries now work as commit-mode passthrough keys

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -11,6 +11,7 @@ M.STAT_BAR_MAX_WIDTH = 20
 
 local GRID_CHROME_LINES = 2 -- global statusline (laststatus=3) + header separator (tabline not accounted for)
 local MIN_DIFF_CONTEXT = 3 -- git's default context line count
+local MIN_GRID_COL_WIDTH = 1
 
 --- Approximate usable editor height for grid layout.
 --- Subtracts cmdheight and global chrome (statusline + header separator); intentionally omits
@@ -29,6 +30,35 @@ function M.compute_grid_context(rows)
   rows = rows or 1
   local row_height = math.floor(M.grid_total_height() / math.max(1, rows))
   return math.max(MIN_DIFF_CONTEXT, math.floor(row_height / 2))
+end
+
+--- Clamp sidebar width so both side panels fit symmetrically in the current editor width.
+--- Leaves at least one column for each grid cell plus the vertical separators.
+---@param cols number Number of grid columns
+---@param requested_width? number Preferred sidebar width
+---@return number
+function M.compute_effective_sidebar_width(cols, requested_width)
+  cols = math.max(1, cols or 1)
+  requested_width = requested_width or M.SIDEBAR_WIDTH
+
+  local separators = cols + 1
+  local remaining = vim.o.columns - cols * MIN_GRID_COL_WIDTH - separators
+  local max_width = math.floor(remaining / 2)
+  return math.max(1, math.min(requested_width, max_width))
+end
+
+--- Truncate sidebar text to fit the available sidebar width.
+---@param text string
+---@param sidebar_width? number
+---@return string
+function M.truncate_sidebar_text(text, sidebar_width)
+  text = text or ""
+  sidebar_width = math.max(1, sidebar_width or M.SIDEBAR_WIDTH)
+  if #text <= sidebar_width - 2 then
+    return text
+  end
+  local keep = math.max(1, sidebar_width - 5)
+  return text:sub(1, keep) .. "..."
 end
 
 --- Compute per-file addition/deletion counts from diff patches
@@ -403,6 +433,7 @@ end
 function M.create_grid_layout(s, rows, cols)
   s.grid_rows = rows
   s.grid_cols = cols
+  s.sidebar_width = M.compute_effective_sidebar_width(cols, M.SIDEBAR_WIDTH)
 
   vim.cmd("only")
 
@@ -412,7 +443,7 @@ function M.create_grid_layout(s, rows, cols)
   s.filetree_win = vim.api.nvim_get_current_win()
   s.filetree_buf = M.create_scratch_buf()
   vim.api.nvim_win_set_buf(s.filetree_win, s.filetree_buf)
-  vim.api.nvim_win_set_width(s.filetree_win, M.SIDEBAR_WIDTH)
+  vim.api.nvim_win_set_width(s.filetree_win, s.sidebar_width)
   vim.wo[s.filetree_win].wrap = false
   vim.wo[s.filetree_win].number = false
   vim.wo[s.filetree_win].relativenumber = false
@@ -428,7 +459,7 @@ function M.create_grid_layout(s, rows, cols)
   s.sidebar_win = vim.api.nvim_get_current_win()
   s.sidebar_buf = M.create_scratch_buf()
   vim.api.nvim_win_set_buf(s.sidebar_win, s.sidebar_buf)
-  vim.api.nvim_win_set_width(s.sidebar_win, M.SIDEBAR_WIDTH)
+  vim.api.nvim_win_set_width(s.sidebar_win, s.sidebar_width)
   vim.wo[s.sidebar_win].cursorline = true
   vim.wo[s.sidebar_win].wrap = false
   vim.wo[s.sidebar_win].number = false
@@ -509,16 +540,16 @@ function M.create_grid_layout(s, rows, cols)
   -- Fix dimensions
   vim.cmd("wincmd =")
   if vim.api.nvim_win_is_valid(s.sidebar_win) then
-    vim.api.nvim_win_set_width(s.sidebar_win, M.SIDEBAR_WIDTH)
+    vim.api.nvim_win_set_width(s.sidebar_win, s.sidebar_width)
   end
   if vim.api.nvim_win_is_valid(s.filetree_win) then
-    vim.api.nvim_win_set_width(s.filetree_win, M.SIDEBAR_WIDTH)
+    vim.api.nvim_win_set_width(s.filetree_win, s.sidebar_width)
   end
   vim.api.nvim_win_set_height(s.header_win, 1)
   local row_height = math.floor(M.grid_total_height() / math.max(1, rows))
   -- After wincmd = equalizes all windows, re-forcing sidebar widths leaves grid columns unbalanced.
   -- Layout (each | is a 1-char separator): filetree | col1 | ... | colN | sidebar = (cols + 1)
-  local grid_width = vim.o.columns - 2 * M.SIDEBAR_WIDTH - (cols + 1)
+  local grid_width = vim.o.columns - 2 * s.sidebar_width - (cols + 1)
   local col_width = math.max(1, math.floor(grid_width / math.max(1, cols)))
   for _, win in ipairs(grid_wins) do
     if vim.api.nvim_win_is_valid(win) then
@@ -1240,6 +1271,7 @@ function M.render_split_sidebar(buf, opts)
 
   local lines = {}
   local highlights = {}
+  local sidebar_width = opts.sidebar_width or M.SIDEBAR_WIDTH
 
   -- Section 1 header
   table.insert(lines, opts.section1_header)
@@ -1247,10 +1279,7 @@ function M.render_split_sidebar(buf, opts)
 
   -- Section 1 commits
   for _, commit in ipairs(opts.section1_commits) do
-    local msg = commit.message
-    if #msg > M.SIDEBAR_WIDTH - 2 then
-      msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
-    end
+    local msg = M.truncate_sidebar_text(commit.message, sidebar_width)
     table.insert(lines, "  " .. msg)
     if opts.commit_hl_fn then
       local hl = opts.commit_hl_fn(commit)
@@ -1267,10 +1296,7 @@ function M.render_split_sidebar(buf, opts)
 
   -- Section 2 commits (dimmed)
   for _, commit in ipairs(opts.section2_commits) do
-    local msg = commit.message
-    if #msg > M.SIDEBAR_WIDTH - 2 then
-      msg = msg:sub(1, M.SIDEBAR_WIDTH - 5) .. "..."
-    end
+    local msg = M.truncate_sidebar_text(commit.message, sidebar_width)
     table.insert(lines, "  " .. msg)
     table.insert(highlights, { line = #lines - 1, hl = "Comment" })
   end

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -47,6 +47,7 @@ local commit_state = {
   cached_stat_lines = nil,
   cached_file_count = nil,
   focus_target = "sidebar",
+  sidebar_width = nil,
 }
 
 --- Commit mode keymaps (global)
@@ -86,6 +87,7 @@ local function reset_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    sidebar_width = nil,
   }
 end
 
@@ -256,6 +258,7 @@ local function render_sidebar()
     section1_commits = commit_state.pr_commits,
     section2_header = "── Base Branch ──",
     section2_commits = commit_state.base_commits,
+    sidebar_width = commit_state.sidebar_width,
   })
   ui.update_sidebar_winbar(commit_state, total_commits())
   update_sidebar_selection()

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -64,6 +64,7 @@ local function make_initial_state()
     cached_file_count = nil,
     focus_target = "sidebar",
     pr_was_active = false,
+    sidebar_width = nil,
   }
 end
 
@@ -256,21 +257,20 @@ local function render_sidebar()
         if commit.sha == nil then return "DiagnosticInfo" end
       end,
       loading = local_state.loading_more,
+      sidebar_width = local_state.sidebar_width,
     })
   else
     -- Flat mode: single section
     local lines = {}
     local highlights = {}
+    local sidebar_width = local_state.sidebar_width or ui.SIDEBAR_WIDTH
 
     local commit_count = math.max(0, total_commits() - 1)
     table.insert(lines, "── Commits (" .. commit_count .. ") ──")
     table.insert(highlights, { line = #lines - 1, hl = "Title" })
 
     for i, commit in ipairs(local_state.branch_commits) do
-      local msg = commit.message
-      if #msg > ui.SIDEBAR_WIDTH - 2 then
-        msg = msg:sub(1, ui.SIDEBAR_WIDTH - 5) .. "..."
-      end
+      local msg = ui.truncate_sidebar_text(commit.message, sidebar_width)
       table.insert(lines, "  " .. msg)
       if commit.sha == nil then
         table.insert(highlights, { line = i, hl = "DiagnosticInfo" })

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -1,6 +1,38 @@
 local commit_ui = require("raccoon.commit_ui")
 
 describe("raccoon.commit_ui", function()
+  describe("compute_effective_sidebar_width", function()
+    it("keeps the requested width when it fits", function()
+      assert.equals(30, commit_ui.compute_effective_sidebar_width(2, 30))
+    end)
+
+    it("clamps oversized sidebars symmetrically", function()
+      local expected = math.floor((vim.o.columns - 2 - 3) / 2)
+      assert.equals(expected, commit_ui.compute_effective_sidebar_width(2, 50))
+    end)
+  end)
+
+  describe("create_grid_layout", function()
+    it("applies the same effective width to both sidebars", function()
+      local original_sidebar_width = commit_ui.SIDEBAR_WIDTH
+      local state = { grid_wins = {}, grid_bufs = {} }
+
+      commit_ui.SIDEBAR_WIDTH = 50
+      commit_ui.create_grid_layout(state, 2, 2)
+
+      assert.equals(state.sidebar_width, vim.api.nvim_win_get_width(state.filetree_win))
+      assert.equals(state.sidebar_width, vim.api.nvim_win_get_width(state.sidebar_win))
+      assert.equals(vim.api.nvim_win_get_width(state.filetree_win), vim.api.nvim_win_get_width(state.sidebar_win))
+
+      commit_ui.close_grid(state)
+      commit_ui.close_win_pair(state, "header_win", "header_buf")
+      commit_ui.close_win_pair(state, "sidebar_win", "sidebar_buf")
+      commit_ui.close_win_pair(state, "filetree_win", "filetree_buf")
+      vim.cmd("only")
+      commit_ui.SIDEBAR_WIDTH = original_sidebar_width
+    end)
+  end)
+
   describe("setup_focus_lock", function()
     it("clears stale popup_win handles", function()
       local state = {


### PR DESCRIPTION
## Summary
- reproduce and fix the commit viewer layout bug where an oversized sidebar width could leave the file tree wider than the commit list
- clamp both sidebars to the same effective width based on the current editor width
- use the effective sidebar width for commit list truncation in both PR and local commit viewers

## Testing
- nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/commit_ui_spec.lua" -c qa
- make test