### PR TITLE
fix: harden Windows diff rendering

### DIFF
--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,20 +1,18 @@
 # Architecture Diff
 
 ## Summary
-Improve cross-platform diff rendering reliability by making highlight resolution theme-aware, enforcing visible diff sign columns in flat diff, and normalizing CRLF patch parsing.
+Improve cross-platform diff rendering reliability by deriving Raccoon's existing diff highlight groups from Neovim's built-in diff highlights, with terminal fallback colors when the colorscheme does not provide them.
 
 ## Diagram(s)
 ```mermaid
 flowchart TD
     A[ColorScheme Groups\nDiffAdd / DiffDelete] --> B[raccoon.init setup_highlights]
-    B --> C[RaccoonAdd / RaccoonDelete\nRaccoonAddSign / RaccoonDeleteSign]
-    D[GitHub/File Patch Text] --> E[raccoon.diff parse_patch]
-    E --> F[Normalized Lines\nstrip trailing CR]
-    F --> G[Changed line map]
-    G --> H[raccoon.diff apply_highlights]
-    H --> I[Extmarks + Signs + Virtual delete lines]
-    J[raccoon.diff open_file] --> K[Window signcolumn yes:1]
-    K --> I
+    D[Fallback RGB + cterm values] --> B
+    B --> C[RaccoonAdd / RaccoonDelete]
+    B --> E[RaccoonAddSign / RaccoonDeleteSign]
+    C --> F[raccoon.diff apply_highlights]
+    E --> F
+    F --> G[Extmarks + Signs + Virtual delete lines]
 ```
 
 ## Changes
@@ -24,10 +22,8 @@ flowchart TD
 
 ### Modified
 - `lua/raccoon/init.lua`: derive raccoon diff/sign highlight values from `DiffAdd`/`DiffDelete` with fallback RGB + cterm values.
-- `lua/raccoon/diff.lua`: normalize CRLF patch lines in parser and enforce `signcolumn=yes:1` when opening review files.
 - `tests/init_spec.lua`: add coverage for inherited highlight colors and fallback colors.
-- `tests/diff_spec.lua`: add CRLF parsing regression test.
-- `CHANGELOG.md`: add unreleased fixes for Windows diff rendering compatibility.
+- `CHANGELOG.md`: add an unreleased note for applying the Windows diff highlight fix to the current main code path.
 
 ### Removed
 - Nothing removed.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,0 +1,33 @@
+# Architecture Diff
+
+## Summary
+Improve cross-platform diff rendering reliability by making highlight resolution theme-aware, enforcing visible diff sign columns in flat diff, and normalizing CRLF patch parsing.
+
+## Diagram(s)
+```mermaid
+flowchart TD
+    A[ColorScheme Groups\nDiffAdd / DiffDelete] --> B[raccoon.init setup_highlights]
+    B --> C[RaccoonAdd / RaccoonDelete\nRaccoonAddSign / RaccoonDeleteSign]
+    D[GitHub/File Patch Text] --> E[raccoon.diff parse_patch]
+    E --> F[Normalized Lines\nstrip trailing CR]
+    F --> G[Changed line map]
+    G --> H[raccoon.diff apply_highlights]
+    H --> I[Extmarks + Signs + Virtual delete lines]
+    J[raccoon.diff open_file] --> K[Window signcolumn yes:1]
+    K --> I
+```
+
+## Changes
+
+### Added
+- No new modules.
+
+### Modified
+- `lua/raccoon/init.lua`: derive raccoon diff/sign highlight values from `DiffAdd`/`DiffDelete` with fallback RGB + cterm values.
+- `lua/raccoon/diff.lua`: normalize CRLF patch lines in parser and enforce `signcolumn=yes:1` when opening review files.
+- `tests/init_spec.lua`: add coverage for inherited highlight colors and fallback colors.
+- `tests/diff_spec.lua`: add CRLF parsing regression test.
+- `CHANGELOG.md`: add unreleased fixes for Windows diff rendering compatibility.
+
+### Removed
+- Nothing removed.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,7 +1,7 @@
 # Architecture Diff
 
 ## Summary
-Improve cross-platform diff rendering reliability by deriving Raccoon's existing diff highlight groups from Neovim's built-in diff highlights, with terminal fallback colors when the colorscheme does not provide them.
+Improve PowerShell/terminal rendering by refreshing diff highlight groups from the active colorscheme, applying real changed-row highlight ranges, and making picker floats inherit the editor background.
 
 ## Diagram(s)
 ```mermaid
@@ -10,9 +10,12 @@ flowchart TD
     D[Fallback RGB + cterm values] --> B
     B --> C[RaccoonAdd / RaccoonDelete]
     B --> E[RaccoonAddSign / RaccoonDeleteSign]
-    C --> F[raccoon.diff apply_highlights]
+    C --> F[raccoon.diff set_change_line_extmark]
     E --> F
-    F --> G[Extmarks + Signs + Virtual delete lines]
+    F --> G[Flat diff added lines]
+    F --> H[Commit diff add/delete lines]
+    I[Normal highlight group] --> J[raccoon.ui create_floating_window]
+    J --> K[PR picker and popups]
 ```
 
 ## Changes
@@ -21,9 +24,12 @@ flowchart TD
 - No new modules.
 
 ### Modified
-- `lua/raccoon/init.lua`: derive raccoon diff/sign highlight values from `DiffAdd`/`DiffDelete` with fallback RGB + cterm values.
-- `tests/init_spec.lua`: add coverage for inherited highlight colors and fallback colors.
-- `CHANGELOG.md`: add an unreleased note for applying the Windows diff highlight fix to the current main code path.
+- `lua/raccoon/init.lua`: refresh raccoon diff/sign highlight values from `DiffAdd`/`DiffDelete` with fallback RGB + cterm values.
+- `lua/raccoon/diff.lua`: centralize changed-line extmarks so signs and full-row highlight ranges are applied together.
+- `lua/raccoon/commit_ui.lua`: reuse the shared changed-line extmark helper for commit diff rows.
+- `lua/raccoon/ui.lua`: make floating windows inherit `Normal` instead of a potentially black `NormalFloat`.
+- `tests/init_spec.lua`, `tests/diff_spec.lua`, `tests/commit_ui_spec.lua`, `tests/ui_spec.lua`: add regression coverage for terminal-safe highlights and picker backgrounds.
+- `CHANGELOG.md`: add an unreleased note for the PowerShell/terminal highlight fix.
 
 ### Removed
 - Nothing removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Diff highlight groups now inherit colors from `DiffAdd` and `DiffDelete` when available, with explicit fallback `cterm` colors for terminals/themes that do not define them.
+- Flat diff file views now force `signcolumn=yes:1` so `+` and `-` markers stay visible on terminals where automatic sign columns hide them.
+- Unified diff parsing now tolerates Windows CRLF line endings (`\r\n`) while keeping line mapping consistent.
+
 ## [0.13.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Diff highlight groups now inherit colors from `DiffAdd` and `DiffDelete` when available, with explicit fallback `cterm` colors for terminals/themes that do not define them.
-- Flat diff file views now force `signcolumn=yes:1` so `+` and `-` markers stay visible on terminals where automatic sign columns hide them.
-- Unified diff parsing now tolerates Windows CRLF line endings (`\r\n`) while keeping line mapping consistent.
+- Windows diff highlights now follow Neovim's `DiffAdd` and `DiffDelete` groups on the current flat-diff code path, while retaining explicit terminal color fallbacks.
 
 ## [0.13.0] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Windows diff highlights now follow Neovim's `DiffAdd` and `DiffDelete` groups on the current flat-diff code path, while retaining explicit terminal color fallbacks.
+- PowerShell/terminal rendering now keeps PR picker floats on the editor background and applies visible add/delete row backgrounds alongside diff signs.
 
 ## [0.13.0] - 2026-05-23
 

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -386,17 +386,9 @@ function M.apply_diff_highlights(ns_id, buf, line_list)
   vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
   for idx, line_data in ipairs(line_list) do
     if line_data.type == "add" then
-      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, idx - 1, 0, {
-        line_hl_group = "RaccoonAdd",
-        sign_text = "+",
-        sign_hl_group = "RaccoonAddSign",
-      })
+      diff.set_change_line_extmark(buf, ns_id, idx - 1, "add")
     elseif line_data.type == "del" then
-      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, idx - 1, 0, {
-        line_hl_group = "RaccoonDelete",
-        sign_text = "-",
-        sign_hl_group = "RaccoonDeleteSign",
-      })
+      diff.set_change_line_extmark(buf, ns_id, idx - 1, "del")
     end
   end
 end

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -41,7 +41,8 @@ function M.parse_patch(patch)
   local current_hunk = nil
   local line_num = 0
 
-  for line in normalized_patch:gmatch("(.-)\n") do
+  for raw_line in normalized_patch:gmatch("(.-)\n") do
+    local line = raw_line:gsub("\r$", "")
     if line:match("^@@") then
       -- New hunk
       if current_hunk then
@@ -240,6 +241,12 @@ function M.open_file(file)
     -- File may still be open despite the error, continue if buffer exists
   end
   local buf = vim.api.nvim_get_current_buf()
+  local win = vim.api.nvim_get_current_win()
+
+  -- Keep diff signs visible even when the user has signcolumn=auto/no.
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.wo[win].signcolumn = "yes:1"
+  end
 
   -- Track buffer in session
   state.add_buffer(buf)

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -7,6 +7,57 @@ local state = require("raccoon.state")
 --- Namespace for diff highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_diff")
 
+local CHANGE_HIGHLIGHTS = {
+  add = {
+    line = "RaccoonAdd",
+    sign = "+",
+    sign_hl = "RaccoonAddSign",
+  },
+  del = {
+    line = "RaccoonDelete",
+    sign = "-",
+    sign_hl = "RaccoonDeleteSign",
+  },
+}
+
+local function line_end_col(buf, line_idx)
+  local ok, lines = pcall(vim.api.nvim_buf_get_lines, buf, line_idx, line_idx + 1, false)
+  if not ok or not lines[1] then
+    return 0
+  end
+  return #lines[1]
+end
+
+--- Apply sign and full-row change highlighting to one buffer line.
+---@param buf number Buffer ID
+---@param namespace number Namespace ID
+---@param line_idx number Zero-based buffer line index
+---@param change_type "add"|"del"
+function M.set_change_line_extmark(buf, namespace, line_idx, change_type)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  local change = CHANGE_HIGHLIGHTS[change_type]
+  if not change then
+    return
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(buf)
+  if line_idx < 0 or line_idx >= line_count then
+    return
+  end
+
+  pcall(vim.api.nvim_buf_set_extmark, buf, namespace, line_idx, 0, {
+    line_hl_group = change.line,
+    hl_group = change.line,
+    end_col = line_end_col(buf, line_idx),
+    hl_eol = true,
+    sign_text = change.sign,
+    sign_hl_group = change.sign_hl,
+  })
+end
+
 --- Parse a unified diff hunk header
 --- Returns start_line, count for the new file (right side)
 ---@param header string Hunk header like "@@ -1,4 +1,5 @@"
@@ -147,13 +198,7 @@ function M.apply_highlights(buf, patch)
   -- Apply green highlight to added lines
   for _, line_num in ipairs(changes.added) do
     local line_idx = line_num - 1
-    if line_idx >= 0 and line_idx < line_count then
-      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, line_idx, 0, {
-        line_hl_group = "RaccoonAdd",
-        sign_text = "+",
-        sign_hl_group = "RaccoonAddSign",
-      })
-    end
+    M.set_change_line_extmark(buf, ns_id, line_idx, "add")
   end
 
   -- For deleted lines, show virtual text with red background

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -41,8 +41,7 @@ function M.parse_patch(patch)
   local current_hunk = nil
   local line_num = 0
 
-  for raw_line in normalized_patch:gmatch("(.-)\n") do
-    local line = raw_line:gsub("\r$", "")
+  for line in normalized_patch:gmatch("(.-)\n") do
     if line:match("^@@") then
       -- New hunk
       if current_hunk then
@@ -241,12 +240,6 @@ function M.open_file(file)
     -- File may still be open despite the error, continue if buffer exists
   end
   local buf = vim.api.nvim_get_current_buf()
-  local win = vim.api.nvim_get_current_win()
-
-  -- Keep diff signs visible even when the user has signcolumn=auto/no.
-  if win and vim.api.nvim_win_is_valid(win) then
-    vim.wo[win].signcolumn = "yes:1"
-  end
 
   -- Track buffer in session
   state.add_buffer(buf)

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -43,7 +43,6 @@ local function setup_highlights()
   vim.api.nvim_set_hl(0, "RaccoonAdd", merge_highlight(diff_add, { "bg", "ctermbg" }, {
     bg = "#2d5a2d",
     ctermbg = 22,
-    default = true,
   }))
 
   -- Red background for deleted lines (high contrast)
@@ -57,20 +56,17 @@ local function setup_highlights()
     fg = "#e88888",
     ctermbg = 52,
     ctermfg = 174,
-    default = true,
   }))
 
   -- Sign column colors
   vim.api.nvim_set_hl(0, "RaccoonAddSign", merge_sign_highlight(diff_add, {
     fg = "#98c379", -- Green
     ctermfg = 114,
-    default = true,
   }))
 
   vim.api.nvim_set_hl(0, "RaccoonDeleteSign", merge_sign_highlight(diff_delete, {
     fg = "#e06c75", -- Red
     ctermfg = 173,
-    default = true,
   }))
 
   -- File tree highlights (commit viewer)

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -11,29 +11,56 @@ M.config = {
 --- Setup highlight groups for diff display
 --- Uses dark green/red backgrounds for added/deleted lines
 local function setup_highlights()
+  local function get_highlight(name)
+    local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = name, link = false })
+    if not ok or type(hl) ~= "table" then
+      return {}
+    end
+    return hl
+  end
+
+  local function merge_highlight(base, keys, fallback)
+    local merged = vim.deepcopy(fallback)
+    for _, key in ipairs(keys) do
+      if base[key] ~= nil then
+        merged[key] = base[key]
+      end
+    end
+    return merged
+  end
+
+  local diff_add = get_highlight("DiffAdd")
+  local diff_delete = get_highlight("DiffDelete")
+
   -- Green background for added lines (high contrast)
-  vim.api.nvim_set_hl(0, "RaccoonAdd", {
+  vim.api.nvim_set_hl(0, "RaccoonAdd", merge_highlight(diff_add, { "bg", "ctermbg" }, {
     bg = "#2d5a2d",
-    default = true,
-  })
+    ctermbg = 22,
+  }))
 
   -- Red background for deleted lines (high contrast)
-  vim.api.nvim_set_hl(0, "RaccoonDelete", {
+  vim.api.nvim_set_hl(0, "RaccoonDelete", merge_highlight(diff_delete, {
+    "fg",
+    "bg",
+    "ctermfg",
+    "ctermbg",
+  }, {
     bg = "#5a2020",
     fg = "#e88888",
-    default = true,
-  })
+    ctermbg = 52,
+    ctermfg = 174,
+  }))
 
   -- Sign column colors
-  vim.api.nvim_set_hl(0, "RaccoonAddSign", {
+  vim.api.nvim_set_hl(0, "RaccoonAddSign", merge_highlight(diff_add, { "fg", "ctermfg" }, {
     fg = "#98c379", -- Green
-    default = true,
-  })
+    ctermfg = 114,
+  }))
 
-  vim.api.nvim_set_hl(0, "RaccoonDeleteSign", {
+  vim.api.nvim_set_hl(0, "RaccoonDeleteSign", merge_highlight(diff_delete, { "fg", "ctermfg" }, {
     fg = "#e06c75", -- Red
-    default = true,
-  })
+    ctermfg = 173,
+  }))
 
   -- File tree highlights (commit viewer)
   vim.api.nvim_set_hl(0, "RaccoonFileNormal", {

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -29,6 +29,13 @@ local function setup_highlights()
     return merged
   end
 
+  local function merge_sign_highlight(base, fallback)
+    if base.bg ~= nil or base.ctermbg ~= nil then
+      return vim.deepcopy(fallback)
+    end
+    return merge_highlight(base, { "fg", "ctermfg" }, fallback)
+  end
+
   local diff_add = get_highlight("DiffAdd")
   local diff_delete = get_highlight("DiffDelete")
 
@@ -36,6 +43,7 @@ local function setup_highlights()
   vim.api.nvim_set_hl(0, "RaccoonAdd", merge_highlight(diff_add, { "bg", "ctermbg" }, {
     bg = "#2d5a2d",
     ctermbg = 22,
+    default = true,
   }))
 
   -- Red background for deleted lines (high contrast)
@@ -49,17 +57,20 @@ local function setup_highlights()
     fg = "#e88888",
     ctermbg = 52,
     ctermfg = 174,
+    default = true,
   }))
 
   -- Sign column colors
-  vim.api.nvim_set_hl(0, "RaccoonAddSign", merge_highlight(diff_add, { "fg", "ctermfg" }, {
+  vim.api.nvim_set_hl(0, "RaccoonAddSign", merge_sign_highlight(diff_add, {
     fg = "#98c379", -- Green
     ctermfg = 114,
+    default = true,
   }))
 
-  vim.api.nvim_set_hl(0, "RaccoonDeleteSign", merge_highlight(diff_delete, { "fg", "ctermfg" }, {
+  vim.api.nvim_set_hl(0, "RaccoonDeleteSign", merge_sign_highlight(diff_delete, {
     fg = "#e06c75", -- Red
     ctermfg = 173,
+    default = true,
   }))
 
   -- File tree highlights (commit viewer)

--- a/lua/raccoon/ui.lua
+++ b/lua/raccoon/ui.lua
@@ -72,6 +72,7 @@ function M.create_floating_window(opts)
   vim.wo[win].wrap = opts.wrap == true
   vim.wo[win].scrolloff = 3
   vim.wo[win].sidescrolloff = 1
+  vim.wo[win].winhl = "Normal:Normal,NormalFloat:Normal,FloatBorder:Normal,FloatTitle:Title"
 
   return win, buf
 end

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -18,6 +18,40 @@ describe("raccoon.commit_ui", function()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
   end
 
+  describe("apply_diff_highlights", function()
+    it("adds terminal-visible range highlights to changed commit lines", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+        "+added line",
+        "-deleted line",
+      })
+      local ns = vim.api.nvim_create_namespace("raccoon_commit_ui_test")
+
+      commit_ui.apply_diff_highlights(ns, buf, {
+        { type = "add", content = "+added line" },
+        { type = "del", content = "-deleted line" },
+      })
+
+      local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })
+      local by_line = {}
+      for _, mark in ipairs(marks) do
+        by_line[mark[2]] = mark[4]
+      end
+
+      assert.equals("RaccoonAdd", by_line[0].line_hl_group)
+      assert.equals("RaccoonAdd", by_line[0].hl_group)
+      assert.is_true(by_line[0].hl_eol)
+      assert.equals(#"+added line", by_line[0].end_col)
+
+      assert.equals("RaccoonDelete", by_line[1].line_hl_group)
+      assert.equals("RaccoonDelete", by_line[1].hl_group)
+      assert.is_true(by_line[1].hl_eol)
+      assert.equals(#"-deleted line", by_line[1].end_col)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+  end)
+
   it("header shows subject then updates to full multiline body", function()
     local buf, win = make_header(80)
 

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -222,6 +222,41 @@ describe("raccoon.diff", function()
       diff.apply_highlights(buf, "")
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
+
+    it("applies terminal-visible range highlights to added lines", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+        "line 1",
+        "new line",
+        "line 2",
+      })
+
+      local patch = [[
+@@ -1,2 +1,3 @@
+ line 1
++new line
+ line 2]]
+
+      diff.apply_highlights(buf, patch)
+
+      local ns = diff.get_namespace()
+      local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })
+      local added_mark
+      for _, mark in ipairs(marks) do
+        if mark[2] == 1 and mark[4].sign_text then
+          added_mark = mark
+          break
+        end
+      end
+
+      assert.is_not_nil(added_mark)
+      assert.equals("RaccoonAdd", added_mark[4].line_hl_group)
+      assert.equals("RaccoonAdd", added_mark[4].hl_group)
+      assert.is_true(added_mark[4].hl_eol)
+      assert.equals(#"new line", added_mark[4].end_col)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
   describe("open_file", function()

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -271,16 +271,6 @@ describe("raccoon.diff", function()
   end)
 
   describe("parse_patch edge cases", function()
-    it("handles CRLF line endings", function()
-      local patch = "@@ -1,2 +1,3 @@\r\n line1\r\n+added\r\n line2\r\n"
-      local hunks = diff.parse_patch(patch)
-      local changes = diff.get_changed_lines(patch)
-
-      assert.equals(1, #hunks)
-      assert.equals(1, #changes.added)
-      assert.equals(2, changes.added[1])
-    end)
-
     it("handles patch with only additions", function()
       local patch = [[
 @@ -0,0 +1,3 @@

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -271,6 +271,16 @@ describe("raccoon.diff", function()
   end)
 
   describe("parse_patch edge cases", function()
+    it("handles CRLF line endings", function()
+      local patch = "@@ -1,2 +1,3 @@\r\n line1\r\n+added\r\n line2\r\n"
+      local hunks = diff.parse_patch(patch)
+      local changes = diff.get_changed_lines(patch)
+
+      assert.equals(1, #hunks)
+      assert.equals(1, #changes.added)
+      assert.equals(2, changes.added[1])
+    end)
+
     it("handles patch with only additions", function()
       local patch = [[
 @@ -0,0 +1,3 @@

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -1,4 +1,21 @@
 describe("raccoon", function()
+  local raccoon_highlight_groups = {
+    "RaccoonAdd",
+    "RaccoonDelete",
+    "RaccoonAddSign",
+    "RaccoonDeleteSign",
+  }
+
+  local function clear_raccoon_highlights()
+    for _, group in ipairs(raccoon_highlight_groups) do
+      vim.cmd("highlight clear " .. group)
+    end
+  end
+
+  before_each(function()
+    clear_raccoon_highlights()
+  end)
+
   it("setup accepts empty options", function()
     local raccoon = require("raccoon")
     -- Should not error
@@ -42,10 +59,10 @@ describe("raccoon", function()
     assert.equals(diff_delete.ctermbg, delete.ctermbg)
     assert.equals(diff_delete.fg, delete.fg)
     assert.equals(diff_delete.ctermfg, delete.ctermfg)
-    assert.equals(diff_add.fg, add_sign.fg)
-    assert.equals(diff_add.ctermfg, add_sign.ctermfg)
-    assert.equals(diff_delete.fg, delete_sign.fg)
-    assert.equals(diff_delete.ctermfg, delete_sign.ctermfg)
+    assert.is_not_nil(add_sign.fg)
+    assert.is_not_nil(add_sign.ctermfg)
+    assert.is_not_nil(delete_sign.fg)
+    assert.is_not_nil(delete_sign.ctermfg)
   end)
 
   it("uses fallback colors when DiffAdd and DiffDelete have no colors", function()
@@ -70,5 +87,65 @@ describe("raccoon", function()
     assert.equals(114, add_sign.ctermfg)
     assert.is_not_nil(delete_sign.fg)
     assert.equals(173, delete_sign.ctermfg)
+  end)
+
+  it("keeps fallback sign colors when DiffAdd and DiffDelete define line backgrounds", function()
+    vim.api.nvim_set_hl(0, "DiffAdd", {
+      fg = "#000000",
+      bg = "#00ff00",
+      ctermfg = 0,
+      ctermbg = 10,
+    })
+    vim.api.nvim_set_hl(0, "DiffDelete", {
+      fg = "#000000",
+      bg = "#ff0000",
+      ctermfg = 0,
+      ctermbg = 9,
+    })
+
+    local raccoon = require("raccoon")
+    raccoon.setup()
+
+    local add_sign = vim.api.nvim_get_hl(0, { name = "RaccoonAddSign", link = false })
+    local delete_sign = vim.api.nvim_get_hl(0, { name = "RaccoonDeleteSign", link = false })
+
+    assert.equals(114, add_sign.ctermfg)
+    assert.equals(173, delete_sign.ctermfg)
+  end)
+
+  it("preserves explicit Raccoon highlight overrides", function()
+    vim.api.nvim_set_hl(0, "DiffAdd", {
+      bg = "#134013",
+      ctermbg = 22,
+    })
+    vim.api.nvim_set_hl(0, "DiffDelete", {
+      fg = "#ffd0d0",
+      bg = "#401313",
+      ctermfg = 224,
+      ctermbg = 52,
+    })
+    vim.api.nvim_set_hl(0, "RaccoonAdd", {
+      bg = "#123456",
+      ctermbg = 24,
+    })
+    vim.api.nvim_set_hl(0, "RaccoonDelete", {
+      fg = "#654321",
+      bg = "#241310",
+      ctermfg = 25,
+      ctermbg = 26,
+    })
+
+    local raccoon = require("raccoon")
+    raccoon.setup()
+
+    local add = vim.api.nvim_get_hl(0, { name = "RaccoonAdd", link = false })
+    local delete = vim.api.nvim_get_hl(0, { name = "RaccoonDelete", link = false })
+
+    assert.equals(tonumber("123456", 16), add.bg)
+    assert.equals(24, add.ctermbg)
+    assert.equals(tonumber("654321", 16), delete.fg)
+    assert.equals(tonumber("241310", 16), delete.bg)
+    assert.equals(25, delete.ctermfg)
+    assert.equals(26, delete.ctermbg)
   end)
 end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -11,4 +11,64 @@ describe("raccoon", function()
     raccoon.setup({ custom_option = "test" })
     assert.equals("test", raccoon.config.custom_option)
   end)
+
+  it("reuses DiffAdd and DiffDelete colors when available", function()
+    vim.api.nvim_set_hl(0, "DiffAdd", {
+      fg = "#d0ffd0",
+      bg = "#134013",
+      ctermfg = 193,
+      ctermbg = 22,
+    })
+    vim.api.nvim_set_hl(0, "DiffDelete", {
+      fg = "#ffd0d0",
+      bg = "#401313",
+      ctermfg = 224,
+      ctermbg = 52,
+    })
+
+    local raccoon = require("raccoon")
+    raccoon.setup()
+
+    local diff_add = vim.api.nvim_get_hl(0, { name = "DiffAdd", link = false })
+    local diff_delete = vim.api.nvim_get_hl(0, { name = "DiffDelete", link = false })
+    local add = vim.api.nvim_get_hl(0, { name = "RaccoonAdd", link = false })
+    local delete = vim.api.nvim_get_hl(0, { name = "RaccoonDelete", link = false })
+    local add_sign = vim.api.nvim_get_hl(0, { name = "RaccoonAddSign", link = false })
+    local delete_sign = vim.api.nvim_get_hl(0, { name = "RaccoonDeleteSign", link = false })
+
+    assert.equals(diff_add.bg, add.bg)
+    assert.equals(diff_add.ctermbg, add.ctermbg)
+    assert.equals(diff_delete.bg, delete.bg)
+    assert.equals(diff_delete.ctermbg, delete.ctermbg)
+    assert.equals(diff_delete.fg, delete.fg)
+    assert.equals(diff_delete.ctermfg, delete.ctermfg)
+    assert.equals(diff_add.fg, add_sign.fg)
+    assert.equals(diff_add.ctermfg, add_sign.ctermfg)
+    assert.equals(diff_delete.fg, delete_sign.fg)
+    assert.equals(diff_delete.ctermfg, delete_sign.ctermfg)
+  end)
+
+  it("uses fallback colors when DiffAdd and DiffDelete have no colors", function()
+    vim.api.nvim_set_hl(0, "DiffAdd", {})
+    vim.api.nvim_set_hl(0, "DiffDelete", {})
+
+    local raccoon = require("raccoon")
+    raccoon.setup()
+
+    local add = vim.api.nvim_get_hl(0, { name = "RaccoonAdd", link = false })
+    local delete = vim.api.nvim_get_hl(0, { name = "RaccoonDelete", link = false })
+    local add_sign = vim.api.nvim_get_hl(0, { name = "RaccoonAddSign", link = false })
+    local delete_sign = vim.api.nvim_get_hl(0, { name = "RaccoonDeleteSign", link = false })
+
+    assert.is_not_nil(add.bg)
+    assert.equals(22, add.ctermbg)
+    assert.is_not_nil(delete.bg)
+    assert.equals(52, delete.ctermbg)
+    assert.is_not_nil(delete.fg)
+    assert.equals(174, delete.ctermfg)
+    assert.is_not_nil(add_sign.fg)
+    assert.equals(114, add_sign.ctermfg)
+    assert.is_not_nil(delete_sign.fg)
+    assert.equals(173, delete_sign.ctermfg)
+  end)
 end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -113,7 +113,7 @@ describe("raccoon", function()
     assert.equals(173, delete_sign.ctermfg)
   end)
 
-  it("preserves explicit Raccoon highlight overrides", function()
+  it("refreshes existing Raccoon highlight groups from active diff colors", function()
     vim.api.nvim_set_hl(0, "DiffAdd", {
       bg = "#134013",
       ctermbg = 22,
@@ -125,27 +125,25 @@ describe("raccoon", function()
       ctermbg = 52,
     })
     vim.api.nvim_set_hl(0, "RaccoonAdd", {
-      bg = "#123456",
-      ctermbg = 24,
+      fg = "#ffffff",
     })
     vim.api.nvim_set_hl(0, "RaccoonDelete", {
-      fg = "#654321",
-      bg = "#241310",
-      ctermfg = 25,
-      ctermbg = 26,
+      fg = "#ffffff",
     })
 
     local raccoon = require("raccoon")
     raccoon.setup()
 
+    local diff_add = vim.api.nvim_get_hl(0, { name = "DiffAdd", link = false })
+    local diff_delete = vim.api.nvim_get_hl(0, { name = "DiffDelete", link = false })
     local add = vim.api.nvim_get_hl(0, { name = "RaccoonAdd", link = false })
     local delete = vim.api.nvim_get_hl(0, { name = "RaccoonDelete", link = false })
 
-    assert.equals(tonumber("123456", 16), add.bg)
-    assert.equals(24, add.ctermbg)
-    assert.equals(tonumber("654321", 16), delete.fg)
-    assert.equals(tonumber("241310", 16), delete.bg)
-    assert.equals(25, delete.ctermfg)
-    assert.equals(26, delete.ctermbg)
+    assert.equals(diff_add.bg, add.bg)
+    assert.equals(diff_add.ctermbg, add.ctermbg)
+    assert.equals(diff_delete.fg, delete.fg)
+    assert.equals(diff_delete.bg, delete.bg)
+    assert.equals(diff_delete.ctermfg, delete.ctermfg)
+    assert.equals(diff_delete.ctermbg, delete.ctermbg)
   end)
 end)

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -95,6 +95,20 @@ describe("raccoon.ui", function()
 
       vim.api.nvim_win_close(win, true)
     end)
+
+    it("uses the editor background instead of NormalFloat for floating windows", function()
+      vim.api.nvim_set_hl(0, "Normal", { bg = "#282828" })
+      vim.api.nvim_set_hl(0, "NormalFloat", { bg = "#000000" })
+
+      local win, _ = ui.create_floating_window({})
+
+      local winhl = vim.wo[win].winhl
+      assert.truthy(winhl:find("Normal:Normal", 1, true))
+      assert.truthy(winhl:find("NormalFloat:Normal", 1, true))
+      assert.truthy(winhl:find("FloatBorder:Normal", 1, true))
+
+      vim.api.nvim_win_close(win, true)
+    end)
   end)
 
   describe("close_pr_list", function()


### PR DESCRIPTION
## Summary
- refresh Raccoon diff/sign highlight groups from the active `DiffAdd`/`DiffDelete` groups so stale plugin-owned highlights cannot lose terminal backgrounds
- make floating pickers inherit the editor `Normal` background instead of a potentially black `NormalFloat`
- apply range highlights with `hl_eol` alongside add/delete signs for flat diff and commit diff rows

## Root Cause
The earlier fix only copied colors into existing highlight groups. In PowerShell/terminal sessions, stale `RaccoonAdd`/`RaccoonDelete` groups could remain without backgrounds, floating windows still used theme `NormalFloat`, and changed rows relied on `line_hl_group` without a real range highlight.

## Testing
- make test
