### PR TITLE
fix: normalize commit mode passthrough keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.6] - 2026-03-22
+
+### Fixed
+- Commit mode now locks down only conflicting global shortcuts while preserving raccoon-specific ones (e.g. leader-pr, exit raccoon)
+- Clamp grid column width to minimum 1 for narrow terminals
+
 ## [0.10.5] - 2026-03-22
 
 ### Fixed

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -101,13 +101,23 @@ end
 local function shadow_global_keymaps(buf, mode)
   if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
   local shortcuts = config.load_shortcuts()
-  local passthrough = {}
-  for _, lhs in ipairs(config.load_commit_viewer().passthrough_keys or {}) do
-    passthrough[lhs] = true
+  local function normalize_lhs(lhs)
+    if type(lhs) ~= "string" or lhs == "" then return nil end
+    return vim.fn.keytrans(vim.api.nvim_replace_termcodes(lhs, true, true, true))
   end
 
-  local function is_raccoon_global_map(map)
-    if map.lhs == shortcuts.pr_list or map.lhs == shortcuts.show_shortcuts then
+  local pr_list_lhs = normalize_lhs(shortcuts.pr_list)
+  local show_shortcuts_lhs = normalize_lhs(shortcuts.show_shortcuts)
+  local passthrough = {}
+  for _, lhs in ipairs(config.load_commit_viewer().passthrough_keys or {}) do
+    local normalized_lhs = normalize_lhs(lhs)
+    if normalized_lhs then
+      passthrough[normalized_lhs] = true
+    end
+  end
+
+  local function is_raccoon_global_map(map, normalized_lhs)
+    if normalized_lhs == pr_list_lhs or normalized_lhs == show_shortcuts_lhs then
       return true
     end
 
@@ -122,10 +132,11 @@ local function shadow_global_keymaps(buf, mode)
   local nop = function() end
   for _, map in ipairs(vim.api.nvim_get_keymap(mode)) do
     local lhs = map.lhs
+    local normalized_lhs = normalize_lhs(lhs)
     if type(lhs) == "string"
         and lhs ~= ""
-        and not passthrough[lhs]
-        and not is_raccoon_global_map(map)
+        and not passthrough[normalized_lhs]
+        and not is_raccoon_global_map(map, normalized_lhs)
         and not lhs:match("^<Plug>")
     then
       pcall(vim.keymap.set, mode, lhs, nop, opts)

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -322,13 +322,39 @@ describe("raccoon.commits keybinding lockdown", function()
   end
 
   local function has_buf_keymap(buf, mode, lhs)
+    local expected_lhs = vim.fn.keytrans(vim.api.nvim_replace_termcodes(lhs, true, true, true))
     local maps = vim.api.nvim_buf_get_keymap(buf, mode)
     for _, map in ipairs(maps) do
-      if map.lhs == lhs then
+      local actual_lhs = vim.fn.keytrans(vim.api.nvim_replace_termcodes(map.lhs, true, true, true))
+      if actual_lhs == expected_lhs then
         return true
       end
     end
     return false
+  end
+
+  local function with_commit_viewer_passthrough_keys(keys, callback)
+    local original_config_path = config.config_path
+    local tmpdir = "/tmp/claude/raccoon-tests"
+    local tmpfile = tmpdir .. "/commit_mode_passthrough.json"
+    vim.fn.mkdir(tmpdir, "p")
+
+    local f = assert(io.open(tmpfile, "w"))
+    f:write(vim.json.encode({
+      commit_viewer = {
+        passthrough_keys = keys,
+      },
+    }))
+    f:close()
+
+    config.config_path = tmpfile
+    local ok, err = xpcall(callback, debug.traceback)
+    config.config_path = original_config_path
+    os.remove(tmpfile)
+
+    if not ok then
+      error(err)
+    end
   end
 
   describe("_lock_buf", function()
@@ -390,31 +416,31 @@ describe("raccoon.commits keybinding lockdown", function()
     end)
 
     it("keeps configured passthrough mappings active", function()
-      local original_config_path = config.config_path
-      local tmpdir = "/tmp/claude/raccoon-tests"
-      local tmpfile = tmpdir .. "/commit_mode_passthrough.json"
-      vim.fn.mkdir(tmpdir, "p")
+      with_commit_viewer_passthrough_keys({ "<F20>" }, function()
+        vim.keymap.set("n", "<F20>", function() end)
 
-      local f = io.open(tmpfile, "w")
-      f:write([[{
-        "commit_viewer": {
-          "passthrough_keys": ["<F20>"]
-        }
-      }]])
-      f:close()
+        local buf = create_scratch_buf()
+        commits._lock_buf(buf)
 
-      config.config_path = tmpfile
-      vim.keymap.set("n", "<F20>", function() end)
+        assert.is_false(has_buf_keymap(buf, "n", "<F20>"))
 
-      local buf = create_scratch_buf()
-      commits._lock_buf(buf)
+        vim.api.nvim_buf_delete(buf, { force = true })
+        vim.keymap.del("n", "<F20>")
+      end)
+    end)
 
-      assert.is_false(has_buf_keymap(buf, "n", "<F20>"))
+    it("keeps configured leader passthrough mappings active", function()
+      with_commit_viewer_passthrough_keys({ "<leader>tp" }, function()
+        vim.keymap.set("n", "<leader>tp", function() end)
 
-      vim.api.nvim_buf_delete(buf, { force = true })
-      vim.keymap.del("n", "<F20>")
-      config.config_path = original_config_path
-      os.remove(tmpfile)
+        local buf = create_scratch_buf()
+        commits._lock_buf(buf)
+
+        assert.is_false(has_buf_keymap(buf, "n", "<leader>tp"))
+
+        vim.api.nvim_buf_delete(buf, { force = true })
+        vim.keymap.del("n", "<leader>tp")
+      end)
     end)
 
     it("keeps raccoon global mappings active", function()


### PR DESCRIPTION
## Summary
- normalize commit-mode passthrough keys before comparing them to global mappings
- preserve buffer-local shortcut shadowing while allowing configured <leader> passthrough keys again
- add a regression test for leader-based passthrough mappings and deduplicate passthrough test config setup

## Testing
- make test
- make lint