### PR TITLE
feat: collapse grid to 1x1 file preview when browsing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11] - 2026-03-23
+
+### Added
+- Grid-to-preview collapse — pressing `browse_files` in commit mode now collapses the NxM diff grid into a 1×1 preview pane showing the currently selected file's diff or content
+- Live file preview updates as you navigate files with j/k in the file tree
+- Toggling back to commit mode restores the original grid layout with diff hunks
+- `rebuild_grid()` helper to resize the grid in-place using the anchor window
+- `render_file_preview()` helper to display diff or file content in the preview cell
+- Works in both PR commit mode and local commit mode
+
 ## [0.10.6] - 2026-03-22
 
 ### Fixed

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -680,7 +680,7 @@ local function finalize_preview(buf, win, filename, lines)
   local ft = vim.filetype.match({ filename = filename })
   if ft then vim.bo[buf].filetype = ft end
   if win and vim.api.nvim_win_is_valid(win) then
-    vim.wo[win].winbar = " " .. filename
+    vim.wo[win].winbar = " " .. filename .. "%=[Enter]"
     pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
   end
 end
@@ -778,7 +778,7 @@ function M._set_preview_empty(buf, win, filename, msg)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", msg })
   vim.bo[buf].modifiable = false
   if win and vim.api.nvim_win_is_valid(win) then
-    vim.wo[win].winbar = " " .. filename
+    vim.wo[win].winbar = " " .. filename .. "%=[Enter]"
   end
 end
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -588,6 +588,7 @@ function M.rebuild_grid(s, rows, cols, apply_keymaps)
 
   if not anchor_win then
     -- Fallback: create a window to the left of sidebar
+    if not s.sidebar_win or not vim.api.nvim_win_is_valid(s.sidebar_win) then return end
     vim.api.nvim_set_current_win(s.sidebar_win)
     vim.cmd("aboveleft vsplit")
     anchor_win = vim.api.nvim_get_current_win()
@@ -644,10 +645,10 @@ function M.rebuild_grid(s, rows, cols, apply_keymaps)
   end
 
   -- Fix dimensions: set sidebar/filetree widths first, then equalize grid cells
-  if vim.api.nvim_win_is_valid(s.sidebar_win) then
+  if s.sidebar_win and vim.api.nvim_win_is_valid(s.sidebar_win) then
     vim.api.nvim_win_set_width(s.sidebar_win, M.SIDEBAR_WIDTH)
   end
-  if vim.api.nvim_win_is_valid(s.filetree_win) then
+  if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
     vim.api.nvim_win_set_width(s.filetree_win, M.SIDEBAR_WIDTH)
   end
   if s.header_win and vim.api.nvim_win_is_valid(s.header_win) then
@@ -667,6 +668,23 @@ function M.rebuild_grid(s, rows, cols, apply_keymaps)
   apply_keymaps(grid_bufs)
 end
 
+--- Write lines to a preview buffer, set filetype, and update winbar.
+---@param buf number Buffer ID
+---@param win number|nil Window ID
+---@param filename string File name for filetype detection and winbar
+---@param lines string[] Lines to write
+local function finalize_preview(buf, win, filename, lines)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+  local ft = vim.filetype.match({ filename = filename })
+  if ft then vim.bo[buf].filetype = ft end
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.wo[win].winbar = " " .. filename
+    pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
+  end
+end
+
 --- Render a file preview into the first grid buffer.
 --- Shows diff if file is changed in the current commit, otherwise shows raw content.
 ---@param s table State table (needs grid_bufs[1])
@@ -679,7 +697,7 @@ function M.render_file_preview(s, opts)
   local git = require("raccoon.git")
   local is_changed = s.commit_files and s.commit_files[opts.filename]
 
-  s.preview_generation = (s.preview_generation or 0) + 1
+  s.preview_generation = s.preview_generation + 1
   local gen = s.preview_generation
 
   if is_changed then
@@ -689,6 +707,7 @@ function M.render_file_preview(s, opts)
 
     fetch_patch(function(patch, err)
       if s.preview_generation ~= gen then return end
+      if not vim.api.nvim_buf_is_valid(buf) then return end
       if err or not patch or patch == "" then
         M._set_preview_empty(buf, win, opts.filename, "  No diff available")
         return
@@ -706,36 +725,46 @@ function M.render_file_preview(s, opts)
           table.insert(hl_lines, { type = line_data.type })
         end
       end
-      vim.bo[buf].modifiable = true
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-      vim.bo[buf].modifiable = false
-      local ft = vim.filetype.match({ filename = opts.filename })
-      if ft then vim.bo[buf].filetype = ft end
+      finalize_preview(buf, win, opts.filename, lines)
       M.apply_diff_highlights(opts.ns_id, buf, hl_lines)
-      if win and vim.api.nvim_win_is_valid(win) then
-        vim.wo[win].winbar = " " .. opts.filename
-        pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
-      end
     end)
   else
     git.show_file_content(opts.repo_path, opts.sha, opts.filename, function(lines, err)
       if s.preview_generation ~= gen then return end
+      if not vim.api.nvim_buf_is_valid(buf) then return end
       if err or not lines then
         M._set_preview_empty(buf, win, opts.filename, "  Cannot read file")
         return
       end
-      vim.bo[buf].modifiable = true
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-      vim.bo[buf].modifiable = false
-      local ft = vim.filetype.match({ filename = opts.filename })
-      if ft then vim.bo[buf].filetype = ft end
+      finalize_preview(buf, win, opts.filename, lines)
       vim.api.nvim_buf_clear_namespace(buf, opts.ns_id, 0, -1)
-      if win and vim.api.nvim_win_is_valid(win) then
-        vim.wo[win].winbar = " " .. opts.filename
-        pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
-      end
     end)
   end
+end
+
+--- Apply a list of keymaps to a set of buffers.
+---@param keymaps table[] Array of {mode, lhs, rhs, desc}
+---@param bufs number[] Buffer IDs
+function M.apply_keymaps_to_bufs(keymaps, bufs)
+  for _, buf in ipairs(bufs) do
+    for _, km in ipairs(keymaps) do
+      vim.keymap.set(km.mode, km.lhs, km.rhs,
+        { buffer = buf, noremap = true, silent = true, desc = km.desc })
+    end
+  end
+end
+
+--- Return sorted line indices that map to file paths in cached_line_paths.
+---@param s table State table (needs cached_line_paths)
+---@return number[]
+function M._sorted_file_lines(s)
+  local result = {}
+  if not s.cached_line_paths then return result end
+  for line_idx, _ in pairs(s.cached_line_paths) do
+    table.insert(result, line_idx)
+  end
+  table.sort(result)
+  return result
 end
 
 --- Helper to set empty preview content
@@ -744,6 +773,7 @@ end
 ---@param filename string File name for winbar
 ---@param msg string Message to display
 function M._set_preview_empty(buf, win, filename, msg)
+  if not vim.api.nvim_buf_is_valid(buf) then return end
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", msg })
   vim.bo[buf].modifiable = false
@@ -1313,13 +1343,7 @@ function M.setup_filetree_nav(s, opts)
   if not s.filetree_buf or not vim.api.nvim_buf_is_valid(s.filetree_buf) then return end
 
   local function all_file_lines()
-    local result = {}
-    if not s.cached_line_paths then return result end
-    for line_idx, _ in pairs(s.cached_line_paths) do
-      table.insert(result, line_idx)
-    end
-    table.sort(result)
-    return result
+    return M._sorted_file_lines(s)
   end
 
   local function go_to_line(line_idx)
@@ -1413,14 +1437,15 @@ end
 ---@param s table State table
 ---@param opts table {apply_keymaps, render_page, ns_id, get_repo_path, get_sha, get_is_working_dir}
 function M.toggle_filetree_focus(s, opts)
-  opts = opts or {}
+  if not opts or not opts.apply_keymaps then return end
   if s.focus_target == "filetree" then
     -- Switching back to sidebar: restore original grid
     s.focus_target = "sidebar"
     if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
       vim.wo[s.filetree_win].cursorline = false
     end
-    if s.orig_grid_rows and opts.apply_keymaps then
+    if s.orig_grid_rows then
+      s.preview_generation = s.preview_generation + 1
       M.rebuild_grid(s, s.orig_grid_rows, s.orig_grid_cols, opts.apply_keymaps)
       s.orig_grid_rows = nil
       s.orig_grid_cols = nil
@@ -1432,12 +1457,10 @@ function M.toggle_filetree_focus(s, opts)
   else
     -- Switching to filetree: collapse grid to 1x1 with file preview
     s.focus_target = "filetree"
-    if opts.apply_keymaps then
-      s.orig_grid_rows = s.grid_rows
-      s.orig_grid_cols = s.grid_cols
-      M.rebuild_grid(s, 1, 1, opts.apply_keymaps)
-      M._preview_file_at_cursor(s, opts)
-    end
+    s.orig_grid_rows = s.grid_rows
+    s.orig_grid_cols = s.grid_cols
+    M.rebuild_grid(s, 1, 1, opts.apply_keymaps)
+    M._preview_file_at_cursor(s, opts)
     if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
       vim.wo[s.filetree_win].cursorline = true
       vim.api.nvim_set_current_win(s.filetree_win)
@@ -1458,11 +1481,7 @@ function M._preview_file_at_cursor(s, opts)
 
   -- If cursor is not on a file line, find the nearest one
   if not path then
-    local file_lines = {}
-    for line_idx, _ in pairs(s.cached_line_paths) do
-      table.insert(file_lines, line_idx)
-    end
-    table.sort(file_lines)
+    local file_lines = M._sorted_file_lines(s)
     -- Find first file line at or after cursor
     for _, idx in ipairs(file_lines) do
       if idx >= cur then
@@ -1478,7 +1497,14 @@ function M._preview_file_at_cursor(s, opts)
     end
   end
 
-  if not path then return end
+  -- Clear stale preview content when no file is found
+  if not path then
+    local buf = s.grid_bufs and s.grid_bufs[1]
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      M._set_preview_empty(buf, s.grid_wins and s.grid_wins[1], "(no file)", "  No file at cursor")
+    end
+    return
+  end
   local repo_path = opts.get_repo_path and opts.get_repo_path()
   if not repo_path then return end
   local sha = opts.get_sha and opts.get_sha()

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -561,6 +561,197 @@ function M.close_grid(s)
   s.grid_bufs = {}
 end
 
+--- Rebuild the grid portion of the layout without touching sidebar/filetree/header.
+--- Keeps one grid window as an anchor to preserve layout position, closes the rest,
+--- then splits the anchor to create the new grid dimensions.
+---@param s table State table
+---@param rows number New grid rows
+---@param cols number New grid cols
+---@param apply_keymaps fun(bufs: number[]) Callback to apply keymaps to new grid buffers
+function M.rebuild_grid(s, rows, cols, apply_keymaps)
+  s.grid_rows = rows
+  s.grid_cols = cols
+
+  -- Keep the first valid grid window as anchor, close the rest
+  local anchor_win = nil
+  for _, win in ipairs(s.grid_wins) do
+    if vim.api.nvim_win_is_valid(win) then
+      if not anchor_win then
+        anchor_win = win
+      else
+        pcall(vim.api.nvim_win_close, win, true)
+      end
+    end
+  end
+  s.grid_wins = {}
+  s.grid_bufs = {}
+
+  if not anchor_win then
+    -- Fallback: create a window to the left of sidebar
+    vim.api.nvim_set_current_win(s.sidebar_win)
+    vim.cmd("aboveleft vsplit")
+    anchor_win = vim.api.nvim_get_current_win()
+  end
+
+  vim.api.nvim_set_current_win(anchor_win)
+
+  -- Build row windows by splitting the anchor downward
+  local row_wins = { anchor_win }
+  for _ = 2, rows do
+    vim.api.nvim_set_current_win(row_wins[#row_wins])
+    vim.cmd("belowright split")
+    table.insert(row_wins, vim.api.nvim_get_current_win())
+  end
+
+  -- Build grid cells by splitting each row rightward
+  local grid_wins = {}
+  local grid_bufs = {}
+  for _, row_win in ipairs(row_wins) do
+    vim.api.nvim_set_current_win(row_win)
+    local col_wins = { row_win }
+    for _ = 2, cols do
+      vim.cmd("belowright vsplit")
+      table.insert(col_wins, vim.api.nvim_get_current_win())
+    end
+    for _, win in ipairs(col_wins) do
+      local buf = M.create_scratch_buf()
+      vim.api.nvim_win_set_buf(win, buf)
+      vim.wo[win].wrap = true
+      vim.wo[win].number = false
+      vim.wo[win].relativenumber = false
+      vim.wo[win].signcolumn = "yes:1"
+      M.lock_buf(buf)
+      table.insert(grid_wins, win)
+      table.insert(grid_bufs, buf)
+    end
+  end
+
+  -- Reverse to reading order: top-left=1, top-right=2, bottom-left=3, etc.
+  local n = #grid_wins
+  for i = 1, math.floor(n / 2) do
+    grid_wins[i], grid_wins[n - i + 1] = grid_wins[n - i + 1], grid_wins[i]
+    grid_bufs[i], grid_bufs[n - i + 1] = grid_bufs[n - i + 1], grid_bufs[i]
+  end
+
+  s.grid_wins = grid_wins
+  s.grid_bufs = grid_bufs
+
+  for i, win in ipairs(grid_wins) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.wo[win].winbar = "%=#" .. i
+      vim.wo[win].winhl = "WinBar:Normal,WinBarNC:Normal"
+    end
+  end
+
+  -- Fix dimensions: set sidebar/filetree widths first, then equalize grid cells
+  if vim.api.nvim_win_is_valid(s.sidebar_win) then
+    vim.api.nvim_win_set_width(s.sidebar_win, M.SIDEBAR_WIDTH)
+  end
+  if vim.api.nvim_win_is_valid(s.filetree_win) then
+    vim.api.nvim_win_set_width(s.filetree_win, M.SIDEBAR_WIDTH)
+  end
+  if s.header_win and vim.api.nvim_win_is_valid(s.header_win) then
+    vim.api.nvim_win_set_height(s.header_win, math.max(1, #vim.api.nvim_buf_get_lines(s.header_buf, 0, -1, false)))
+  end
+  local row_height = math.floor(M.grid_total_height() / math.max(1, rows))
+  local grid_width = vim.o.columns - 2 * M.SIDEBAR_WIDTH - (cols + 1)
+  local col_width = math.max(1, math.floor(grid_width / math.max(1, cols)))
+  for _, win in ipairs(grid_wins) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_set_height(win, row_height)
+      vim.api.nvim_win_set_width(win, col_width)
+    end
+  end
+
+  -- Apply keymaps to the new buffers
+  apply_keymaps(grid_bufs)
+end
+
+--- Render a file preview into the first grid buffer.
+--- Shows diff if file is changed in the current commit, otherwise shows raw content.
+---@param s table State table (needs grid_bufs[1])
+---@param opts table {ns_id, repo_path, sha, filename, is_working_dir}
+function M.render_file_preview(s, opts)
+  local buf = s.grid_bufs and s.grid_bufs[1]
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
+  local win = s.grid_wins and s.grid_wins[1]
+
+  local git = require("raccoon.git")
+  local is_changed = s.commit_files and s.commit_files[opts.filename]
+
+  s.preview_generation = (s.preview_generation or 0) + 1
+  local gen = s.preview_generation
+
+  if is_changed then
+    local fetch_patch = opts.is_working_dir
+        and function(cb) git.diff_working_dir_file(opts.repo_path, opts.filename, cb) end
+      or function(cb) git.show_commit_file(opts.repo_path, opts.sha, opts.filename, cb) end
+
+    fetch_patch(function(patch, err)
+      if s.preview_generation ~= gen then return end
+      if err or not patch or patch == "" then
+        M._set_preview_empty(buf, win, opts.filename, "  No diff available")
+        return
+      end
+      local hunks = diff.parse_patch(patch)
+      if #hunks == 0 then
+        M._set_preview_empty(buf, win, opts.filename, "  No changes")
+        return
+      end
+      local lines = {}
+      local hl_lines = {}
+      for _, hunk in ipairs(hunks) do
+        for _, line_data in ipairs(hunk.lines) do
+          table.insert(lines, line_data.content or "")
+          table.insert(hl_lines, { type = line_data.type })
+        end
+      end
+      vim.bo[buf].modifiable = true
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.bo[buf].modifiable = false
+      local ft = vim.filetype.match({ filename = opts.filename })
+      if ft then vim.bo[buf].filetype = ft end
+      M.apply_diff_highlights(opts.ns_id, buf, hl_lines)
+      if win and vim.api.nvim_win_is_valid(win) then
+        vim.wo[win].winbar = " " .. opts.filename
+        pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
+      end
+    end)
+  else
+    git.show_file_content(opts.repo_path, opts.sha, opts.filename, function(lines, err)
+      if s.preview_generation ~= gen then return end
+      if err or not lines then
+        M._set_preview_empty(buf, win, opts.filename, "  Cannot read file")
+        return
+      end
+      vim.bo[buf].modifiable = true
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.bo[buf].modifiable = false
+      local ft = vim.filetype.match({ filename = opts.filename })
+      if ft then vim.bo[buf].filetype = ft end
+      vim.api.nvim_buf_clear_namespace(buf, opts.ns_id, 0, -1)
+      if win and vim.api.nvim_win_is_valid(win) then
+        vim.wo[win].winbar = " " .. opts.filename
+        pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
+      end
+    end)
+  end
+end
+
+--- Helper to set empty preview content
+---@param buf number Buffer ID
+---@param win number|nil Window ID
+---@param filename string File name for winbar
+---@param msg string Message to display
+function M._set_preview_empty(buf, win, filename, msg)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "", msg })
+  vim.bo[buf].modifiable = false
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.wo[win].winbar = " " .. filename
+  end
+end
+
 --- Open a maximize floating window for a full-file diff
 ---@param opts table {ns_id, repo_path, sha, filename, commit_message, generation, ...}
 function M.open_maximize(opts)
@@ -1115,9 +1306,9 @@ function M.setup_focus_lock(s, augroup_name)
 end
 
 --- Setup filetree browsing keymaps. j/k navigate all files, Enter shows file diff.
---- The diff grid stays intact while browsing.
+--- When in filetree focus (1x1 grid), navigation also updates the file preview.
 ---@param s table State table
----@param opts table {get_repo_path, get_sha, ns_id}
+---@param opts table {get_repo_path, get_sha, get_commit_message, get_is_working_dir, ns_id}
 function M.setup_filetree_nav(s, opts)
   if not s.filetree_buf or not vim.api.nvim_buf_is_valid(s.filetree_buf) then return end
 
@@ -1137,13 +1328,19 @@ function M.setup_filetree_nav(s, opts)
     end
   end
 
+  local function maybe_preview()
+    if s.focus_target == "filetree" and s.orig_grid_rows then
+      M._preview_file_at_cursor(s, opts)
+    end
+  end
+
   local function ft_move_down()
     if not s.filetree_win or not vim.api.nvim_win_is_valid(s.filetree_win) then return end
     local lines = all_file_lines()
     if #lines == 0 then return end
     local cur = vim.api.nvim_win_get_cursor(s.filetree_win)[1] - 1
     for _, idx in ipairs(lines) do
-      if idx > cur then go_to_line(idx); return end
+      if idx > cur then go_to_line(idx); maybe_preview(); return end
     end
   end
 
@@ -1153,18 +1350,18 @@ function M.setup_filetree_nav(s, opts)
     if #lines == 0 then return end
     local cur = vim.api.nvim_win_get_cursor(s.filetree_win)[1] - 1
     for i = #lines, 1, -1 do
-      if lines[i] < cur then go_to_line(lines[i]); return end
+      if lines[i] < cur then go_to_line(lines[i]); maybe_preview(); return end
     end
   end
 
   local function ft_move_top()
     local lines = all_file_lines()
-    if #lines > 0 then go_to_line(lines[1]) end
+    if #lines > 0 then go_to_line(lines[1]); maybe_preview() end
   end
 
   local function ft_move_bottom()
     local lines = all_file_lines()
-    if #lines > 0 then go_to_line(lines[#lines]) end
+    if #lines > 0 then go_to_line(lines[#lines]); maybe_preview() end
   end
 
   local function ft_select()
@@ -1210,24 +1407,88 @@ function M.setup_filetree_nav(s, opts)
   })
 end
 
---- Toggle focus between sidebar and filetree panels
+--- Toggle focus between sidebar and filetree panels.
+--- When switching to filetree, collapses the grid to 1x1 and shows a file preview.
+--- When switching back to sidebar, restores the original NxM grid.
 ---@param s table State table
-function M.toggle_filetree_focus(s)
+---@param opts table {apply_keymaps, render_page, ns_id, get_repo_path, get_sha, get_is_working_dir}
+function M.toggle_filetree_focus(s, opts)
+  opts = opts or {}
   if s.focus_target == "filetree" then
+    -- Switching back to sidebar: restore original grid
     s.focus_target = "sidebar"
     if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
       vim.wo[s.filetree_win].cursorline = false
+    end
+    if s.orig_grid_rows and opts.apply_keymaps then
+      M.rebuild_grid(s, s.orig_grid_rows, s.orig_grid_cols, opts.apply_keymaps)
+      s.orig_grid_rows = nil
+      s.orig_grid_cols = nil
+      if opts.render_page then opts.render_page() end
     end
     if s.sidebar_win and vim.api.nvim_win_is_valid(s.sidebar_win) then
       vim.api.nvim_set_current_win(s.sidebar_win)
     end
   else
+    -- Switching to filetree: collapse grid to 1x1 with file preview
     s.focus_target = "filetree"
+    if opts.apply_keymaps then
+      s.orig_grid_rows = s.grid_rows
+      s.orig_grid_cols = s.grid_cols
+      M.rebuild_grid(s, 1, 1, opts.apply_keymaps)
+      M._preview_file_at_cursor(s, opts)
+    end
     if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
       vim.wo[s.filetree_win].cursorline = true
       vim.api.nvim_set_current_win(s.filetree_win)
     end
   end
+end
+
+--- Preview the file at the current filetree cursor position in the 1x1 grid.
+--- If the cursor is not on a file line, moves to the nearest file line first.
+---@param s table State table
+---@param opts table {ns_id, get_repo_path, get_sha, get_is_working_dir}
+function M._preview_file_at_cursor(s, opts)
+  if not s.filetree_win or not vim.api.nvim_win_is_valid(s.filetree_win) then return end
+  if not s.cached_line_paths then return end
+
+  local cur = vim.api.nvim_win_get_cursor(s.filetree_win)[1] - 1
+  local path = s.cached_line_paths[cur]
+
+  -- If cursor is not on a file line, find the nearest one
+  if not path then
+    local file_lines = {}
+    for line_idx, _ in pairs(s.cached_line_paths) do
+      table.insert(file_lines, line_idx)
+    end
+    table.sort(file_lines)
+    -- Find first file line at or after cursor
+    for _, idx in ipairs(file_lines) do
+      if idx >= cur then
+        path = s.cached_line_paths[idx]
+        pcall(vim.api.nvim_win_set_cursor, s.filetree_win, { idx + 1, 0 })
+        break
+      end
+    end
+    -- Fall back to first file line
+    if not path and #file_lines > 0 then
+      path = s.cached_line_paths[file_lines[1]]
+      pcall(vim.api.nvim_win_set_cursor, s.filetree_win, { file_lines[1] + 1, 0 })
+    end
+  end
+
+  if not path then return end
+  local repo_path = opts.get_repo_path and opts.get_repo_path()
+  if not repo_path then return end
+  local sha = opts.get_sha and opts.get_sha()
+  M.render_file_preview(s, {
+    ns_id = opts.ns_id,
+    repo_path = repo_path,
+    sha = sha,
+    filename = path,
+    is_working_dir = opts.get_is_working_dir and opts.get_is_working_dir() or false,
+  })
 end
 
 --- Render a two-section sidebar (section1 commits + separator + section2 commits dimmed).

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -360,53 +360,7 @@ local function setup_keymaps()
     end
   end
 
-  -- Helper to apply mode keymaps to a set of buffers
-  local function apply_keymaps_to_bufs(bufs)
-    for _, buf in ipairs(bufs) do
-      for _, km in ipairs(commit_mode_keymaps) do
-        vim.keymap.set(km.mode, km.lhs, km.rhs,
-          { buffer = buf, noremap = true, silent = true, desc = km.desc })
-      end
-    end
-  end
-
-  local toggle_opts = {
-    ns_id = ns_id,
-    get_repo_path = function() return state.get_clone_path() end,
-    get_sha = function()
-      local c = get_commit(commit_state.selected_index)
-      return c and c.sha
-    end,
-    get_is_working_dir = function() return false end,
-    apply_keymaps = apply_keymaps_to_bufs,
-    render_page = render_grid_page,
-  }
-
-  -- Browse files toggle
-  if config.is_enabled(shortcuts.commit_mode.browse_files) then
-    table.insert(commit_mode_keymaps, {
-      mode = NORMAL_MODE,
-      lhs = shortcuts.commit_mode.browse_files,
-      rhs = function() ui.toggle_filetree_focus(commit_state, toggle_opts) end,
-      desc = "Toggle file tree browsing",
-    })
-  end
-
-  -- Apply keymaps buffer-locally
-  local commit_bufs = ui.collect_bufs(commit_state)
-  apply_keymaps_to_bufs(commit_bufs)
-
-  -- Sidebar-local keymaps
-  ui.setup_sidebar_nav(commit_state.sidebar_buf, {
-    move_down = move_down,
-    move_up = move_up,
-    move_to_top = move_to_top,
-    move_to_bottom = move_to_bottom,
-    select_at_cursor = select_at_cursor,
-  })
-
-  -- Filetree navigation keymaps
-  ui.setup_filetree_nav(commit_state, {
+  local filetree_opts = {
     ns_id = ns_id,
     get_repo_path = function() return state.get_clone_path() end,
     get_sha = function()
@@ -418,7 +372,35 @@ local function setup_keymaps()
       return c and c.message or ""
     end,
     get_is_working_dir = function() return false end,
+    apply_keymaps = function(bufs) ui.apply_keymaps_to_bufs(commit_mode_keymaps, bufs) end,
+    render_page = render_grid_page,
+  }
+
+  -- Browse files toggle
+  if config.is_enabled(shortcuts.commit_mode.browse_files) then
+    table.insert(commit_mode_keymaps, {
+      mode = NORMAL_MODE,
+      lhs = shortcuts.commit_mode.browse_files,
+      rhs = function() ui.toggle_filetree_focus(commit_state, filetree_opts) end,
+      desc = "Toggle file tree browsing",
+    })
+  end
+
+  -- Apply keymaps buffer-locally
+  local commit_bufs = ui.collect_bufs(commit_state)
+  ui.apply_keymaps_to_bufs(commit_mode_keymaps, commit_bufs)
+
+  -- Sidebar-local keymaps
+  ui.setup_sidebar_nav(commit_state.sidebar_buf, {
+    move_down = move_down,
+    move_up = move_up,
+    move_to_top = move_to_top,
+    move_to_bottom = move_to_bottom,
+    select_at_cursor = select_at_cursor,
   })
+
+  -- Filetree navigation keymaps
+  ui.setup_filetree_nav(commit_state, filetree_opts)
 
   -- Focus lock autocmd
   commit_state.focus_augroup = ui.setup_focus_lock(commit_state, "RaccoonCommitFocus")

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -47,6 +47,9 @@ local commit_state = {
   cached_stat_lines = nil,
   cached_file_count = nil,
   focus_target = "sidebar",
+  orig_grid_rows = nil,
+  orig_grid_cols = nil,
+  preview_generation = 0,
 }
 
 --- Commit mode keymaps (global)
@@ -86,6 +89,9 @@ local function reset_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    orig_grid_rows = nil,
+    orig_grid_cols = nil,
+    preview_generation = 0,
   }
 end
 
@@ -354,24 +360,41 @@ local function setup_keymaps()
     end
   end
 
+  -- Helper to apply mode keymaps to a set of buffers
+  local function apply_keymaps_to_bufs(bufs)
+    for _, buf in ipairs(bufs) do
+      for _, km in ipairs(commit_mode_keymaps) do
+        vim.keymap.set(km.mode, km.lhs, km.rhs,
+          { buffer = buf, noremap = true, silent = true, desc = km.desc })
+      end
+    end
+  end
+
+  local toggle_opts = {
+    ns_id = ns_id,
+    get_repo_path = function() return state.get_clone_path() end,
+    get_sha = function()
+      local c = get_commit(commit_state.selected_index)
+      return c and c.sha
+    end,
+    get_is_working_dir = function() return false end,
+    apply_keymaps = apply_keymaps_to_bufs,
+    render_page = render_grid_page,
+  }
+
   -- Browse files toggle
   if config.is_enabled(shortcuts.commit_mode.browse_files) then
     table.insert(commit_mode_keymaps, {
       mode = NORMAL_MODE,
       lhs = shortcuts.commit_mode.browse_files,
-      rhs = function() ui.toggle_filetree_focus(commit_state) end,
+      rhs = function() ui.toggle_filetree_focus(commit_state, toggle_opts) end,
       desc = "Toggle file tree browsing",
     })
   end
 
   -- Apply keymaps buffer-locally
   local commit_bufs = ui.collect_bufs(commit_state)
-  for _, buf in ipairs(commit_bufs) do
-    for _, km in ipairs(commit_mode_keymaps) do
-      vim.keymap.set(km.mode, km.lhs, km.rhs,
-        { buffer = buf, noremap = true, silent = true, desc = km.desc })
-    end
-  end
+  apply_keymaps_to_bufs(commit_bufs)
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(commit_state.sidebar_buf, {
@@ -394,6 +417,7 @@ local function setup_keymaps()
       local c = get_commit(commit_state.selected_index)
       return c and c.message or ""
     end,
+    get_is_working_dir = function() return false end,
   })
 
   -- Focus lock autocmd

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -63,6 +63,9 @@ local function make_initial_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    orig_grid_rows = nil,
+    orig_grid_cols = nil,
+    preview_generation = 0,
     pr_was_active = false,
   }
 end
@@ -455,24 +458,44 @@ local function setup_keymaps()
     })
   end
 
+  -- Helper to apply mode keymaps to a set of buffers
+  local function apply_keymaps_to_bufs(bufs)
+    for _, buf in ipairs(bufs) do
+      for _, km in ipairs(local_mode_keymaps) do
+        vim.keymap.set(km.mode, km.lhs, km.rhs,
+          { buffer = buf, noremap = true, silent = true, desc = km.desc })
+      end
+    end
+  end
+
+  local toggle_opts = {
+    ns_id = ns_id,
+    get_repo_path = function() return local_state.repo_path end,
+    get_sha = function()
+      local c = get_commit(local_state.selected_index)
+      return c and c.sha
+    end,
+    get_is_working_dir = function()
+      local c = get_commit(local_state.selected_index)
+      return c and c.sha == nil
+    end,
+    apply_keymaps = apply_keymaps_to_bufs,
+    render_page = render_grid_page,
+  }
+
   -- Browse files toggle
   if config.is_enabled(shortcuts.commit_mode.browse_files) then
     table.insert(local_mode_keymaps, {
       mode = NORMAL_MODE,
       lhs = shortcuts.commit_mode.browse_files,
-      rhs = function() ui.toggle_filetree_focus(local_state) end,
+      rhs = function() ui.toggle_filetree_focus(local_state, toggle_opts) end,
       desc = "Toggle file tree browsing",
     })
   end
 
   -- Apply keymaps buffer-locally
   local commit_bufs = ui.collect_bufs(local_state)
-  for _, buf in ipairs(commit_bufs) do
-    for _, km in ipairs(local_mode_keymaps) do
-      vim.keymap.set(km.mode, km.lhs, km.rhs,
-        { buffer = buf, noremap = true, silent = true, desc = km.desc })
-    end
-  end
+  apply_keymaps_to_bufs(commit_bufs)
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(local_state.sidebar_buf, {
@@ -494,6 +517,10 @@ local function setup_keymaps()
     get_commit_message = function()
       local c = get_commit(local_state.selected_index)
       return c and c.message or ""
+    end,
+    get_is_working_dir = function()
+      local c = get_commit(local_state.selected_index)
+      return c and c.sha == nil
     end,
   })
 

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -458,56 +458,7 @@ local function setup_keymaps()
     })
   end
 
-  -- Helper to apply mode keymaps to a set of buffers
-  local function apply_keymaps_to_bufs(bufs)
-    for _, buf in ipairs(bufs) do
-      for _, km in ipairs(local_mode_keymaps) do
-        vim.keymap.set(km.mode, km.lhs, km.rhs,
-          { buffer = buf, noremap = true, silent = true, desc = km.desc })
-      end
-    end
-  end
-
-  local toggle_opts = {
-    ns_id = ns_id,
-    get_repo_path = function() return local_state.repo_path end,
-    get_sha = function()
-      local c = get_commit(local_state.selected_index)
-      return c and c.sha
-    end,
-    get_is_working_dir = function()
-      local c = get_commit(local_state.selected_index)
-      return c and c.sha == nil
-    end,
-    apply_keymaps = apply_keymaps_to_bufs,
-    render_page = render_grid_page,
-  }
-
-  -- Browse files toggle
-  if config.is_enabled(shortcuts.commit_mode.browse_files) then
-    table.insert(local_mode_keymaps, {
-      mode = NORMAL_MODE,
-      lhs = shortcuts.commit_mode.browse_files,
-      rhs = function() ui.toggle_filetree_focus(local_state, toggle_opts) end,
-      desc = "Toggle file tree browsing",
-    })
-  end
-
-  -- Apply keymaps buffer-locally
-  local commit_bufs = ui.collect_bufs(local_state)
-  apply_keymaps_to_bufs(commit_bufs)
-
-  -- Sidebar-local keymaps
-  ui.setup_sidebar_nav(local_state.sidebar_buf, {
-    move_down = move_down,
-    move_up = move_up,
-    move_to_top = move_to_top,
-    move_to_bottom = move_to_bottom,
-    select_at_cursor = select_at_cursor,
-  })
-
-  -- Filetree navigation keymaps
-  ui.setup_filetree_nav(local_state, {
+  local filetree_opts = {
     ns_id = ns_id,
     get_repo_path = function() return local_state.repo_path end,
     get_sha = function()
@@ -522,7 +473,35 @@ local function setup_keymaps()
       local c = get_commit(local_state.selected_index)
       return c and c.sha == nil
     end,
+    apply_keymaps = function(bufs) ui.apply_keymaps_to_bufs(local_mode_keymaps, bufs) end,
+    render_page = render_grid_page,
+  }
+
+  -- Browse files toggle
+  if config.is_enabled(shortcuts.commit_mode.browse_files) then
+    table.insert(local_mode_keymaps, {
+      mode = NORMAL_MODE,
+      lhs = shortcuts.commit_mode.browse_files,
+      rhs = function() ui.toggle_filetree_focus(local_state, filetree_opts) end,
+      desc = "Toggle file tree browsing",
+    })
+  end
+
+  -- Apply keymaps buffer-locally
+  local commit_bufs = ui.collect_bufs(local_state)
+  ui.apply_keymaps_to_bufs(local_mode_keymaps, commit_bufs)
+
+  -- Sidebar-local keymaps
+  ui.setup_sidebar_nav(local_state.sidebar_buf, {
+    move_down = move_down,
+    move_up = move_up,
+    move_to_top = move_to_top,
+    move_to_bottom = move_to_bottom,
+    select_at_cursor = select_at_cursor,
   })
+
+  -- Filetree navigation keymaps
+  ui.setup_filetree_nav(local_state, filetree_opts)
 
   -- Focus lock autocmd
   local_state.focus_augroup = ui.setup_focus_lock(local_state, "RaccoonLocalCommitFocus")


### PR DESCRIPTION
## Summary
- In commit mode (local + PR), toggling to file browsing now collapses the NxM diff grid into a single 1x1 pane that previews the currently selected file
- j/k navigation in the filetree updates the preview live (diff for changed files, raw content for unchanged)
- Toggling back to commit browsing restores the original NxM grid with hunk diffs

## Test plan
- [ ] Open local commit mode, browse commits, press browse_files key — grid collapses to 1x1 with file preview
- [ ] Navigate files with j/k — preview updates to show each file
- [ ] Press Enter on a file — maximize window opens as before
- [ ] Press browse_files key again — grid restores to NxM with commit hunks
- [ ] Repeat above in PR commit mode
- [ ] `make test` passes (136/136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)