### PR TITLE
Render PR review as split full-file diff

### DIFF
--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,65 +1,43 @@
 # Architecture Diff
 
 ## Summary
-Split diff rendering now uses exact character inline decorations, stable left-column cursor placement, and side-aware comment thread buckets.
+Split diff comments now use one target classification, and inline diff highlights are token-stable and projected onto wrapped rows.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    A[Paired delete/add line] --> B[Split into UTF-8 chars with byte columns]
-    B --> C[Trim common prefix and suffix]
-    C --> D[LCS over changed middle]
-    D --> E[Coalesce changed char runs]
-    E --> F[Inline delete spans]
-    E --> G[Inline add spans]
-    F --> H[apply_split_render priority 200]
-    G --> H
-    I[Syntax projection priority 110] --> H
-    J[Full-line diff priority 90] --> H
-```
-
-```mermaid
-sequenceDiagram
-    participant Nav as Navigation
-    participant Diff as diff metadata
-    participant UI as Split buffer cursor
-    participant Comments as Comment action
-
-    Nav->>Diff: find_split_row(path, side, line)
-    Diff-->>Nav: rendered row plus left content column
-    Nav->>Diff: set_split_semantic_target(path, side, line, row)
-    Nav->>UI: place cursor at left content column
-    Comments->>Diff: resolve_cursor_target(row, col)
-    Diff-->>Comments: stored semantic side when cursor is still on row
+    A[Cursor target] --> B[resolve_new_thread_target]
+    B --> C{Target kind}
+    C -->|line| D[New Thread title and line REST comment]
+    C -->|file| E[New File Comment title and file REST comment]
+    C -->|disabled| F[Warn and disable send]
+    D --> G[Picker label]
+    E --> G
+    F --> G
 ```
 
 ```mermaid
 flowchart LR
-    A[GitHub comments] --> B[thread_index.build]
-    B --> C[line_state_by_file aggregate]
-    B --> D[side_line_state_by_file]
-    B --> E[side_comment_line_state_by_file]
-    D --> F[Split badges LEFT old line]
-    D --> G[Split badges RIGHT new line]
-    E --> H[Same-line picker for selected side]
-    I[Line nil placeholder] --> J[File-level new thread editor]
+    A[Paired delete/add row] --> B[UTF-8 char diff]
+    B --> C[Expand heavily changed identifier fragments]
+    C --> D[Inline byte spans]
+    D --> E[Split rendered chunks with byte ranges]
+    E --> F[Project spans onto visible row chunks]
+    F --> G[Neovim extmarks]
 ```
 
 ## Changes
 
 ### Added
-- `diff.left_cursor_col(rendered)` for split cursor placement.
-- `rendered.position_by_key[path|side|line]` for O(1) split row lookup before scan fallback.
-- `diff.set_split_semantic_target()` so right-side navigation can display left while preserving right-side comment semantics.
-- Side-aware thread index maps for split badges and same-line thread pickers.
+- `comments.lua` now resolves new comment targets as `line`, `file`, or `disabled` before labeling, restoring, or sending.
+- Split inline rendering now tracks byte ranges for each wrapped visual chunk.
 
 ### Modified
-- Inline changed-line highlighting now computes exact UTF-8 character add/delete runs with byte columns for Neovim extmarks.
-- Split navigation, thread jumps, file jumps, diff-only jumps, and resize restore now use the left content column.
-- Split comment badge rendering reads LEFT buckets from `old_line` and RIGHT buckets from `new_line`.
-- Same-line thread lookup passes the resolved target side.
+- Out-of-hunk changed-file targets remain allowed, but are consistently labeled and sent as file comments.
+- Identifier replacements with noisy character matches are highlighted as whole changed tokens.
+- Inline split highlights are projected onto continuation rows instead of disappearing when a changed line wraps.
 
 ### Removed
-- One-span prefix/suffix inline diff highlighting for paired changed lines.
-- Side-insensitive split badge and same-line picker lookup.
+- Independent picker/editor/send decisions that could label a file comment as a line thread.
+- The single-row-only guard that skipped inline highlights for wrapped split rows.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,45 +1,65 @@
 # Architecture Diff
 
 ## Summary
-Combined diff/comment navigation now uses side-aware diff change points, and split inline range highlights are layered above syntax and full-line diff highlights.
+Split diff rendering now uses exact character inline decorations, stable left-column cursor placement, and side-aware comment thread buckets.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    subgraph Navigation
-        A[Unified patch] --> B[diff.parse_patch]
-        B --> C[diff.get_change_points]
-        C --> D{Change block}
-        D -->|Add or replacement| E[RIGHT new line]
-        D -->|Delete only| F[LEFT old line]
-        E --> G[keymaps get_file_points]
-        F --> G
-        H[Thread index comments] --> G
-        G --> I[Sorted combined points]
-        I --> J[diff.find_split_row]
-        J --> K[Rendered row and side column]
-    end
+    A[Paired delete/add line] --> B[Split into UTF-8 chars with byte columns]
+    B --> C[Trim common prefix and suffix]
+    C --> D[LCS over changed middle]
+    D --> E[Coalesce changed char runs]
+    E --> F[Inline delete spans]
+    E --> G[Inline add spans]
+    F --> H[apply_split_render priority 200]
+    G --> H
+    I[Syntax projection priority 110] --> H
+    J[Full-line diff priority 90] --> H
+```
 
-    subgraph HighlightLayering
-        L[Split rows] --> M[Full-line diff extmarks priority 90]
-        L --> N[Syntax projection priority 110]
-        L --> O[Inline add/delete ranges priority 200]
-        M --> P[apply_split_render]
-        N --> P
-        O --> P
-    end
+```mermaid
+sequenceDiagram
+    participant Nav as Navigation
+    participant Diff as diff metadata
+    participant UI as Split buffer cursor
+    participant Comments as Comment action
+
+    Nav->>Diff: find_split_row(path, side, line)
+    Diff-->>Nav: rendered row plus left content column
+    Nav->>Diff: set_split_semantic_target(path, side, line, row)
+    Nav->>UI: place cursor at left content column
+    Comments->>Diff: resolve_cursor_target(row, col)
+    Diff-->>Comments: stored semantic side when cursor is still on row
+```
+
+```mermaid
+flowchart LR
+    A[GitHub comments] --> B[thread_index.build]
+    B --> C[line_state_by_file aggregate]
+    B --> D[side_line_state_by_file]
+    B --> E[side_comment_line_state_by_file]
+    D --> F[Split badges LEFT old line]
+    D --> G[Split badges RIGHT new line]
+    E --> H[Same-line picker for selected side]
+    I[Line nil placeholder] --> J[File-level new thread editor]
 ```
 
 ## Changes
 
 ### Added
-- `diff.get_change_points(patch)`: returns one `{ line, side, type = "diff" }` point per contiguous add/delete block.
-- Split range highlight priorities for syntax and inline diff entries.
+- `diff.left_cursor_col(rendered)` for split cursor placement.
+- `rendered.position_by_key[path|side|line]` for O(1) split row lookup before scan fallback.
+- `diff.set_split_semantic_target()` so right-side navigation can display left while preserving right-side comment semantics.
+- Side-aware thread index maps for split badges and same-line thread pickers.
 
 ### Modified
-- `keymaps`: uses `diff.get_change_points()` for diff navigation while preserving side-aware comment navigation.
-- `diff.apply_split_render()`: applies range highlights with extmarks so priority is explicit.
+- Inline changed-line highlighting now computes exact UTF-8 character add/delete runs with byte columns for Neovim extmarks.
+- Split navigation, thread jumps, file jumps, diff-only jumps, and resize restore now use the left content column.
+- Split comment badge rendering reads LEFT buckets from `old_line` and RIGHT buckets from `new_line`.
+- Same-line thread lookup passes the resolved target side.
 
 ### Removed
-- Mixed old/new changed-line grouping from combined point navigation.
+- One-span prefix/suffix inline diff highlighting for paired changed lines.
+- Side-insensitive split badge and same-line picker lookup.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,53 +1,45 @@
 # Architecture Diff
 
 ## Summary
-Flat PR review now renders a read-only full-file split diff buffer with side-aware row metadata for comments and navigation.
+Combined diff/comment navigation now uses side-aware diff change points, and split inline range highlights are layered above syntax and full-line diff highlights.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    A[PR file metadata] --> B[diff.parse_patch]
-    C[PR checkout file] --> D[new-side lines]
-    B --> E[old-side reconstruction]
-    D --> E
-    E --> F[split semantic rows]
-    D --> F
-    F --> G[wrapped display rows]
-    G --> H[split scratch buffer]
-    G --> I[row metadata]
-    I --> J[cursor target resolver]
-    J --> K[comment editor]
-```
+    subgraph Navigation
+        A[Unified patch] --> B[diff.parse_patch]
+        B --> C[diff.get_change_points]
+        C --> D{Change block}
+        D -->|Add or replacement| E[RIGHT new line]
+        D -->|Delete only| F[LEFT old line]
+        E --> G[keymaps get_file_points]
+        F --> G
+        H[Thread index comments] --> G
+        G --> I[Sorted combined points]
+        I --> J[diff.find_split_row]
+        J --> K[Rendered row and side column]
+    end
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Buffer as Split Diff Buffer
-    participant Comments
-    participant Diff as diff.resolve_cursor_target
-    participant GitHub
-
-    User->>Buffer: Place cursor on old or new side
-    User->>Comments: Start comment
-    Comments->>Diff: Resolve path, line, side, context
-    Diff-->>Comments: Target metadata
-    Comments->>GitHub: Create review comment
-    alt LEFT line rejected by GitHub validation
-        Comments->>GitHub: Retry as file-level comment
+    subgraph HighlightLayering
+        L[Split rows] --> M[Full-line diff extmarks priority 90]
+        L --> N[Syntax projection priority 110]
+        L --> O[Inline add/delete ranges priority 200]
+        M --> P[apply_split_render]
+        N --> P
+        O --> P
     end
 ```
 
 ## Changes
 
 ### Added
-- `lua/raccoon/diff.lua`: split diff model, full-file row alignment, wrapping, metadata attachment, cursor target resolution, inline span helper, and Tree-sitter projection caps.
-- `ARCHITECTURE_DIFF.md`: documents the rendering and comment submission flow.
+- `diff.get_change_points(patch)`: returns one `{ line, side, type = "diff" }` point per contiguous add/delete block.
+- Split range highlight priorities for syntax and inline diff entries.
 
 ### Modified
-- `lua/raccoon/comments.lua`: resolves comment targets from split row metadata, renders side-local badges, submits `LEFT` comments, and falls back to file-level comments on GitHub validation failures.
-- `lua/raccoon/commit_ui.lua`: reuses shared inline character spans for stacked commit and local commit diff buffers.
-- `lua/raccoon/init.lua`: adds split change and inline highlight groups.
+- `keymaps`: uses `diff.get_change_points()` for diff navigation while preserving side-aware comment navigation.
+- `diff.apply_split_render()`: applies range highlights with extmarks so priority is explicit.
 
 ### Removed
-- The flat review path no longer opens the PR checkout file directly as the primary review surface.
+- Mixed old/new changed-line grouping from combined point navigation.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,0 +1,53 @@
+# Architecture Diff
+
+## Summary
+Flat PR review now renders a read-only full-file split diff buffer with side-aware row metadata for comments and navigation.
+
+## Diagram(s)
+
+```mermaid
+flowchart TD
+    A[PR file metadata] --> B[diff.parse_patch]
+    C[PR checkout file] --> D[new-side lines]
+    B --> E[old-side reconstruction]
+    D --> E
+    E --> F[split semantic rows]
+    D --> F
+    F --> G[wrapped display rows]
+    G --> H[split scratch buffer]
+    G --> I[row metadata]
+    I --> J[cursor target resolver]
+    J --> K[comment editor]
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Buffer as Split Diff Buffer
+    participant Comments
+    participant Diff as diff.resolve_cursor_target
+    participant GitHub
+
+    User->>Buffer: Place cursor on old or new side
+    User->>Comments: Start comment
+    Comments->>Diff: Resolve path, line, side, context
+    Diff-->>Comments: Target metadata
+    Comments->>GitHub: Create review comment
+    alt LEFT line rejected by GitHub validation
+        Comments->>GitHub: Retry as file-level comment
+    end
+```
+
+## Changes
+
+### Added
+- `lua/raccoon/diff.lua`: split diff model, full-file row alignment, wrapping, metadata attachment, cursor target resolution, inline span helper, and Tree-sitter projection caps.
+- `ARCHITECTURE_DIFF.md`: documents the rendering and comment submission flow.
+
+### Modified
+- `lua/raccoon/comments.lua`: resolves comment targets from split row metadata, renders side-local badges, submits `LEFT` comments, and falls back to file-level comments on GitHub validation failures.
+- `lua/raccoon/commit_ui.lua`: reuses shared inline character spans for stacked commit and local commit diff buffers.
+- `lua/raccoon/init.lua`: adds split change and inline highlight groups.
+
+### Removed
+- The flat review path no longer opens the PR checkout file directly as the primary review surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.14.0] - 2026-06-10
 
 ### Fixed
+- Paired changed lines now highlight exact UTF-8 character add/delete ranges instead of one broad changed middle span.
+- Split diff navigation now keeps the visible cursor on the left content column while preserving the semantic LEFT/RIGHT target for comments.
+- Split diff comment badges and same-line thread pickers now keep LEFT and RIGHT threads with the same numeric line in separate buckets.
+- File-level split placeholder rows can open new file comments without a line coordinate.
 - Combined diff/comment navigation now lands replacement hunks on the right-side changed row instead of the paired left-side deletion row.
 - Split diff inline add/delete character highlights now use higher-priority range extmarks so they remain visible over syntax and full-line diff highlights.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.14.0] - 2026-06-10
+
+### Fixed
+- Combined diff/comment navigation now lands replacement hunks on the right-side changed row instead of the paired left-side deletion row.
+- Split diff inline add/delete character highlights now use higher-priority range extmarks so they remain visible over syntax and full-line diff highlights.
+
+### Added
+- Internal `diff.get_change_points(patch)` helper for side-aware first-change navigation points per contiguous diff block.
+
 ## [0.13.0] - 2026-05-23
 
 ### Added

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -688,8 +688,10 @@ end
 
 ---@param path string
 ---@param line number
+---@param side? string
 ---@return string|nil
-local function new_thread_disable_reason(path, line)
+local function new_thread_disable_reason(path, line, side)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
   if line == nil then
     return find_pr_file(path) and nil or file_outside_pr_changes_message()
   end
@@ -701,9 +703,11 @@ local function new_thread_disable_reason(path, line)
     return file_outside_pr_changes_message()
   end
 
-  local line_count = checkout_line_count(path)
-  if line_count and line > line_count then
-    return line_outside_file_bounds_message()
+  if side == "RIGHT" then
+    local line_count = checkout_line_count(path)
+    if line_count and line > line_count then
+      return line_outside_file_bounds_message()
+    end
   end
 
   return nil
@@ -732,12 +736,12 @@ local function send_new_thread(path, line, side, in_diff_context)
     vim.notify("Empty thread", vim.log.levels.WARN)
     return
   end
-  local disable_reason = new_thread_disable_reason(path, line)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
   if disable_reason then
     vim.notify(disable_reason, vim.log.levels.WARN)
     return
   end
-  side = side == "LEFT" and "LEFT" or "RIGHT"
   local line_commentable = in_diff_context
   if line_commentable == nil then
     line_commentable = is_line_commentable(path, line, side)
@@ -794,13 +798,14 @@ end
 ---@param prefill_lines string[]
 ---@return boolean
 local function open_new_thread_from_line(path, line, prefill_lines, target)
-  local disable_reason = new_thread_disable_reason(path, line)
+  local side = target and target.side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
   if disable_reason then
     vim.notify(disable_reason, vim.log.levels.WARN)
     return false
   end
   open_new_thread_editor(path, line, prefill_lines or {}, {
-    side = target and target.side,
+    side = side,
     in_diff_context = target and target.in_diff_context,
   })
   return true
@@ -978,24 +983,10 @@ end
 
 local function split_row_for_line(buf, path, line, side)
   local rendered = diff.get_split_metadata(buf)
-  if not rendered then
-    return nil
-  end
-  side = side == "LEFT" and "LEFT" or "RIGHT"
-  for idx, row in ipairs(rendered.rows or {}) do
-    if row.path == path then
-      if side == "LEFT" and row.old_line == line and not row.left_continuation then
-        return idx, rendered.left_range.content_start_col
-      end
-      if side == "RIGHT" and row.new_line == line and not row.right_continuation then
-        return idx, rendered.right_range.content_start_col
-      end
-    end
-  end
-  return nil
+  return diff.find_split_row(rendered, { path = path, line = line, side = side })
 end
 
-local function jump_to_path_and_line(path, line)
+local function jump_to_path_and_line(path, line, side)
   local files = state.get_files()
   local target_file = nil
   local target_index = nil
@@ -1015,7 +1006,7 @@ local function jump_to_path_and_line(path, line)
     M.show_comments(buf, state.get_comments(path))
   end
   if line then
-    local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, "RIGHT")
+    local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, side)
     local line_count = vim.api.nvim_buf_line_count(0)
     vim.api.nvim_win_set_cursor(0, { math.max(1, math.min(rendered_row or line, line_count)), rendered_col or 0 })
     vim.cmd("normal! zz")
@@ -1033,7 +1024,7 @@ function M.jump_to_thread(thread_id, opts)
     return false
   end
   state.set_selected_thread_id(thread.thread_id)
-  if not jump_to_path_and_line(thread.path, thread.line) then
+  if not jump_to_path_and_line(thread.path, thread.line, thread.side) then
     return false
   end
   if opts and opts.open_window then
@@ -1084,7 +1075,7 @@ local function jump_to_file_target(path)
     end
   end
   if first_issue_line then
-    return jump_to_path_and_line(path, first_issue_line)
+    return jump_to_path_and_line(path, first_issue_line, "RIGHT")
   end
   local file = nil
   for _, entry in ipairs(state.get_files()) do
@@ -1094,7 +1085,7 @@ local function jump_to_file_target(path)
     end
   end
   local changed_line = first_changed_line(file)
-  return jump_to_path_and_line(path, changed_line or 1)
+  return jump_to_path_and_line(path, changed_line or 1, "RIGHT")
 end
 
 function M.jump_to_file(path)
@@ -1257,13 +1248,8 @@ end
 
 local function restore_new_thread_snapshot(snapshot)
   local disable_reason = nil
-  if not find_pr_file(snapshot.path) then
+  if new_thread_disable_reason(snapshot.path, snapshot.line, snapshot.side) then
     disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
-  else
-    local line_count = checkout_line_count(snapshot.path)
-    if line_count and snapshot.line and snapshot.line > line_count then
-      disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
-    end
   end
   open_new_thread_editor(
     snapshot.path,
@@ -1611,7 +1597,7 @@ local function issue_prefill_lines(issue_comments)
   return lines
 end
 
-local function open_same_line_picker(path, line, line_state)
+local function open_same_line_picker(path, line, line_state, target)
   local thread_rows = {}
   local selected_thread_id = state.get_selected_thread_id()
   local selected = 1
@@ -1648,7 +1634,7 @@ local function open_same_line_picker(path, line, line_state)
       key = "new_thread:" .. path .. ":" .. tostring(line),
       text = "[NEW] New thread on this line",
       on_select = function()
-        open_new_thread_editor(path, line, {})
+        open_new_thread_from_line(path, line, {}, target)
       end,
     })
   end
@@ -1683,7 +1669,7 @@ function M.show_comment_thread()
     return
   end
   if #line_state.threads > 0 then
-    open_same_line_picker(path, line, line_state)
+    open_same_line_picker(path, line, line_state, target)
     return
   end
   open_new_thread_from_line(path, line, issue_prefill_lines(line_state.issue_comments), target)

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -648,19 +648,6 @@ end
 
 ---@param path string
 ---@param line number
----@return boolean
-local function can_start_new_thread(path, line)
-  if line == nil then
-    return find_pr_file(path) ~= nil
-  end
-  if type(line) ~= "number" or line < 1 then
-    return false
-  end
-  return find_pr_file(path) ~= nil
-end
-
----@param path string
----@param line number
 ---@param side? string
 ---@return string|nil
 local function new_thread_disable_reason(path, line, side)
@@ -689,6 +676,30 @@ local function new_thread_disable_reason(path, line, side)
   return nil
 end
 
+local function resolve_new_thread_target(path, line, side, in_diff_context)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
+  if disable_reason then
+    return {
+      kind = "disabled",
+      side = side,
+      line_commentable = false,
+      disable_reason = disable_reason,
+    }
+  end
+
+  local line_commentable = in_diff_context
+  if line_commentable == nil then
+    line_commentable = is_line_commentable(path, line, side)
+  end
+
+  return {
+    kind = line_commentable and "line" or "file",
+    side = side,
+    line_commentable = line_commentable == true,
+  }
+end
+
 local function is_anchor_validation_error(err)
   if not err then
     return false
@@ -713,14 +724,10 @@ local function send_new_thread(path, line, side, in_diff_context)
     return
   end
   side = side == "LEFT" and "LEFT" or "RIGHT"
-  local disable_reason = new_thread_disable_reason(path, line, side)
-  if disable_reason then
-    vim.notify(disable_reason, vim.log.levels.WARN)
+  local target = resolve_new_thread_target(path, line, side, in_diff_context)
+  if target.kind == "disabled" then
+    vim.notify(target.disable_reason, vim.log.levels.WARN)
     return
-  end
-  local line_commentable = in_diff_context
-  if line_commentable == nil then
-    line_commentable = is_line_commentable(path, line, side)
   end
 
   local function on_send_success()
@@ -762,7 +769,7 @@ local function send_new_thread(path, line, side, in_diff_context)
     end)
   end
 
-  if not line_commentable then
+  if target.kind == "file" then
     send_via_rest(nil, { subject_type = "file" })
     return
   end
@@ -775,14 +782,14 @@ end
 ---@return boolean
 local function open_new_thread_from_line(path, line, prefill_lines, target)
   local side = target and target.side == "LEFT" and "LEFT" or "RIGHT"
-  local disable_reason = new_thread_disable_reason(path, line, side)
-  if disable_reason then
-    vim.notify(disable_reason, vim.log.levels.WARN)
+  local resolved = resolve_new_thread_target(path, line, side, target and target.in_diff_context)
+  if resolved.kind == "disabled" then
+    vim.notify(resolved.disable_reason, vim.log.levels.WARN)
     return false
   end
   open_new_thread_editor(path, line, prefill_lines or {}, {
-    side = side,
-    in_diff_context = target and target.in_diff_context,
+    side = resolved.side,
+    in_diff_context = resolved.line_commentable,
   })
   return true
 end
@@ -791,12 +798,10 @@ open_new_thread_editor = function(path, line, prefill_lines, opts)
   opts = opts or {}
   local shortcuts = config.load_shortcuts()
   local side = opts.side == "LEFT" and "LEFT" or "RIGHT"
-  local line_commentable = opts.in_diff_context
-  if line_commentable == nil then
-    line_commentable = is_line_commentable(path, line, side)
-  end
-  local title_prefix = line_commentable and "New Thread" or "New File Comment"
-  local intro_line = line_commentable
+  local target = resolve_new_thread_target(path, line, side, opts.in_diff_context)
+  local line_commentable = target.line_commentable
+  local title_prefix = target.kind == "line" and "New Thread" or "New File Comment"
+  local intro_line = target.kind == "line"
     and "New thread on this line"
     or "New file comment (GitHub shows it at the top of the file)"
   local lines = { intro_line, "" }
@@ -817,12 +822,12 @@ open_new_thread_editor = function(path, line, prefill_lines, opts)
     kind = "new_thread",
     path = path,
     line = line,
-    side = side,
+    side = target.side,
     in_diff_context = line_commentable,
     prefill_lines = prefill_lines,
     initial_input_lines = opts.initial_input_lines,
     on_send = opts.disable_send_reason and nil or function()
-      send_new_thread(path, line, side, line_commentable)
+      send_new_thread(path, line, target.side, line_commentable)
     end,
   })
   if opts.disable_send_reason then
@@ -1234,7 +1239,8 @@ end
 
 local function restore_new_thread_snapshot(snapshot)
   local disable_reason = nil
-  if new_thread_disable_reason(snapshot.path, snapshot.line, snapshot.side) then
+  local target = resolve_new_thread_target(snapshot.path, snapshot.line, snapshot.side, snapshot.in_diff_context)
+  if target.kind == "disabled" then
     disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
   end
   open_new_thread_editor(
@@ -1244,8 +1250,8 @@ local function restore_new_thread_snapshot(snapshot)
     {
       initial_input_lines = snapshot.input_lines,
       disable_send_reason = disable_reason,
-      side = snapshot.side,
-      in_diff_context = snapshot.in_diff_context,
+      side = target.side,
+      in_diff_context = target.line_commentable,
     }
   )
 end
@@ -1615,10 +1621,13 @@ local function open_same_line_picker(path, line, line_state, target)
       end,
     })
   end
-  if can_start_new_thread(path, line) then
+  local new_target = resolve_new_thread_target(path, line, target and target.side, target and target.in_diff_context)
+  if new_target.kind ~= "disabled" then
     table.insert(thread_rows, {
       key = "new_thread:" .. path .. ":" .. tostring(line),
-      text = "[NEW] New thread on this line",
+      text = new_target.kind == "line"
+          and "[NEW] New thread on this line"
+        or "[NEW] New file comment for this file",
       on_select = function()
         open_new_thread_from_line(path, line, {}, target)
       end,

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -100,6 +100,8 @@ local editor_state = {
   thread_id = nil,
   path = nil,
   line = nil,
+  side = nil,
+  in_diff_context = nil,
   prefill_lines = nil,
   augroup = nil,
 }
@@ -111,6 +113,10 @@ local function trim(text)
 end
 
 local function current_buf_path(buf)
+  local rendered = diff.get_split_metadata(buf or 0)
+  if rendered and rendered.rows and rendered.rows[1] then
+    return rendered.rows[1].path
+  end
   local clone_path = state.get_clone_path()
   if not clone_path then
     return nil
@@ -181,6 +187,8 @@ local function close_active_editor(force)
     thread_id = nil,
     path = nil,
     line = nil,
+    side = nil,
+    in_diff_context = nil,
     prefill_lines = nil,
     augroup = nil,
   }
@@ -272,6 +280,29 @@ local function line_summary(bucket)
   return string.format("%d issue notes on this line", #bucket.issue_comments)
 end
 
+local function bucket_sides(bucket)
+  local sides = { LEFT = false, RIGHT = false }
+  for _, thread in ipairs(bucket.threads or {}) do
+    local saw_side = false
+    for _, comment in ipairs(thread.comments or {}) do
+      if comment.side == "LEFT" then
+        sides.LEFT = true
+        saw_side = true
+      elseif comment.side == "RIGHT" then
+        sides.RIGHT = true
+        saw_side = true
+      end
+    end
+    if not saw_side then
+      sides.RIGHT = true
+    end
+  end
+  if #(bucket.issue_comments or {}) > 0 then
+    sides.RIGHT = true
+  end
+  return sides
+end
+
 local function setup_override_highlights()
   vim.api.nvim_set_hl(0, "RaccoonCommentBadge", { default = true, bold = true })
   vim.api.nvim_set_hl(0, "RaccoonCommentBadgeStrong", { default = true, bold = true, link = "Title" })
@@ -317,6 +348,41 @@ function M.show_comments(buf, _comments)
   end)
 
   local line_map = index.line_state_by_file[path] or {}
+  local rendered = diff.get_split_metadata(buf)
+  if rendered then
+    for row_idx, row in ipairs(rendered.rows or {}) do
+      local specs = {}
+      if row.old_line and line_map[row.old_line] then
+        local bucket = line_map[row.old_line]
+        if bucket_sides(bucket).LEFT then
+          table.insert(specs, {
+            col = rendered.left_range.start_col,
+            bucket = bucket,
+          })
+        end
+      end
+      if row.new_line and line_map[row.new_line] then
+        local bucket = line_map[row.new_line]
+        if bucket_sides(bucket).RIGHT then
+          table.insert(specs, {
+            col = rendered.right_range.start_col,
+            bucket = bucket,
+          })
+        end
+      end
+      for _, spec in ipairs(specs) do
+        local badge = build_badge(spec.bucket.counts)
+        local badge_hl = (spec.bucket.counts.nr or 0) > 0 and "RaccoonCommentBadgeStrong" or "RaccoonCommentBadge"
+        pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row_idx - 1, 0, {
+          virt_text = { { badge, badge_hl } },
+          virt_text_pos = "overlay",
+          virt_text_win_col = spec.col,
+        })
+      end
+    end
+    return
+  end
+
   local line_count = vim.api.nvim_buf_line_count(buf)
   local ordered_lines = {}
   for line in pairs(line_map) do
@@ -476,6 +542,8 @@ local function open_editor_window(opts)
     thread_id = opts.thread_id,
     path = opts.path,
     line = opts.line,
+    side = opts.side,
+    in_diff_context = opts.in_diff_context,
     prefill_lines = opts.prefill_lines,
     augroup = nil,
   }
@@ -530,16 +598,37 @@ local function get_editor_input_lines()
   return vim.api.nvim_buf_get_lines(editor_state.buf, editor_state.input_start - 1, -1, false)
 end
 
-local function is_line_commentable(path, line)
+local function is_line_commentable(path, line, side)
   if type(line) ~= "number" or line < 1 then
     return false
   end
   for _, file in ipairs(state.get_files()) do
     if file.filename == path then
-      return diff.is_line_in_review_context(file.patch, line)
+      return diff.is_line_in_review_context(file.patch, line, side or "RIGHT")
     end
   end
   return false
+end
+
+local function current_review_target()
+  local buf = vim.api.nvim_get_current_buf()
+  local rendered = diff.get_split_metadata(buf)
+  if rendered then
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    return diff.resolve_cursor_target(buf, cursor[1], cursor[2])
+  end
+
+  local path = current_buf_path(buf)
+  if not path then
+    return nil
+  end
+  local line = vim.fn.line(".")
+  return {
+    path = path,
+    line = line,
+    side = "RIGHT",
+    in_diff_context = is_line_commentable(path, line, "RIGHT"),
+  }
 end
 
 ---@param path string
@@ -588,6 +677,9 @@ end
 ---@param line number
 ---@return boolean
 local function can_start_new_thread(path, line)
+  if line == nil then
+    return find_pr_file(path) ~= nil
+  end
   if type(line) ~= "number" or line < 1 then
     return false
   end
@@ -598,6 +690,9 @@ end
 ---@param line number
 ---@return string|nil
 local function new_thread_disable_reason(path, line)
+  if line == nil then
+    return find_pr_file(path) and nil or file_outside_pr_changes_message()
+  end
   if type(line) ~= "number" or line < 1 then
     return "Invalid line number for comment"
   end
@@ -614,7 +709,18 @@ local function new_thread_disable_reason(path, line)
   return nil
 end
 
-local function send_new_thread(path, line)
+local function is_anchor_validation_error(err)
+  if not err then
+    return false
+  end
+  local text = tostring(err):lower()
+  return text:match("422") ~= nil
+    or text:match("validation") ~= nil
+    or text:match("position") ~= nil
+    or text:match("context") ~= nil
+end
+
+local function send_new_thread(path, line, side, in_diff_context)
   local ctx, ctx_err = ensure_review_context()
   if ctx_err then
     vim.notify(ctx_err, vim.log.levels.ERROR)
@@ -631,7 +737,11 @@ local function send_new_thread(path, line)
     vim.notify(disable_reason, vim.log.levels.WARN)
     return
   end
-  local line_commentable = is_line_commentable(path, line)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local line_commentable = in_diff_context
+  if line_commentable == nil then
+    line_commentable = is_line_commentable(path, line, side)
+  end
 
   local function on_send_success()
     close_active_editor(true)
@@ -654,11 +764,15 @@ local function send_new_thread(path, line)
       comment_opts.subject_type = "file"
     else
       comment_opts.line = line
-      comment_opts.side = "RIGHT"
+      comment_opts.side = side
     end
     api.create_comment(ctx.owner, ctx.repo, ctx.number, comment_opts, ctx.token, function(_result, err)
       vim.schedule(function()
         if err then
+          if rest_opts.allow_file_retry and is_anchor_validation_error(err) then
+            send_via_rest(rest_error_prefix, { subject_type = "file" })
+            return
+          end
           local prefix = rest_error_prefix or "Failed to send thread"
           vim.notify(prefix .. ": " .. err, vim.log.levels.ERROR)
           return
@@ -672,27 +786,34 @@ local function send_new_thread(path, line)
     send_via_rest(nil, { subject_type = "file" })
     return
   end
-  send_via_rest()
+  send_via_rest(nil, { allow_file_retry = side == "LEFT" })
 end
 
 ---@param path string
 ---@param line number
 ---@param prefill_lines string[]
 ---@return boolean
-local function open_new_thread_from_line(path, line, prefill_lines)
+local function open_new_thread_from_line(path, line, prefill_lines, target)
   local disable_reason = new_thread_disable_reason(path, line)
   if disable_reason then
     vim.notify(disable_reason, vim.log.levels.WARN)
     return false
   end
-  open_new_thread_editor(path, line, prefill_lines or {})
+  open_new_thread_editor(path, line, prefill_lines or {}, {
+    side = target and target.side,
+    in_diff_context = target and target.in_diff_context,
+  })
   return true
 end
 
 open_new_thread_editor = function(path, line, prefill_lines, opts)
   opts = opts or {}
   local shortcuts = config.load_shortcuts()
-  local line_commentable = is_line_commentable(path, line)
+  local side = opts.side == "LEFT" and "LEFT" or "RIGHT"
+  local line_commentable = opts.in_diff_context
+  if line_commentable == nil then
+    line_commentable = is_line_commentable(path, line, side)
+  end
   local title_prefix = line_commentable and "New Thread" or "New File Comment"
   local intro_line = line_commentable
     and "New thread on this line"
@@ -707,17 +828,20 @@ open_new_thread_editor = function(path, line, prefill_lines, opts)
   local input_start = #lines + 1
   table.insert(lines, "")
   local allow_send = not opts.disable_send_reason
+  local line_label = line and (" L" .. tostring(line)) or " FILE"
   open_editor_window({
-    title = build_editor_title(title_prefix .. " L" .. tostring(line), shortcuts, allow_send, false, false),
+    title = build_editor_title(title_prefix .. line_label, shortcuts, allow_send, false, false),
     lines = lines,
     input_start = input_start,
     kind = "new_thread",
     path = path,
     line = line,
+    side = side,
+    in_diff_context = line_commentable,
     prefill_lines = prefill_lines,
     initial_input_lines = opts.initial_input_lines,
     on_send = opts.disable_send_reason and nil or function()
-      send_new_thread(path, line)
+      send_new_thread(path, line, side, line_commentable)
     end,
   })
   if opts.disable_send_reason then
@@ -852,6 +976,25 @@ local function open_thread_editor(thread_id, opts)
   end
 end
 
+local function split_row_for_line(buf, path, line, side)
+  local rendered = diff.get_split_metadata(buf)
+  if not rendered then
+    return nil
+  end
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  for idx, row in ipairs(rendered.rows or {}) do
+    if row.path == path then
+      if side == "LEFT" and row.old_line == line and not row.left_continuation then
+        return idx, rendered.left_range.content_start_col
+      end
+      if side == "RIGHT" and row.new_line == line and not row.right_continuation then
+        return idx, rendered.right_range.content_start_col
+      end
+    end
+  end
+  return nil
+end
+
 local function jump_to_path_and_line(path, line)
   local files = state.get_files()
   local target_file = nil
@@ -872,8 +1015,9 @@ local function jump_to_path_and_line(path, line)
     M.show_comments(buf, state.get_comments(path))
   end
   if line then
+    local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, "RIGHT")
     local line_count = vim.api.nvim_buf_line_count(0)
-    vim.api.nvim_win_set_cursor(0, { math.max(1, math.min(line, line_count)), 0 })
+    vim.api.nvim_win_set_cursor(0, { math.max(1, math.min(rendered_row or line, line_count)), rendered_col or 0 })
     vim.cmd("normal! zz")
   end
   return true
@@ -1090,6 +1234,8 @@ function M.capture_ui_state()
       thread_id = editor_state.thread_id,
       path = editor_state.path,
       line = editor_state.line,
+      side = editor_state.side,
+      in_diff_context = editor_state.in_diff_context,
       prefill_lines = editor_state.prefill_lines,
       input_lines = get_editor_input_lines(),
     }
@@ -1115,7 +1261,7 @@ local function restore_new_thread_snapshot(snapshot)
     disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
   else
     local line_count = checkout_line_count(snapshot.path)
-    if line_count and snapshot.line > line_count then
+    if line_count and snapshot.line and snapshot.line > line_count then
       disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
     end
   end
@@ -1126,6 +1272,8 @@ local function restore_new_thread_snapshot(snapshot)
     {
       initial_input_lines = snapshot.input_lines,
       disable_send_reason = disable_reason,
+      side = snapshot.side,
+      in_diff_context = snapshot.in_diff_context,
     }
   )
 end
@@ -1301,8 +1449,9 @@ function M.list_comments(opts)
   local selected = resolve_selected_row(rows, opts.selection_key, opts.selected_index)
   if not opts.selection_key and not opts.selected_index then
     local current_thread_id = state.get_selected_thread_id()
-    local current_path = current_buf_path(0)
-    local current_line = vim.fn.line(".")
+    local target = current_review_target()
+    local current_path = target and target.path or current_buf_path(0)
+    local current_line = target and target.line or vim.fn.line(".")
     for row_idx, row in ipairs(rows) do
       if current_thread_id and row.thread_id == current_thread_id then
         selected = row_idx
@@ -1353,8 +1502,9 @@ function M.list_threads(opts)
   local rows = {}
   local selected = 1
   local current_thread_id = state.get_selected_thread_id()
-  local current_path = current_buf_path(0)
-  local current_line = vim.fn.line(".")
+  local target = current_review_target()
+  local current_path = target and target.path or current_buf_path(0)
+  local current_line = target and target.line or vim.fn.line(".")
   for row_idx, thread in ipairs(index.unresolved_threads) do
     if current_thread_id and thread.thread_id == current_thread_id then
       selected = row_idx
@@ -1516,26 +1666,27 @@ function M.show_comment_thread()
     flat_diff_only_message()
     return
   end
-  local path = current_buf_path(0)
-  if not path then
+  local target = current_review_target()
+  if not target or not target.path then
     vim.notify("Not in a PR file", vim.log.levels.WARN)
     return
   end
-  local line = vim.fn.line(".")
+  local path = target.path
+  local line = target.line
   local index = build_index()
   if not index then
     return
   end
   local line_state = thread_index.get_comment_line_state(index, path, line)
   if not line_state then
-    open_new_thread_from_line(path, line, {})
+    open_new_thread_from_line(path, line, {}, target)
     return
   end
   if #line_state.threads > 0 then
     open_same_line_picker(path, line, line_state)
     return
   end
-  open_new_thread_from_line(path, line, issue_prefill_lines(line_state.issue_comments))
+  open_new_thread_from_line(path, line, issue_prefill_lines(line_state.issue_comments), target)
 end
 
 --- Get the namespace ID

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -280,29 +280,6 @@ local function line_summary(bucket)
   return string.format("%d issue notes on this line", #bucket.issue_comments)
 end
 
-local function bucket_sides(bucket)
-  local sides = { LEFT = false, RIGHT = false }
-  for _, thread in ipairs(bucket.threads or {}) do
-    local saw_side = false
-    for _, comment in ipairs(thread.comments or {}) do
-      if comment.side == "LEFT" then
-        sides.LEFT = true
-        saw_side = true
-      elseif comment.side == "RIGHT" then
-        sides.RIGHT = true
-        saw_side = true
-      end
-    end
-    if not saw_side then
-      sides.RIGHT = true
-    end
-  end
-  if #(bucket.issue_comments or {}) > 0 then
-    sides.RIGHT = true
-  end
-  return sides
-end
-
 local function setup_override_highlights()
   vim.api.nvim_set_hl(0, "RaccoonCommentBadge", { default = true, bold = true })
   vim.api.nvim_set_hl(0, "RaccoonCommentBadgeStrong", { default = true, bold = true, link = "Title" })
@@ -352,23 +329,19 @@ function M.show_comments(buf, _comments)
   if rendered then
     for row_idx, row in ipairs(rendered.rows or {}) do
       local specs = {}
-      if row.old_line and line_map[row.old_line] then
-        local bucket = line_map[row.old_line]
-        if bucket_sides(bucket).LEFT then
-          table.insert(specs, {
-            col = rendered.left_range.start_col,
-            bucket = bucket,
-          })
-        end
+      local left_bucket = thread_index.get_line_state(index, path, row.old_line, "LEFT")
+      if left_bucket then
+        table.insert(specs, {
+          col = rendered.left_range.start_col,
+          bucket = left_bucket,
+        })
       end
-      if row.new_line and line_map[row.new_line] then
-        local bucket = line_map[row.new_line]
-        if bucket_sides(bucket).RIGHT then
-          table.insert(specs, {
-            col = rendered.right_range.start_col,
-            bucket = bucket,
-          })
-        end
+      local right_bucket = thread_index.get_line_state(index, path, row.new_line, "RIGHT")
+      if right_bucket then
+        table.insert(specs, {
+          col = rendered.right_range.start_col,
+          bucket = right_bucket,
+        })
       end
       for _, spec in ipairs(specs) do
         local badge = build_badge(spec.bucket.counts)
@@ -693,7 +666,10 @@ end
 local function new_thread_disable_reason(path, line, side)
   side = side == "LEFT" and "LEFT" or "RIGHT"
   if line == nil then
-    return find_pr_file(path) and nil or file_outside_pr_changes_message()
+    if find_pr_file(path) then
+      return nil
+    end
+    return file_outside_pr_changes_message()
   end
   if type(line) ~= "number" or line < 1 then
     return "Invalid line number for comment"
@@ -1008,6 +984,16 @@ local function jump_to_path_and_line(path, line, side)
   if line then
     local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, side)
     local line_count = vim.api.nvim_buf_line_count(0)
+    if rendered_row then
+      diff.set_split_semantic_target(vim.api.nvim_get_current_buf(), {
+        path = path,
+        line = line,
+        side = side,
+        row = rendered_row,
+      })
+    else
+      diff.set_split_semantic_target(vim.api.nvim_get_current_buf(), nil)
+    end
     vim.api.nvim_win_set_cursor(0, { math.max(1, math.min(rendered_row or line, line_count)), rendered_col or 0 })
     vim.cmd("normal! zz")
   end
@@ -1663,7 +1649,11 @@ function M.show_comment_thread()
   if not index then
     return
   end
-  local line_state = thread_index.get_comment_line_state(index, path, line)
+  if line == nil then
+    open_new_thread_from_line(path, nil, {}, target)
+    return
+  end
+  local line_state = thread_index.get_comment_line_state(index, path, line, target.side)
   if not line_state then
     open_new_thread_from_line(path, line, {}, target)
     return

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -399,6 +399,9 @@ function M.apply_diff_highlights(ns_id, buf, line_list)
       })
     end
   end
+  for _, span in ipairs(diff.render_stacked_inline_spans(line_list)) do
+    pcall(vim.api.nvim_buf_add_highlight, buf, ns_id, span.hl, span.line - 1, span.start_col, span.end_col)
+  end
 end
 
 --- Clamp a config value to an integer within [min_val, max_val], or return default
@@ -916,7 +919,7 @@ function M.render_file_preview(s, opts)
       for _, hunk in ipairs(hunks) do
         for _, line_data in ipairs(hunk.lines) do
           table.insert(lines, line_data.content or "")
-          table.insert(hl_lines, { type = line_data.type })
+          table.insert(hl_lines, { type = line_data.type, content = line_data.content or "" })
         end
       end
       finalize_preview(buf, win, opts.filename, lines)
@@ -1001,7 +1004,7 @@ function M.open_maximize(opts)
     for _, hunk in ipairs(hunks) do
       for _, line_data in ipairs(hunk.lines) do
         table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type })
+        table.insert(hl_lines, { type = line_data.type, content = line_data.content or "" })
       end
     end
 
@@ -1261,7 +1264,7 @@ function M.refresh_maximize(s)
     for _, hunk in ipairs(hunks) do
       for _, line_data in ipairs(hunk.lines) do
         table.insert(lines, line_data.content or "")
-        table.insert(hl_lines, { type = line_data.type })
+        table.insert(hl_lines, { type = line_data.type, content = line_data.content or "" })
       end
     end
 

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -257,41 +257,154 @@ local function line_or_hunk_content(lines, line_num, fallback)
   return fallback or ""
 end
 
-local function changed_span(left, right)
-  if #left > M.MAX_INLINE_DIFF_DISPLAY_CHARS or #right > M.MAX_INLINE_DIFF_DISPLAY_CHARS then
-    return nil, nil
+local function split_utf8_chars(text)
+  local chars = {}
+  local byte_idx = 1
+  text = text or ""
+  while byte_idx <= #text do
+    local byte = text:byte(byte_idx)
+    local char_len = 1
+    if byte and byte >= 0xF0 then
+      char_len = 4
+    elseif byte and byte >= 0xE0 then
+      char_len = 3
+    elseif byte and byte >= 0xC0 then
+      char_len = 2
+    end
+    local end_idx = math.min(#text, byte_idx + char_len - 1)
+    table.insert(chars, {
+      value = text:sub(byte_idx, end_idx),
+      start_col = byte_idx - 1,
+      end_col = end_idx,
+    })
+    byte_idx = end_idx + 1
+  end
+  return chars
+end
+
+local function append_changed_char_spans(spans, chars, changed)
+  local start_idx = nil
+  for idx = 1, #chars do
+    if changed[idx] then
+      start_idx = start_idx or idx
+    elseif start_idx then
+      table.insert(spans, {
+        start_col = chars[start_idx].start_col,
+        end_col = chars[idx - 1].end_col,
+      })
+      start_idx = nil
+    end
+  end
+  if start_idx then
+    table.insert(spans, {
+      start_col = chars[start_idx].start_col,
+      end_col = chars[#chars].end_col,
+    })
+  end
+end
+
+local function mark_lcs_matches(
+  left_chars,
+  left_start,
+  left_end,
+  right_chars,
+  right_start,
+  right_end,
+  left_changed,
+  right_changed
+)
+  local left_count = left_end - left_start + 1
+  local right_count = right_end - right_start + 1
+  if left_count <= 0 or right_count <= 0 then
+    return
   end
 
+  local dp = {}
+  for left_idx = 1, left_count + 1 do
+    dp[left_idx] = {}
+    for right_idx = 1, right_count + 1 do
+      dp[left_idx][right_idx] = 0
+    end
+  end
+
+  for left_idx = left_count, 1, -1 do
+    for right_idx = right_count, 1, -1 do
+      local actual_left = left_start + left_idx - 1
+      local actual_right = right_start + right_idx - 1
+      if left_chars[actual_left].value == right_chars[actual_right].value then
+        dp[left_idx][right_idx] = dp[left_idx + 1][right_idx + 1] + 1
+      else
+        dp[left_idx][right_idx] = math.max(dp[left_idx + 1][right_idx], dp[left_idx][right_idx + 1])
+      end
+    end
+  end
+
+  local left_idx = 1
+  local right_idx = 1
+  while left_idx <= left_count and right_idx <= right_count do
+    local actual_left = left_start + left_idx - 1
+    local actual_right = right_start + right_idx - 1
+    if left_chars[actual_left].value == right_chars[actual_right].value then
+      left_changed[actual_left] = false
+      right_changed[actual_right] = false
+      left_idx = left_idx + 1
+      right_idx = right_idx + 1
+    elseif dp[left_idx + 1][right_idx] >= dp[left_idx][right_idx + 1] then
+      left_idx = left_idx + 1
+    else
+      right_idx = right_idx + 1
+    end
+  end
+end
+
+local function compute_inline_char_spans(left, right)
+  if #left > M.MAX_INLINE_DIFF_DISPLAY_CHARS or #right > M.MAX_INLINE_DIFF_DISPLAY_CHARS then
+    return {}, {}
+  end
+
+  if left == right then
+    return {}, {}
+  end
+
+  local left_chars = split_utf8_chars(left)
+  local right_chars = split_utf8_chars(right)
   local prefix = 0
-  local max_prefix = math.min(#left, #right)
-  while prefix < max_prefix and left:sub(prefix + 1, prefix + 1) == right:sub(prefix + 1, prefix + 1) do
+  local max_prefix = math.min(#left_chars, #right_chars)
+  while prefix < max_prefix and left_chars[prefix + 1].value == right_chars[prefix + 1].value do
     prefix = prefix + 1
   end
 
-  local left_suffix = #left
-  local right_suffix = #right
-  while left_suffix > prefix
-    and right_suffix > prefix
-    and left:sub(left_suffix, left_suffix) == right:sub(right_suffix, right_suffix)
+  local left_end = #left_chars
+  local right_end = #right_chars
+  while left_end > prefix
+    and right_end > prefix
+    and left_chars[left_end].value == right_chars[right_end].value
   do
-    left_suffix = left_suffix - 1
-    right_suffix = right_suffix - 1
+    left_end = left_end - 1
+    right_end = right_end - 1
   end
 
-  local old_span = nil
-  if left_suffix > prefix then
-    old_span = { start_col = prefix, end_col = left_suffix }
+  local left_changed = {}
+  local right_changed = {}
+  for idx = prefix + 1, left_end do
+    left_changed[idx] = true
   end
-  local new_span = nil
-  if right_suffix > prefix then
-    new_span = { start_col = prefix, end_col = right_suffix }
+  for idx = prefix + 1, right_end do
+    right_changed[idx] = true
   end
-  return old_span, new_span
+
+  mark_lcs_matches(left_chars, prefix + 1, left_end, right_chars, prefix + 1, right_end, left_changed, right_changed)
+
+  local old_spans = {}
+  local new_spans = {}
+  append_changed_char_spans(old_spans, left_chars, left_changed)
+  append_changed_char_spans(new_spans, right_chars, right_changed)
+  return old_spans, new_spans
 end
 
 local function append_pair_spans(spans, left_line, right_line, left_content, right_content, left_hl, right_hl)
-  local old_span, new_span = changed_span(left_content or "", right_content or "")
-  if old_span then
+  local old_spans, new_spans = compute_inline_char_spans(left_content or "", right_content or "")
+  for _, old_span in ipairs(old_spans) do
     table.insert(spans, {
       line = left_line,
       start_col = old_span.start_col,
@@ -299,7 +412,7 @@ local function append_pair_spans(spans, left_line, right_line, left_content, rig
       hl = left_hl,
     })
   end
-  if new_span then
+  for _, new_span in ipairs(new_spans) do
     table.insert(spans, {
       line = right_line,
       start_col = new_span.start_col,
@@ -671,6 +784,20 @@ local function line_highlight(kind)
   return nil
 end
 
+local function split_position_key(path, side, line)
+  if not path or type(line) ~= "number" then
+    return nil
+  end
+  return path .. "|" .. side .. "|" .. tostring(line)
+end
+
+--- Return the visible cursor column for split diff jumps.
+---@param rendered table|nil
+---@return number col
+function M.left_cursor_col(rendered)
+  return rendered and rendered.left_range and rendered.left_range.content_start_col or 0
+end
+
 --- Render a changed file as a read-only full-file split diff.
 ---@param opts table {path, previous_path?, status?, old_lines?, new_lines?, patch?, width?, binary?}
 ---@return table rendered {lines, rows, highlights, separator_col, left_range, right_range}
@@ -685,6 +812,7 @@ function M.render_split_file(opts)
   local rows = {}
   local highlights = {}
   local inline_highlights = {}
+  local position_by_key = {}
 
   local function append_rendered_row(row)
     local left_chunks = split_to_display_width(row.old_content or "", layout.content_width)
@@ -718,6 +846,22 @@ function M.render_split_file(opts)
         hunk = row.hunk,
       }
       table.insert(rows, rendered_row)
+      if chunk_idx == 1 then
+        local left_key = split_position_key(rendered_row.path, "LEFT", rendered_row.old_line)
+        if left_key then
+          position_by_key[left_key] = {
+            row = #rows,
+            col = layout.left_range.content_start_col,
+          }
+        end
+        local right_key = split_position_key(rendered_row.path, "RIGHT", rendered_row.new_line)
+        if right_key then
+          position_by_key[right_key] = {
+            row = #rows,
+            col = layout.left_range.content_start_col,
+          }
+        end
+      end
       local hl = line_highlight(row.kind)
       if hl then
         table.insert(highlights, {
@@ -729,8 +873,8 @@ function M.render_split_file(opts)
     end
 
     if row.kind == "change" and first_line == #lines then
-      local old_span, new_span = changed_span(row.old_content or "", row.new_content or "")
-      if old_span then
+      local old_spans, new_spans = compute_inline_char_spans(row.old_content or "", row.new_content or "")
+      for _, old_span in ipairs(old_spans) do
         table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.left_range.content_start_col + old_span.start_col,
@@ -739,7 +883,7 @@ function M.render_split_file(opts)
           priority = INLINE_HIGHLIGHT_PRIORITY,
         })
       end
-      if new_span then
+      for _, new_span in ipairs(new_spans) do
         table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.right_range.content_start_col + new_span.start_col,
@@ -794,6 +938,7 @@ function M.render_split_file(opts)
     right_range = layout.right_range,
     side_width = layout.side_width,
     content_width = layout.content_width,
+    position_by_key = position_by_key,
     syntax_enabled = syntax_enabled,
     syntax_skip_reason = syntax_skip_reason,
   }
@@ -832,28 +977,8 @@ function M.get_split_metadata(buf)
   return split_metadata_by_buf[buf]
 end
 
---- Resolve a buffer row/column into a GitHub review target.
----@param buf number
----@param row number 1-based row
----@param col number 0-based column
----@return table|nil target {path, line, side, in_diff_context, row}
-function M.resolve_cursor_target(buf, row, col)
-  local rendered = M.get_split_metadata(buf)
-  if not rendered then
-    return nil
-  end
-  local meta = rendered.rows and rendered.rows[row]
-  if not meta then
-    return nil
-  end
-
-  local side = "RIGHT"
-  if col >= rendered.left_range.start_col and col <= rendered.left_range.end_col then
-    side = "LEFT"
-  elseif col >= rendered.right_range.start_col and col <= rendered.right_range.end_col then
-    side = "RIGHT"
-  end
-
+local function split_target_from_row(rendered, meta, row, side)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
   local line = side == "LEFT" and meta.old_line or meta.new_line
   if not line and side == "LEFT" and meta.new_line then
     side = "RIGHT"
@@ -870,7 +995,69 @@ function M.resolve_cursor_target(buf, row, col)
     in_diff_context = meta.in_diff_context == true,
     kind = meta.kind,
     row = row,
+    rendered = rendered,
   }
+end
+
+--- Store the semantic side for a split jump whose visible cursor is placed left.
+---@param buf number
+---@param target table|nil {path:string, line:number|nil, side:string, row:number|nil}
+function M.set_split_semantic_target(buf, target)
+  local rendered = M.get_split_metadata(buf)
+  if not rendered then
+    return
+  end
+  if not target then
+    rendered.last_semantic_target = nil
+    return
+  end
+  local row = target.row
+  if not row then
+    row = M.find_split_row(rendered, target)
+  end
+  if not row then
+    rendered.last_semantic_target = nil
+    return
+  end
+  rendered.last_semantic_target = {
+    path = target.path,
+    line = target.line,
+    side = target.side == "LEFT" and "LEFT" or "RIGHT",
+    row = row,
+  }
+end
+
+--- Resolve a buffer row/column into a GitHub review target.
+---@param buf number
+---@param row number 1-based row
+---@param col number 0-based column
+---@return table|nil target {path, line, side, in_diff_context, row}
+function M.resolve_cursor_target(buf, row, col)
+  local rendered = M.get_split_metadata(buf)
+  if not rendered then
+    return nil
+  end
+  local meta = rendered.rows and rendered.rows[row]
+  if not meta then
+    return nil
+  end
+
+  local semantic = rendered.last_semantic_target
+  if semantic and semantic.row == row and semantic.path == meta.path then
+    local target = split_target_from_row(rendered, meta, row, semantic.side)
+    if semantic.line == nil or target.line == semantic.line then
+      return target
+    end
+  end
+
+  local side = "RIGHT"
+  if col >= rendered.left_range.start_col and col <= rendered.left_range.end_col then
+    side = "LEFT"
+  elseif col >= rendered.right_range.start_col and col <= rendered.right_range.end_col then
+    side = "RIGHT"
+  end
+
+  return split_target_from_row(rendered, meta, row, side)
 end
 
 --- Apply rendered split diff content and highlights to a buffer.
@@ -964,13 +1151,18 @@ function M.find_split_row(rendered, target)
     return nil
   end
   local side = target.side == "LEFT" and "LEFT" or "RIGHT"
+  local key = split_position_key(target.path, side, target.line)
+  local pos = key and rendered.position_by_key and rendered.position_by_key[key] or nil
+  if pos then
+    return pos.row, pos.col
+  end
   for idx, row in ipairs(rendered.rows or {}) do
     if row.path == target.path then
       if side == "LEFT" and row.old_line == target.line and not row.left_continuation then
-        return idx, rendered.left_range and rendered.left_range.content_start_col or 0
+        return idx, M.left_cursor_col(rendered)
       end
       if side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
-        return idx, rendered.right_range and rendered.right_range.content_start_col or 0
+        return idx, M.left_cursor_col(rendered)
       end
     end
   end
@@ -986,6 +1178,7 @@ local function restore_target_cursor(buf, rendered, target)
   if not row then
     return
   end
+  M.set_split_semantic_target(buf, vim.tbl_extend("force", target, { row = row }))
   pcall(vim.api.nvim_win_set_cursor, win, { row, col })
 end
 
@@ -1350,12 +1543,20 @@ local function get_current_split_change_rows()
     local is_continuation = row.left_continuation or row.right_continuation
     if is_change and not is_continuation then
       local previous = rows[#rows]
-      if not previous or idx > previous + 1 then
-        table.insert(rows, idx)
+      if not previous or idx > previous.row + 1 then
+        table.insert(rows, {
+          row = idx,
+          target = {
+            path = row.path,
+            line = row.new_line or row.old_line,
+            side = row.new_line and "RIGHT" or "LEFT",
+            row = idx,
+          },
+        })
       end
     end
   end
-  return rows
+  return rendered, rows
 end
 
 --- Navigate to the next diff hunk in the current file
@@ -1366,16 +1567,17 @@ function M.next_diff()
     return false
   end
 
-  local split_rows = get_current_split_change_rows()
+  local rendered, split_rows = get_current_split_change_rows()
   if split_rows then
     if #split_rows == 0 then
       vim.notify("No changes in this file", vim.log.levels.INFO)
       return false
     end
     local current_line = vim.fn.line(".")
-    for _, line in ipairs(split_rows) do
-      if line > current_line then
-        vim.api.nvim_win_set_cursor(0, { line, 0 })
+    for _, entry in ipairs(split_rows) do
+      if entry.row > current_line then
+        M.set_split_semantic_target(vim.api.nvim_get_current_buf(), entry.target)
+        vim.api.nvim_win_set_cursor(0, { entry.row, M.left_cursor_col(rendered) })
         vim.cmd("normal! zz")
         return true
       end
@@ -1413,7 +1615,7 @@ function M.prev_diff()
     return false
   end
 
-  local split_rows = get_current_split_change_rows()
+  local rendered, split_rows = get_current_split_change_rows()
   if split_rows then
     if #split_rows == 0 then
       vim.notify("No changes in this file", vim.log.levels.INFO)
@@ -1421,9 +1623,10 @@ function M.prev_diff()
     end
     local current_line = vim.fn.line(".")
     for i = #split_rows, 1, -1 do
-      local line = split_rows[i]
-      if line < current_line then
-        vim.api.nvim_win_set_cursor(0, { line, 0 })
+      local entry = split_rows[i]
+      if entry.row < current_line then
+        M.set_split_semantic_target(vim.api.nvim_get_current_buf(), entry.target)
+        vim.api.nvim_win_set_cursor(0, { entry.row, M.left_cursor_col(rendered) })
         vim.cmd("normal! zz")
         return true
       end

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -11,6 +11,9 @@ M.MAX_SYNTAX_ROWS = 5000
 M.MAX_SYNTAX_SIDE_BYTES = 500 * 1024
 M.MAX_INLINE_DIFF_DISPLAY_CHARS = 1000
 
+local LINE_HIGHLIGHT_PRIORITY = 90
+local SYNTAX_HIGHLIGHT_PRIORITY = 110
+local INLINE_HIGHLIGHT_PRIORITY = 200
 local SPLIT_SEPARATOR = " │ "
 local split_metadata_by_buf = {}
 
@@ -110,7 +113,12 @@ function M.parse_patch(patch)
           line_num = line_num,
           old_line = old_line_num,
         })
-        table.insert(current_hunk.changes, { type = "del", line_num = line_num, content = line:sub(2) })
+        table.insert(current_hunk.changes, {
+          type = "del",
+          line_num = line_num,
+          old_line = old_line_num,
+          content = line:sub(2),
+        })
         old_line_num = old_line_num + 1
       elseif not line:match("^\\ No newline at end of file$") and (line:match("^%s") or line == "") then
         -- Context line
@@ -148,12 +156,61 @@ function M.get_changed_lines(patch)
         table.insert(changes.added, change.line_num)
       elseif change.type == "del" then
         -- For deleted lines, we track the line after which they were deleted + content
-        table.insert(changes.deleted, { line_num = change.line_num, content = change.content })
+        table.insert(changes.deleted, {
+          line_num = change.line_num,
+          old_line = change.old_line,
+          content = change.content,
+        })
       end
     end
   end
 
   return changes
+end
+
+--- Get first navigable changed point for each contiguous add/delete block.
+---@param patch string The patch content
+---@return table[] points Array of {line, side, type = "diff"}
+function M.get_change_points(patch)
+  local points = {}
+  local hunks = M.parse_patch(patch)
+
+  for _, hunk in ipairs(hunks) do
+    local idx = 1
+    while idx <= #hunk.lines do
+      local line_data = hunk.lines[idx]
+      if line_data.type == "add" or line_data.type == "del" then
+        local first_add = nil
+        local first_del = nil
+        while idx <= #hunk.lines and (hunk.lines[idx].type == "add" or hunk.lines[idx].type == "del") do
+          if hunk.lines[idx].type == "add" and not first_add then
+            first_add = hunk.lines[idx]
+          elseif hunk.lines[idx].type == "del" and not first_del then
+            first_del = hunk.lines[idx]
+          end
+          idx = idx + 1
+        end
+
+        if first_add and (first_add.new_line or first_add.line_num) then
+          table.insert(points, {
+            line = first_add.new_line or first_add.line_num,
+            side = "RIGHT",
+            type = "diff",
+          })
+        elseif first_del and (first_del.old_line or first_del.line_num) then
+          table.insert(points, {
+            line = first_del.old_line or math.max(1, first_del.line_num),
+            side = "LEFT",
+            type = "diff",
+          })
+        end
+      else
+        idx = idx + 1
+      end
+    end
+  end
+
+  return points
 end
 
 --- Check whether a file line is in GitHub PR review diff context.
@@ -549,6 +606,7 @@ local function collect_syntax_highlights_for_side(lang, source_lines, line_map, 
             start_col = content_start_col + start_col,
             end_col = content_start_col + math.min(end_col, content_width),
             hl = "@" .. capture,
+            priority = SYNTAX_HIGHLIGHT_PRIORITY,
           })
         end
       end
@@ -626,6 +684,7 @@ function M.render_split_file(opts)
   local lines = {}
   local rows = {}
   local highlights = {}
+  local inline_highlights = {}
 
   local function append_rendered_row(row)
     local left_chunks = split_to_display_width(row.old_content or "", layout.content_width)
@@ -661,26 +720,32 @@ function M.render_split_file(opts)
       table.insert(rows, rendered_row)
       local hl = line_highlight(row.kind)
       if hl then
-        table.insert(highlights, { line = #lines - 1, line_hl_group = hl })
+        table.insert(highlights, {
+          line = #lines - 1,
+          line_hl_group = hl,
+          priority = LINE_HIGHLIGHT_PRIORITY,
+        })
       end
     end
 
     if row.kind == "change" and first_line == #lines then
       local old_span, new_span = changed_span(row.old_content or "", row.new_content or "")
       if old_span then
-        table.insert(highlights, {
+        table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.left_range.content_start_col + old_span.start_col,
           end_col = layout.left_range.content_start_col + old_span.end_col,
           hl = "RaccoonInlineDelete",
+          priority = INLINE_HIGHLIGHT_PRIORITY,
         })
       end
       if new_span then
-        table.insert(highlights, {
+        table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.right_range.content_start_col + new_span.start_col,
           end_col = layout.right_range.content_start_col + new_span.end_col,
           hl = "RaccoonInlineAdd",
+          priority = INLINE_HIGHLIGHT_PRIORITY,
         })
       end
     end
@@ -742,6 +807,9 @@ function M.render_split_file(opts)
       rendered.syntax_enabled = false
       rendered.syntax_skip_reason = "no parser"
     end
+  end
+  for _, hl in ipairs(inline_highlights) do
+    table.insert(rendered.highlights, hl)
   end
   return rendered
 end
@@ -820,9 +888,14 @@ function M.apply_split_render(buf, rendered)
     if hl.line_hl_group then
       pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, hl.line, 0, {
         line_hl_group = hl.line_hl_group,
+        priority = hl.priority or LINE_HIGHLIGHT_PRIORITY,
       })
     elseif hl.start_col and hl.end_col and hl.end_col > hl.start_col then
-      pcall(vim.api.nvim_buf_add_highlight, buf, ns_id, hl.hl, hl.line, hl.start_col, hl.end_col)
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, hl.line, hl.start_col, {
+        end_col = hl.end_col,
+        hl_group = hl.hl,
+        priority = hl.priority or SYNTAX_HIGHLIGHT_PRIORITY,
+      })
     end
   end
   M.attach_split_metadata(buf, rendered)
@@ -881,17 +954,23 @@ local function resolve_active_target(buf)
   return M.resolve_cursor_target(buf, cursor[1], cursor[2])
 end
 
-local function find_rendered_row(rendered, target)
+--- Resolve a semantic split target to its rendered row and side content column.
+---@param rendered table|nil rendered split metadata
+---@param target table|nil {path:string, line:number, side:string}
+---@return number|nil row 1-based rendered row
+---@return number|nil col 0-based side content column
+function M.find_split_row(rendered, target)
   if not rendered or not target then
     return nil
   end
+  local side = target.side == "LEFT" and "LEFT" or "RIGHT"
   for idx, row in ipairs(rendered.rows or {}) do
     if row.path == target.path then
-      if target.side == "LEFT" and row.old_line == target.line and not row.left_continuation then
-        return idx
+      if side == "LEFT" and row.old_line == target.line and not row.left_continuation then
+        return idx, rendered.left_range and rendered.left_range.content_start_col or 0
       end
-      if target.side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
-        return idx
+      if side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
+        return idx, rendered.right_range and rendered.right_range.content_start_col or 0
       end
     end
   end
@@ -903,11 +982,10 @@ local function restore_target_cursor(buf, rendered, target)
   if win == -1 or not target then
     return
   end
-  local row = find_rendered_row(rendered, target)
+  local row, col = M.find_split_row(rendered, target)
   if not row then
     return
   end
-  local col = target.side == "LEFT" and rendered.left_range.content_start_col or rendered.right_range.content_start_col
   pcall(vim.api.nvim_win_set_cursor, win, { row, col })
 end
 

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -814,6 +814,16 @@ function M.render_split_file(opts)
   local inline_highlights = {}
   local position_by_key = {}
 
+  local function add_position(path_for_key, side, line_num, row_num)
+    local key = split_position_key(path_for_key, side, line_num)
+    if key then
+      position_by_key[key] = {
+        row = row_num,
+        col = layout.left_range.content_start_col,
+      }
+    end
+  end
+
   local function append_rendered_row(row)
     local left_chunks = split_to_display_width(row.old_content or "", layout.content_width)
     local right_chunks = split_to_display_width(row.new_content or "", layout.content_width)
@@ -847,20 +857,8 @@ function M.render_split_file(opts)
       }
       table.insert(rows, rendered_row)
       if chunk_idx == 1 then
-        local left_key = split_position_key(rendered_row.path, "LEFT", rendered_row.old_line)
-        if left_key then
-          position_by_key[left_key] = {
-            row = #rows,
-            col = layout.left_range.content_start_col,
-          }
-        end
-        local right_key = split_position_key(rendered_row.path, "RIGHT", rendered_row.new_line)
-        if right_key then
-          position_by_key[right_key] = {
-            row = #rows,
-            col = layout.left_range.content_start_col,
-          }
-        end
+        add_position(rendered_row.path, "LEFT", rendered_row.old_line, #rows)
+        add_position(rendered_row.path, "RIGHT", rendered_row.new_line, #rows)
       end
       local hl = line_highlight(row.kind)
       if hl then
@@ -977,7 +975,7 @@ function M.get_split_metadata(buf)
   return split_metadata_by_buf[buf]
 end
 
-local function split_target_from_row(rendered, meta, row, side)
+local function split_target_from_row(meta, row, side)
   side = side == "LEFT" and "LEFT" or "RIGHT"
   local line = side == "LEFT" and meta.old_line or meta.new_line
   if not line and side == "LEFT" and meta.new_line then
@@ -995,7 +993,6 @@ local function split_target_from_row(rendered, meta, row, side)
     in_diff_context = meta.in_diff_context == true,
     kind = meta.kind,
     row = row,
-    rendered = rendered,
   }
 end
 
@@ -1044,7 +1041,7 @@ function M.resolve_cursor_target(buf, row, col)
 
   local semantic = rendered.last_semantic_target
   if semantic and semantic.row == row and semantic.path == meta.path then
-    local target = split_target_from_row(rendered, meta, row, semantic.side)
+    local target = split_target_from_row(meta, row, semantic.side)
     if semantic.line == nil or target.line == semantic.line then
       return target
     end
@@ -1057,7 +1054,7 @@ function M.resolve_cursor_target(buf, row, col)
     side = "RIGHT"
   end
 
-  return split_target_from_row(rendered, meta, row, side)
+  return split_target_from_row(meta, row, side)
 end
 
 --- Apply rendered split diff content and highlights to a buffer.

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -7,21 +7,44 @@ local state = require("raccoon.state")
 --- Namespace for diff highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_diff")
 
+M.MAX_SYNTAX_ROWS = 5000
+M.MAX_SYNTAX_SIDE_BYTES = 500 * 1024
+M.MAX_INLINE_DIFF_DISPLAY_CHARS = 1000
+
+local SPLIT_SEPARATOR = " │ "
+local split_metadata_by_buf = {}
+
+--- Parse a unified diff hunk header into old and new ranges.
+---@param header string Hunk header like "@@ -1,4 +1,5 @@"
+---@return table|nil ranges {old_start, old_count, new_start, new_count}
+function M.parse_hunk_ranges(header)
+  if type(header) ~= "string" then
+    return nil
+  end
+  local old_start, old_count, new_start, new_count =
+    header:match("^@@%s+%-(%d+),?(%d*)%s+%+(%d+),?(%d*)%s*@@")
+  if not old_start or not new_start then
+    return nil
+  end
+  return {
+    old_start = tonumber(old_start),
+    old_count = old_count ~= "" and tonumber(old_count) or 1,
+    new_start = tonumber(new_start),
+    new_count = new_count ~= "" and tonumber(new_count) or 1,
+  }
+end
+
 --- Parse a unified diff hunk header
 --- Returns start_line, count for the new file (right side)
 ---@param header string Hunk header like "@@ -1,4 +1,5 @@"
 ---@return number|nil start_line
 ---@return number|nil count
 function M.parse_hunk_header(header)
-  -- Format: @@ -old_start,old_count +new_start,new_count @@
-  -- Sometimes count is omitted if it's 1
-  local new_start, new_count = header:match("^@@.-+(%d+),?(%d*)%s*@@")
-  if not new_start then
+  local ranges = M.parse_hunk_ranges(header)
+  if not ranges then
     return nil, nil
   end
-  new_start = tonumber(new_start)
-  new_count = tonumber(new_count) or 1
-  return new_start, new_count
+  return ranges.new_start, ranges.new_count
 end
 
 --- Parse a unified diff patch into structured hunks
@@ -40,6 +63,8 @@ function M.parse_patch(patch)
   local hunks = {}
   local current_hunk = nil
   local line_num = 0
+  local old_line_num = 0
+  local new_line_num = 0
 
   for line in normalized_patch:gmatch("(.-)\n") do
     if line:match("^@@") then
@@ -47,30 +72,58 @@ function M.parse_patch(patch)
       if current_hunk then
         table.insert(hunks, current_hunk)
       end
-      local start_line, count = M.parse_hunk_header(line)
+      local ranges = M.parse_hunk_ranges(line)
+      local start_line = ranges and ranges.new_start or 1
+      local count = ranges and ranges.new_count or 0
       current_hunk = {
         header = line,
         lines = {},
         start_line = start_line or 1,
         count = count or 0,
+        old_start = ranges and ranges.old_start or 1,
+        old_count = ranges and ranges.old_count or 0,
+        new_start = start_line or 1,
+        new_count = count or 0,
         changes = {},
       }
       line_num = (start_line or 1) - 1
+      old_line_num = (current_hunk.old_start or 1)
+      new_line_num = (current_hunk.new_start or 1)
     elseif current_hunk then
       if line:match("^%+") and not line:match("^%+%+%+") then
         -- Added line
         line_num = line_num + 1
-        table.insert(current_hunk.lines, { type = "add", content = line:sub(2), line_num = line_num })
+        table.insert(current_hunk.lines, {
+          type = "add",
+          content = line:sub(2),
+          line_num = line_num,
+          new_line = new_line_num,
+        })
         table.insert(current_hunk.changes, { type = "add", line_num = line_num })
+        new_line_num = new_line_num + 1
       elseif line:match("^%-") and not line:match("^%-%-%-") then
         -- Removed line (doesn't increment line number in new file)
         -- Store the content for virtual text display
-        table.insert(current_hunk.lines, { type = "del", content = line:sub(2), line_num = line_num })
+        table.insert(current_hunk.lines, {
+          type = "del",
+          content = line:sub(2),
+          line_num = line_num,
+          old_line = old_line_num,
+        })
         table.insert(current_hunk.changes, { type = "del", line_num = line_num, content = line:sub(2) })
+        old_line_num = old_line_num + 1
       elseif not line:match("^\\ No newline at end of file$") and (line:match("^%s") or line == "") then
         -- Context line
         line_num = line_num + 1
-        table.insert(current_hunk.lines, { type = "ctx", content = line:sub(2), line_num = line_num })
+        table.insert(current_hunk.lines, {
+          type = "ctx",
+          content = line:sub(2),
+          line_num = line_num,
+          old_line = old_line_num,
+          new_line = new_line_num,
+        })
+        old_line_num = old_line_num + 1
+        new_line_num = new_line_num + 1
       end
     end
   end
@@ -108,22 +161,795 @@ end
 --- that are shown inside a diff hunk.
 ---@param patch string|nil
 ---@param target_line number|nil
+---@param side? string "LEFT" for old-side comments, "RIGHT" for new-side comments
 ---@return boolean
-function M.is_line_in_review_context(patch, target_line)
+function M.is_line_in_review_context(patch, target_line, side)
   if type(target_line) ~= "number" or target_line < 1 then
     return false
   end
+  side = side == "LEFT" and "LEFT" or "RIGHT"
 
   local hunks = M.parse_patch(patch)
   for _, hunk in ipairs(hunks) do
     for _, line in ipairs(hunk.lines) do
-      if line.line_num == target_line and (line.type == "add" or line.type == "ctx") then
+      if side == "LEFT" then
+        if line.old_line == target_line and (line.type == "del" or line.type == "ctx") then
+          return true
+        end
+      elseif line.line_num == target_line and (line.type == "add" or line.type == "ctx") then
         return true
       end
     end
   end
 
   return false
+end
+
+local function string_byte_count(lines)
+  local total = 0
+  for _, line in ipairs(lines or {}) do
+    total = total + #(line or "") + 1
+  end
+  return total
+end
+
+local function line_or_hunk_content(lines, line_num, fallback)
+  if type(line_num) == "number" and lines and lines[line_num] ~= nil then
+    return lines[line_num]
+  end
+  return fallback or ""
+end
+
+local function changed_span(left, right)
+  if #left > M.MAX_INLINE_DIFF_DISPLAY_CHARS or #right > M.MAX_INLINE_DIFF_DISPLAY_CHARS then
+    return nil, nil
+  end
+
+  local prefix = 0
+  local max_prefix = math.min(#left, #right)
+  while prefix < max_prefix and left:sub(prefix + 1, prefix + 1) == right:sub(prefix + 1, prefix + 1) do
+    prefix = prefix + 1
+  end
+
+  local left_suffix = #left
+  local right_suffix = #right
+  while left_suffix > prefix
+    and right_suffix > prefix
+    and left:sub(left_suffix, left_suffix) == right:sub(right_suffix, right_suffix)
+  do
+    left_suffix = left_suffix - 1
+    right_suffix = right_suffix - 1
+  end
+
+  local old_span = nil
+  if left_suffix > prefix then
+    old_span = { start_col = prefix, end_col = left_suffix }
+  end
+  local new_span = nil
+  if right_suffix > prefix then
+    new_span = { start_col = prefix, end_col = right_suffix }
+  end
+  return old_span, new_span
+end
+
+local function append_pair_spans(spans, left_line, right_line, left_content, right_content, left_hl, right_hl)
+  local old_span, new_span = changed_span(left_content or "", right_content or "")
+  if old_span then
+    table.insert(spans, {
+      line = left_line,
+      start_col = old_span.start_col,
+      end_col = old_span.end_col,
+      hl = left_hl,
+    })
+  end
+  if new_span then
+    table.insert(spans, {
+      line = right_line,
+      start_col = new_span.start_col,
+      end_col = new_span.end_col,
+      hl = right_hl,
+    })
+  end
+end
+
+--- Build inline spans for stacked hunk buffers.
+---@param line_list table[] Array of {type, content}
+---@return table[] spans Array of {line, start_col, end_col, hl}
+function M.render_stacked_inline_spans(line_list)
+  local spans = {}
+  local idx = 1
+
+  while idx <= #(line_list or {}) do
+    local line_data = line_list[idx]
+    if line_data and (line_data.type == "del" or line_data.type == "add") then
+      local dels = {}
+      local adds = {}
+      while idx <= #line_list and (line_list[idx].type == "del" or line_list[idx].type == "add") do
+        if line_list[idx].type == "del" then
+          table.insert(dels, { index = idx, content = line_list[idx].content or "" })
+        else
+          table.insert(adds, { index = idx, content = line_list[idx].content or "" })
+        end
+        idx = idx + 1
+      end
+      for pair_idx = 1, math.min(#dels, #adds) do
+        append_pair_spans(
+          spans,
+          dels[pair_idx].index,
+          adds[pair_idx].index,
+          dels[pair_idx].content,
+          adds[pair_idx].content,
+          "RaccoonInlineDelete",
+          "RaccoonInlineAdd"
+        )
+      end
+    else
+      idx = idx + 1
+    end
+  end
+
+  table.sort(spans, function(left, right)
+    if left.line ~= right.line then
+      return left.line < right.line
+    end
+    return left.start_col < right.start_col
+  end)
+  return spans
+end
+
+local function build_hunk_rows(hunk)
+  local rows = {}
+  local idx = 1
+  while idx <= #hunk.lines do
+    local line_data = hunk.lines[idx]
+    if line_data.type == "del" or line_data.type == "add" then
+      local dels = {}
+      local adds = {}
+      while idx <= #hunk.lines and (hunk.lines[idx].type == "del" or hunk.lines[idx].type == "add") do
+        if hunk.lines[idx].type == "del" then
+          table.insert(dels, hunk.lines[idx])
+        else
+          table.insert(adds, hunk.lines[idx])
+        end
+        idx = idx + 1
+      end
+      local count = math.max(#dels, #adds)
+      for pair_idx = 1, count do
+        local del = dels[pair_idx]
+        local add = adds[pair_idx]
+        table.insert(rows, {
+          old_line = del and del.old_line or nil,
+          new_line = add and add.new_line or nil,
+          old_content = del and del.content or nil,
+          new_content = add and add.content or nil,
+          kind = del and add and "change" or (del and "del" or "add"),
+          in_diff_context = true,
+        })
+      end
+    else
+      table.insert(rows, {
+        old_line = line_data.old_line,
+        new_line = line_data.new_line,
+        old_content = line_data.content,
+        new_content = line_data.content,
+        kind = "context",
+        in_diff_context = true,
+      })
+      idx = idx + 1
+    end
+  end
+  return rows
+end
+
+local function append_unchanged_rows(rows, path, old_lines, new_lines, old_idx, new_idx, old_stop, new_stop)
+  while old_idx < old_stop or new_idx < new_stop do
+    local old_line = old_idx < old_stop and old_idx or nil
+    local new_line = new_idx < new_stop and new_idx or nil
+    table.insert(rows, {
+      path = path,
+      old_line = old_line,
+      new_line = new_line,
+      old_content = old_line and old_lines[old_line] or "",
+      new_content = new_line and new_lines[new_line] or "",
+      kind = "context",
+      in_diff_context = false,
+    })
+    if old_line then old_idx = old_idx + 1 end
+    if new_line then new_idx = new_idx + 1 end
+  end
+  return old_idx, new_idx
+end
+
+local function build_split_rows(opts)
+  local path = opts.path
+  local old_lines = opts.old_lines or {}
+  local new_lines = opts.new_lines or {}
+  local rows = {}
+
+  local hunks = M.parse_patch(opts.patch)
+  if #hunks == 0 then
+    local max_lines = math.max(#old_lines, #new_lines)
+    for idx = 1, max_lines do
+      table.insert(rows, {
+        path = path,
+        old_line = old_lines[idx] ~= nil and idx or nil,
+        new_line = new_lines[idx] ~= nil and idx or nil,
+        old_content = old_lines[idx] or "",
+        new_content = new_lines[idx] or "",
+        kind = "context",
+        in_diff_context = false,
+      })
+    end
+    return rows
+  end
+
+  local old_idx = 1
+  local new_idx = 1
+  for _, hunk in ipairs(hunks) do
+    local old_stop = math.max(1, hunk.old_start or 1)
+    local new_stop = math.max(1, hunk.new_start or 1)
+    old_idx, new_idx = append_unchanged_rows(rows, path, old_lines, new_lines, old_idx, new_idx, old_stop, new_stop)
+
+    local max_old_line = nil
+    local max_new_line = nil
+    for _, row in ipairs(build_hunk_rows(hunk)) do
+      row.path = path
+      row.old_content = line_or_hunk_content(old_lines, row.old_line, row.old_content)
+      row.new_content = line_or_hunk_content(new_lines, row.new_line, row.new_content)
+      table.insert(rows, row)
+      if row.old_line then
+        max_old_line = math.max(max_old_line or row.old_line, row.old_line)
+      end
+      if row.new_line then
+        max_new_line = math.max(max_new_line or row.new_line, row.new_line)
+      end
+    end
+    if max_old_line then
+      old_idx = math.max(old_idx, max_old_line + 1)
+    end
+    if max_new_line then
+      new_idx = math.max(new_idx, max_new_line + 1)
+    end
+  end
+
+  append_unchanged_rows(rows, path, old_lines, new_lines, old_idx, new_idx, #old_lines + 1, #new_lines + 1)
+  return rows
+end
+
+local function split_to_display_width(text, width)
+  width = math.max(1, width)
+  text = text or ""
+  if text == "" then
+    return { "" }
+  end
+  local chunks = {}
+  local current = ""
+  local current_width = 0
+  local char_count = vim.fn.strchars(text)
+  for idx = 0, char_count - 1 do
+    local char = vim.fn.strcharpart(text, idx, 1)
+    local char_width = math.max(1, vim.fn.strdisplaywidth(char))
+    if current ~= "" and current_width + char_width > width then
+      table.insert(chunks, current)
+      current = char
+      current_width = char_width
+    else
+      current = current .. char
+      current_width = current_width + char_width
+    end
+  end
+  table.insert(chunks, current)
+  return chunks
+end
+
+local function pad_to_display_width(text, width)
+  local result = text or ""
+  local display_width = vim.fn.strdisplaywidth(result)
+  if display_width >= width then
+    return result
+  end
+  return result .. string.rep(" ", width - display_width)
+end
+
+local function format_side(line_num, chunk, line_num_width, content_width)
+  local label = line_num and tostring(line_num) or ""
+  label = string.rep(" ", math.max(0, line_num_width - #label)) .. label
+  return label .. " " .. pad_to_display_width(chunk or "", content_width)
+end
+
+local function split_layout(width, max_line)
+  width = math.max(20, width or vim.o.columns or 80)
+  local line_num_width = math.max(1, #tostring(math.max(1, max_line or 1)))
+  local separator_width = #SPLIT_SEPARATOR
+  local side_width = math.max(line_num_width + 2, math.floor((width - separator_width) / 2))
+  local content_width = math.max(1, side_width - line_num_width - 1)
+  return {
+    line_num_width = line_num_width,
+    side_width = side_width,
+    content_width = content_width,
+    separator_col = side_width,
+    left_range = {
+      start_col = 0,
+      end_col = side_width - 1,
+      content_start_col = line_num_width + 1,
+      content_end_col = side_width - 1,
+    },
+    right_range = {
+      start_col = side_width + separator_width,
+      end_col = side_width + separator_width + side_width - 1,
+      content_start_col = side_width + separator_width + line_num_width + 1,
+      content_end_col = side_width + separator_width + side_width - 1,
+    },
+  }
+end
+
+local function syntax_status(opts, rendered_row_count)
+  if rendered_row_count > M.MAX_SYNTAX_ROWS then
+    return false, "row cap", nil
+  end
+  if string_byte_count(opts.old_lines) > M.MAX_SYNTAX_SIDE_BYTES
+      or string_byte_count(opts.new_lines) > M.MAX_SYNTAX_SIDE_BYTES
+  then
+    return false, "byte cap", nil
+  end
+
+  local ft = vim.filetype.match({ filename = opts.path })
+  if not ft then
+    return false, "no filetype", nil
+  end
+  local ok, lang = pcall(vim.treesitter.language.get_lang, ft)
+  if not ok or not lang then
+    return false, "no parser", nil
+  end
+  return true, nil, lang
+end
+
+local function syntax_query_for(lang)
+  if not vim.treesitter or not vim.treesitter.query then
+    return nil
+  end
+  local ok, query = pcall(vim.treesitter.query.get, lang, "highlights")
+  if ok then
+    return query
+  end
+  return nil
+end
+
+local function collect_syntax_highlights_for_side(lang, source_lines, line_map, content_start_col, content_width)
+  local query = syntax_query_for(lang)
+  if not query then
+    return nil
+  end
+
+  local temp_buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(temp_buf, 0, -1, false, source_lines or {})
+  local ok_parser, parser = pcall(vim.treesitter.get_parser, temp_buf, lang)
+  if not ok_parser or not parser then
+    pcall(vim.api.nvim_buf_delete, temp_buf, { force = true })
+    return nil
+  end
+
+  local ok_parse, trees = pcall(parser.parse, parser)
+  if not ok_parse or not trees then
+    pcall(vim.api.nvim_buf_delete, temp_buf, { force = true })
+    return nil
+  end
+
+  local highlights = {}
+  for _, tree in ipairs(trees) do
+    local root = tree:root()
+    for capture_id, node in query:iter_captures(root, temp_buf, 0, -1) do
+      local capture = query.captures[capture_id]
+      local start_row, start_col, end_row, end_col = node:range()
+      if start_row == end_row then
+        local rendered_line = line_map[start_row + 1]
+        if rendered_line and start_col < content_width then
+          table.insert(highlights, {
+            line = rendered_line,
+            start_col = content_start_col + start_col,
+            end_col = content_start_col + math.min(end_col, content_width),
+            hl = "@" .. capture,
+          })
+        end
+      end
+    end
+  end
+
+  pcall(vim.api.nvim_buf_delete, temp_buf, { force = true })
+  return highlights
+end
+
+local function collect_syntax_highlights(lang, rendered, old_lines, new_lines)
+  local left_map = {}
+  local right_map = {}
+  for row_idx, row in ipairs(rendered.rows or {}) do
+    if row.old_line and not row.left_continuation then
+      left_map[row.old_line] = row_idx - 1
+    end
+    if row.new_line and not row.right_continuation then
+      right_map[row.new_line] = row_idx - 1
+    end
+  end
+
+  local highlights = {}
+  local left_highlights = collect_syntax_highlights_for_side(
+    lang,
+    old_lines,
+    left_map,
+    rendered.left_range.content_start_col,
+    rendered.content_width
+  )
+  if not left_highlights then
+    return nil
+  end
+  local right_highlights = collect_syntax_highlights_for_side(
+    lang,
+    new_lines,
+    right_map,
+    rendered.right_range.content_start_col,
+    rendered.content_width
+  )
+  if not right_highlights then
+    return nil
+  end
+
+  for _, hl in ipairs(left_highlights) do
+    table.insert(highlights, hl)
+  end
+  for _, hl in ipairs(right_highlights) do
+    table.insert(highlights, hl)
+  end
+  return highlights
+end
+
+local function line_highlight(kind)
+  if kind == "add" then
+    return "RaccoonAdd"
+  elseif kind == "del" then
+    return "RaccoonDelete"
+  elseif kind == "change" then
+    return "RaccoonChange"
+  end
+  return nil
+end
+
+--- Render a changed file as a read-only full-file split diff.
+---@param opts table {path, previous_path?, status?, old_lines?, new_lines?, patch?, width?, binary?}
+---@return table rendered {lines, rows, highlights, separator_col, left_range, right_range}
+function M.render_split_file(opts)
+  opts = opts or {}
+  local path = opts.path or opts.filename or ""
+  local old_lines = opts.old_lines or {}
+  local new_lines = opts.new_lines or {}
+  local max_line = math.max(#old_lines, #new_lines)
+  local layout = split_layout(opts.width, max_line)
+  local lines = {}
+  local rows = {}
+  local highlights = {}
+
+  local function append_rendered_row(row)
+    local left_chunks = split_to_display_width(row.old_content or "", layout.content_width)
+    local right_chunks = split_to_display_width(row.new_content or "", layout.content_width)
+    local chunk_count = math.max(#left_chunks, #right_chunks)
+    local first_line = #lines + 1
+    for chunk_idx = 1, chunk_count do
+      local left_num = chunk_idx == 1 and row.old_line or nil
+      local right_num = chunk_idx == 1 and row.new_line or nil
+      local left_side = format_side(
+        left_num,
+        left_chunks[chunk_idx] or "",
+        layout.line_num_width,
+        layout.content_width
+      )
+      local right_side = format_side(
+        right_num,
+        right_chunks[chunk_idx] or "",
+        layout.line_num_width,
+        layout.content_width
+      )
+      table.insert(lines, left_side .. SPLIT_SEPARATOR .. right_side)
+      local rendered_row = {
+        path = row.path or path,
+        old_line = row.old_line,
+        new_line = row.new_line,
+        kind = row.kind,
+        in_diff_context = row.in_diff_context == true,
+        left_continuation = chunk_idx > 1 and row.old_line ~= nil,
+        right_continuation = chunk_idx > 1 and row.new_line ~= nil,
+        hunk = row.hunk,
+      }
+      table.insert(rows, rendered_row)
+      local hl = line_highlight(row.kind)
+      if hl then
+        table.insert(highlights, { line = #lines - 1, line_hl_group = hl })
+      end
+    end
+
+    if row.kind == "change" and first_line == #lines then
+      local old_span, new_span = changed_span(row.old_content or "", row.new_content or "")
+      if old_span then
+        table.insert(highlights, {
+          line = first_line - 1,
+          start_col = layout.left_range.content_start_col + old_span.start_col,
+          end_col = layout.left_range.content_start_col + old_span.end_col,
+          hl = "RaccoonInlineDelete",
+        })
+      end
+      if new_span then
+        table.insert(highlights, {
+          line = first_line - 1,
+          start_col = layout.right_range.content_start_col + new_span.start_col,
+          end_col = layout.right_range.content_start_col + new_span.end_col,
+          hl = "RaccoonInlineAdd",
+        })
+      end
+    end
+  end
+
+  if opts.binary or opts.unreadable then
+    append_rendered_row({
+      path = path,
+      old_content = "Binary or unreadable file",
+      new_content = "Binary or unreadable file",
+      kind = "file",
+      in_diff_context = false,
+    })
+  else
+    if opts.status == "renamed" and opts.previous_path and opts.previous_path ~= path then
+      append_rendered_row({
+        path = path,
+        old_content = "renamed from " .. opts.previous_path,
+        new_content = "renamed to " .. path,
+        kind = "file",
+        in_diff_context = false,
+      })
+    end
+    for _, row in ipairs(build_split_rows({
+      path = path,
+      old_lines = old_lines,
+      new_lines = new_lines,
+      patch = opts.patch,
+    })) do
+      append_rendered_row(row)
+    end
+  end
+
+  local syntax_enabled, syntax_skip_reason, syntax_lang = syntax_status({
+    path = path,
+    old_lines = old_lines,
+    new_lines = new_lines,
+  }, #rows)
+
+  local rendered = {
+    lines = lines,
+    rows = rows,
+    highlights = highlights,
+    separator_col = layout.separator_col,
+    left_range = layout.left_range,
+    right_range = layout.right_range,
+    side_width = layout.side_width,
+    content_width = layout.content_width,
+    syntax_enabled = syntax_enabled,
+    syntax_skip_reason = syntax_skip_reason,
+  }
+  if syntax_enabled then
+    local syntax_highlights = collect_syntax_highlights(syntax_lang, rendered, old_lines, new_lines)
+    if syntax_highlights then
+      for _, hl in ipairs(syntax_highlights) do
+        table.insert(rendered.highlights, hl)
+      end
+    else
+      rendered.syntax_enabled = false
+      rendered.syntax_skip_reason = "no parser"
+    end
+  end
+  return rendered
+end
+
+--- Attach split diff metadata to a buffer.
+---@param buf number
+---@param rendered table
+function M.attach_split_metadata(buf, rendered)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+  split_metadata_by_buf[buf] = rendered
+  vim.b[buf].raccoon_split_diff = true
+end
+
+--- Return split diff metadata for a buffer.
+---@param buf number
+---@return table|nil
+function M.get_split_metadata(buf)
+  return split_metadata_by_buf[buf]
+end
+
+--- Resolve a buffer row/column into a GitHub review target.
+---@param buf number
+---@param row number 1-based row
+---@param col number 0-based column
+---@return table|nil target {path, line, side, in_diff_context, row}
+function M.resolve_cursor_target(buf, row, col)
+  local rendered = M.get_split_metadata(buf)
+  if not rendered then
+    return nil
+  end
+  local meta = rendered.rows and rendered.rows[row]
+  if not meta then
+    return nil
+  end
+
+  local side = "RIGHT"
+  if col >= rendered.left_range.start_col and col <= rendered.left_range.end_col then
+    side = "LEFT"
+  elseif col >= rendered.right_range.start_col and col <= rendered.right_range.end_col then
+    side = "RIGHT"
+  end
+
+  local line = side == "LEFT" and meta.old_line or meta.new_line
+  if not line and side == "LEFT" and meta.new_line then
+    side = "RIGHT"
+    line = meta.new_line
+  elseif not line and side == "RIGHT" and meta.old_line then
+    side = "LEFT"
+    line = meta.old_line
+  end
+
+  return {
+    path = meta.path,
+    line = line,
+    side = side,
+    in_diff_context = meta.in_diff_context == true,
+    kind = meta.kind,
+    row = row,
+  }
+end
+
+--- Apply rendered split diff content and highlights to a buffer.
+---@param buf number
+---@param rendered table
+function M.apply_split_render(buf, rendered)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) or not rendered then
+    return
+  end
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, rendered.lines or {})
+  vim.bo[buf].modifiable = false
+  vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
+  for _, hl in ipairs(rendered.highlights or {}) do
+    if hl.line_hl_group then
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, hl.line, 0, {
+        line_hl_group = hl.line_hl_group,
+      })
+    elseif hl.start_col and hl.end_col and hl.end_col > hl.start_col then
+      pcall(vim.api.nvim_buf_add_highlight, buf, ns_id, hl.hl, hl.line, hl.start_col, hl.end_col)
+    end
+  end
+  M.attach_split_metadata(buf, rendered)
+end
+
+local function replace_range(lines, start_idx, count, replacement)
+  local result = {}
+  start_idx = math.max(1, start_idx)
+  for idx = 1, start_idx - 1 do
+    table.insert(result, lines[idx])
+  end
+  for _, line in ipairs(replacement or {}) do
+    table.insert(result, line)
+  end
+  for idx = start_idx + count, #lines do
+    table.insert(result, lines[idx])
+  end
+  return result
+end
+
+--- Reconstruct old-side content from new-side content and a patch.
+---@param new_lines string[]
+---@param patch string|nil
+---@return string[]
+function M.derive_old_lines_from_patch(new_lines, patch)
+  local old_lines = vim.deepcopy(new_lines or {})
+  local hunks = M.parse_patch(patch)
+  for hunk_idx = #hunks, 1, -1 do
+    local hunk = hunks[hunk_idx]
+    local replacement = {}
+    for _, line_data in ipairs(hunk.lines) do
+      if line_data.type == "ctx" or line_data.type == "del" then
+        table.insert(replacement, line_data.content or "")
+      end
+    end
+    local start_idx = math.max(1, hunk.new_start or 1)
+    old_lines = replace_range(old_lines, start_idx, hunk.new_count or 0, replacement)
+  end
+  return old_lines
+end
+
+local function read_worktree_file(path)
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok then
+    return nil
+  end
+  return lines
+end
+
+local function resolve_active_target(buf)
+  local win = vim.fn.bufwinid(buf)
+  if win == -1 then
+    return nil
+  end
+  local cursor = vim.api.nvim_win_get_cursor(win)
+  return M.resolve_cursor_target(buf, cursor[1], cursor[2])
+end
+
+local function find_rendered_row(rendered, target)
+  if not rendered or not target then
+    return nil
+  end
+  for idx, row in ipairs(rendered.rows or {}) do
+    if row.path == target.path then
+      if target.side == "LEFT" and row.old_line == target.line and not row.left_continuation then
+        return idx
+      end
+      if target.side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
+        return idx
+      end
+    end
+  end
+  return nil
+end
+
+local function restore_target_cursor(buf, rendered, target)
+  local win = vim.fn.bufwinid(buf)
+  if win == -1 or not target then
+    return
+  end
+  local row = find_rendered_row(rendered, target)
+  if not row then
+    return
+  end
+  local col = target.side == "LEFT" and rendered.left_range.content_start_col or rendered.right_range.content_start_col
+  pcall(vim.api.nvim_win_set_cursor, win, { row, col })
+end
+
+local function render_split_to_buffer(buf, file, old_lines, new_lines, binary)
+  local target = resolve_active_target(buf)
+  local win = vim.fn.bufwinid(buf)
+  local width = win ~= -1 and vim.api.nvim_win_get_width(win) or vim.o.columns
+  local rendered = M.render_split_file({
+    path = file.filename,
+    previous_path = file.previous_filename,
+    status = file.status,
+    old_lines = old_lines,
+    new_lines = new_lines,
+    patch = file.patch,
+    binary = binary,
+    width = width,
+  })
+  M.apply_split_render(buf, rendered)
+  restore_target_cursor(buf, rendered, target)
+  return rendered
+end
+
+local function setup_split_resize(buf, file, source)
+  local group = vim.api.nvim_create_augroup("RaccoonSplitDiff" .. buf, { clear = true })
+  vim.api.nvim_create_autocmd("VimResized", {
+    group = group,
+    callback = function()
+      if not vim.api.nvim_buf_is_valid(buf) then
+        pcall(vim.api.nvim_del_augroup_by_id, group)
+        return
+      end
+      render_split_to_buffer(buf, file, source.old_lines, source.new_lines, source.binary)
+    end,
+  })
+  vim.api.nvim_create_autocmd("BufWipeout", {
+    group = group,
+    buffer = buf,
+    callback = function()
+      split_metadata_by_buf[buf] = nil
+      pcall(vim.api.nvim_del_augroup_by_id, group)
+    end,
+  })
 end
 
 --- Apply diff highlights to a buffer
@@ -221,35 +1047,72 @@ function M.open_file(file)
 
   local file_path = vim.fs.joinpath(clone_path, file.filename)
 
-  -- Check if file exists (might be deleted)
-  if vim.fn.filereadable(file_path) == 0 then
+  local new_lines = read_worktree_file(file_path)
+  local binary = false
+  if not new_lines then
     if file.status == "removed" then
-      vim.notify("File was deleted: " .. file.filename, vim.log.levels.WARN)
+      new_lines = {}
     else
-      vim.notify("File not found: " .. file.filename, vim.log.levels.ERROR)
+      binary = true
+      new_lines = {}
     end
-    return nil
   end
 
-  -- Open the file (wrapped in pcall to handle treesitter/filetype plugin errors gracefully)
-  local ok, err = pcall(vim.cmd, "edit! " .. vim.fn.fnameescape(file_path))
-  if not ok then
-    -- Extract first line of error for cleaner display
-    local short_err = tostring(err):match("^[^\n]+") or "unknown error"
-    vim.notify("Failed to open file: " .. file.filename .. " (" .. short_err .. ")", vim.log.levels.WARN)
-    -- File may still be open despite the error, continue if buffer exists
+  local old_lines = M.derive_old_lines_from_patch(new_lines, file.patch)
+  if file.status == "added" then
+    old_lines = {}
+  elseif file.status == "removed" and #old_lines == 0 then
+    old_lines = M.derive_old_lines_from_patch({}, file.patch)
   end
-  local buf = vim.api.nvim_get_current_buf()
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].swapfile = false
+  pcall(vim.api.nvim_buf_set_name, buf, file_path)
+  vim.api.nvim_set_current_buf(buf)
+  vim.bo[buf].modifiable = false
+  local ft = vim.filetype.match({ filename = file.filename })
+  if ft then
+    vim.bo[buf].filetype = ft
+  end
+  vim.wo.wrap = false
+  vim.wo.number = false
+  vim.wo.relativenumber = false
+  vim.wo.signcolumn = "yes:2"
 
   -- Track buffer in session
   state.add_buffer(buf)
-  vim.bo[buf].modifiable = false
 
-  -- Apply diff highlights
-  if file.patch then
-    -- Defer to allow buffer to fully load
-    vim.schedule(function()
-      M.apply_highlights(buf, file.patch)
+  local source = {
+    old_lines = old_lines,
+    new_lines = new_lines,
+    binary = binary,
+  }
+  render_split_to_buffer(buf, file, source.old_lines, source.new_lines, source.binary)
+  setup_split_resize(buf, file, source)
+
+  local pr = state.get_pr()
+  local base_ref = pr and pr.base and pr.base.ref
+  if base_ref then
+    local git = require("raccoon.git")
+    git.merge_base(clone_path, "HEAD", "origin/" .. base_ref, function(merge_base, merge_err)
+      if merge_err or not merge_base then
+        return
+      end
+      local old_path = file.previous_filename or file.filename
+      git.show_file_content(clone_path, merge_base, old_path, function(base_lines, _base_err)
+        if not vim.api.nvim_buf_is_valid(buf) or not base_lines then
+          return
+        end
+        source.old_lines = base_lines
+        source.binary = false
+        render_split_to_buffer(buf, file, source.old_lines, source.new_lines, source.binary)
+        local ok_comments, comments = pcall(require, "raccoon.comments")
+        if ok_comments then
+          comments.show_comments(buf, state.get_comments(file.filename))
+        end
+      end)
     end)
   end
 
@@ -398,11 +1261,48 @@ local function get_current_file_diff_hunks()
   return hunks
 end
 
+local function get_current_split_change_rows()
+  local rendered = M.get_split_metadata(vim.api.nvim_get_current_buf())
+  if not rendered then
+    return nil
+  end
+  local rows = {}
+  for idx, row in ipairs(rendered.rows or {}) do
+    local is_change = row.kind == "add" or row.kind == "del" or row.kind == "change"
+    local is_continuation = row.left_continuation or row.right_continuation
+    if is_change and not is_continuation then
+      local previous = rows[#rows]
+      if not previous or idx > previous + 1 then
+        table.insert(rows, idx)
+      end
+    end
+  end
+  return rows
+end
+
 --- Navigate to the next diff hunk in the current file
 ---@return boolean success
 function M.next_diff()
   if not state.is_active() then
     vim.notify("No active PR session", vim.log.levels.WARN)
+    return false
+  end
+
+  local split_rows = get_current_split_change_rows()
+  if split_rows then
+    if #split_rows == 0 then
+      vim.notify("No changes in this file", vim.log.levels.INFO)
+      return false
+    end
+    local current_line = vim.fn.line(".")
+    for _, line in ipairs(split_rows) do
+      if line > current_line then
+        vim.api.nvim_win_set_cursor(0, { line, 0 })
+        vim.cmd("normal! zz")
+        return true
+      end
+    end
+    vim.notify("No more changes below", vim.log.levels.INFO)
     return false
   end
 
@@ -432,6 +1332,25 @@ end
 function M.prev_diff()
   if not state.is_active() then
     vim.notify("No active PR session", vim.log.levels.WARN)
+    return false
+  end
+
+  local split_rows = get_current_split_change_rows()
+  if split_rows then
+    if #split_rows == 0 then
+      vim.notify("No changes in this file", vim.log.levels.INFO)
+      return false
+    end
+    local current_line = vim.fn.line(".")
+    for i = #split_rows, 1, -1 do
+      local line = split_rows[i]
+      if line < current_line then
+        vim.api.nvim_win_set_cursor(0, { line, 0 })
+        vim.cmd("normal! zz")
+        return true
+      end
+    end
+    vim.notify("No more changes above", vim.log.levels.INFO)
     return false
   end
 

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -303,6 +303,70 @@ local function append_changed_char_spans(spans, chars, changed)
   end
 end
 
+local function span_overlaps_token(span, token_start_col, token_end_col)
+  return span.start_col < token_end_col and span.end_col > token_start_col
+end
+
+local function expand_fragmented_identifier_spans(text, spans)
+  if #spans < 2 then
+    return spans
+  end
+
+  local remove = {}
+  local additions = {}
+  for token_start, token in (text or ""):gmatch("()([%w_]+)") do
+    local token_start_col = token_start - 1
+    local token_end_col = token_start_col + #token
+    local token_span_indices = {}
+    local changed_cols = {}
+    for span_idx, span in ipairs(spans) do
+      if span_overlaps_token(span, token_start_col, token_end_col) then
+        table.insert(token_span_indices, span_idx)
+        local start_col = math.max(span.start_col, token_start_col)
+        local end_col = math.min(span.end_col, token_end_col)
+        for col = start_col, end_col - 1 do
+          changed_cols[col] = true
+        end
+      end
+    end
+
+    local changed_count = 0
+    for _ in pairs(changed_cols) do
+      changed_count = changed_count + 1
+    end
+    if #token_span_indices > 1 and changed_count >= math.ceil(#token / 2) then
+      for _, span_idx in ipairs(token_span_indices) do
+        remove[span_idx] = true
+      end
+      table.insert(additions, {
+        start_col = token_start_col,
+        end_col = token_end_col,
+      })
+    end
+  end
+
+  if #additions == 0 then
+    return spans
+  end
+
+  local expanded = {}
+  for span_idx, span in ipairs(spans) do
+    if not remove[span_idx] then
+      table.insert(expanded, span)
+    end
+  end
+  for _, span in ipairs(additions) do
+    table.insert(expanded, span)
+  end
+  table.sort(expanded, function(left, right)
+    if left.start_col ~= right.start_col then
+      return left.start_col < right.start_col
+    end
+    return left.end_col < right.end_col
+  end)
+  return expanded
+end
+
 local function mark_lcs_matches(
   left_chars,
   left_start,
@@ -399,7 +463,7 @@ local function compute_inline_char_spans(left, right)
   local new_spans = {}
   append_changed_char_spans(old_spans, left_chars, left_changed)
   append_changed_char_spans(new_spans, right_chars, right_changed)
-  return old_spans, new_spans
+  return expand_fragmented_identifier_spans(left, old_spans), expand_fragmented_identifier_spans(right, new_spans)
 end
 
 local function append_pair_spans(spans, left_line, right_line, left_content, right_content, left_hl, right_hl)
@@ -590,25 +654,45 @@ local function split_to_display_width(text, width)
   width = math.max(1, width)
   text = text or ""
   if text == "" then
-    return { "" }
+    return {
+      {
+        text = "",
+        start_col = 0,
+        end_col = 0,
+      },
+    }
   end
   local chunks = {}
   local current = ""
   local current_width = 0
-  local char_count = vim.fn.strchars(text)
-  for idx = 0, char_count - 1 do
-    local char = vim.fn.strcharpart(text, idx, 1)
-    local char_width = math.max(1, vim.fn.strdisplaywidth(char))
+  local current_start_col = 0
+  local current_end_col = 0
+  for _, char in ipairs(split_utf8_chars(text)) do
+    local char_width = math.max(1, vim.fn.strdisplaywidth(char.value))
     if current ~= "" and current_width + char_width > width then
-      table.insert(chunks, current)
-      current = char
+      table.insert(chunks, {
+        text = current,
+        start_col = current_start_col,
+        end_col = current_end_col,
+      })
+      current = char.value
       current_width = char_width
+      current_start_col = char.start_col
+      current_end_col = char.end_col
     else
-      current = current .. char
+      if current == "" then
+        current_start_col = char.start_col
+      end
+      current = current .. char.value
       current_width = current_width + char_width
+      current_end_col = char.end_col
     end
   end
-  table.insert(chunks, current)
+  table.insert(chunks, {
+    text = current,
+    start_col = current_start_col,
+    end_col = current_end_col,
+  })
   return chunks
 end
 
@@ -625,6 +709,24 @@ local function format_side(line_num, chunk, line_num_width, content_width)
   local label = line_num and tostring(line_num) or ""
   label = string.rep(" ", math.max(0, line_num_width - #label)) .. label
   return label .. " " .. pad_to_display_width(chunk or "", content_width)
+end
+
+local function append_projected_inline_highlights(highlights, first_line, chunks, spans, range, hl)
+  for _, span in ipairs(spans) do
+    for chunk_idx, chunk in ipairs(chunks) do
+      local start_col = math.max(span.start_col, chunk.start_col)
+      local end_col = math.min(span.end_col, chunk.end_col)
+      if end_col > start_col then
+        table.insert(highlights, {
+          line = first_line + chunk_idx - 2,
+          start_col = range.content_start_col + start_col - chunk.start_col,
+          end_col = range.content_start_col + end_col - chunk.start_col,
+          hl = hl,
+          priority = INLINE_HIGHLIGHT_PRIORITY,
+        })
+      end
+    end
+  end
 end
 
 local function split_layout(width, max_line)
@@ -830,17 +932,19 @@ function M.render_split_file(opts)
     local chunk_count = math.max(#left_chunks, #right_chunks)
     local first_line = #lines + 1
     for chunk_idx = 1, chunk_count do
+      local left_chunk = left_chunks[chunk_idx] or { text = "", start_col = 0, end_col = 0 }
+      local right_chunk = right_chunks[chunk_idx] or { text = "", start_col = 0, end_col = 0 }
       local left_num = chunk_idx == 1 and row.old_line or nil
       local right_num = chunk_idx == 1 and row.new_line or nil
       local left_side = format_side(
         left_num,
-        left_chunks[chunk_idx] or "",
+        left_chunk.text,
         layout.line_num_width,
         layout.content_width
       )
       local right_side = format_side(
         right_num,
-        right_chunks[chunk_idx] or "",
+        right_chunk.text,
         layout.line_num_width,
         layout.content_width
       )
@@ -870,26 +974,24 @@ function M.render_split_file(opts)
       end
     end
 
-    if row.kind == "change" and first_line == #lines then
+    if row.kind == "change" then
       local old_spans, new_spans = compute_inline_char_spans(row.old_content or "", row.new_content or "")
-      for _, old_span in ipairs(old_spans) do
-        table.insert(inline_highlights, {
-          line = first_line - 1,
-          start_col = layout.left_range.content_start_col + old_span.start_col,
-          end_col = layout.left_range.content_start_col + old_span.end_col,
-          hl = "RaccoonInlineDelete",
-          priority = INLINE_HIGHLIGHT_PRIORITY,
-        })
-      end
-      for _, new_span in ipairs(new_spans) do
-        table.insert(inline_highlights, {
-          line = first_line - 1,
-          start_col = layout.right_range.content_start_col + new_span.start_col,
-          end_col = layout.right_range.content_start_col + new_span.end_col,
-          hl = "RaccoonInlineAdd",
-          priority = INLINE_HIGHLIGHT_PRIORITY,
-        })
-      end
+      append_projected_inline_highlights(
+        inline_highlights,
+        first_line,
+        left_chunks,
+        old_spans,
+        layout.left_range,
+        "RaccoonInlineDelete"
+      )
+      append_projected_inline_highlights(
+        inline_highlights,
+        first_line,
+        right_chunks,
+        new_spans,
+        layout.right_range,
+        "RaccoonInlineAdd"
+      )
     end
   end
 

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -24,6 +24,23 @@ local function setup_highlights()
     default = true,
   })
 
+  vim.api.nvim_set_hl(0, "RaccoonChange", {
+    bg = "#4a3d16",
+    default = true,
+  })
+
+  vim.api.nvim_set_hl(0, "RaccoonInlineAdd", {
+    bg = "#3f7a3f",
+    bold = true,
+    default = true,
+  })
+
+  vim.api.nvim_set_hl(0, "RaccoonInlineDelete", {
+    bg = "#7a3030",
+    bold = true,
+    default = true,
+  })
+
   -- Sign column colors
   vim.api.nvim_set_hl(0, "RaccoonAddSign", {
     fg = "#98c379", -- Green

--- a/lua/raccoon/keymaps.lua
+++ b/lua/raccoon/keymaps.lua
@@ -122,16 +122,36 @@ local function split_position_for_point(point)
   if not rendered then
     return nil
   end
-  return diff.find_split_row(rendered, {
+  local row, col = diff.find_split_row(rendered, {
     path = point.file and point.file.filename,
     line = point.line,
     side = point.side,
   })
+  local semantic_col = point.side == "LEFT"
+    and rendered.left_range.content_start_col
+    or rendered.right_range.content_start_col
+  return row, col, semantic_col
 end
 
-local function rendered_line_for_current_point(point)
-  local row = split_position_for_point(point)
-  return row or point.line
+local function rendered_order_for_point(point)
+  local row, _, semantic_col = split_position_for_point(point)
+  return row or point.line, semantic_col or 0
+end
+
+local function current_rendered_order()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+  if not rendered then
+    return cursor[1], cursor[2]
+  end
+  local target = diff.resolve_cursor_target(vim.api.nvim_get_current_buf(), cursor[1], cursor[2])
+  if target then
+    local semantic_col = target.side == "LEFT"
+      and rendered.left_range.content_start_col
+      or rendered.right_range.content_start_col
+    return cursor[1], semantic_col
+  end
+  return cursor[1], cursor[2]
 end
 
 --- Navigate to a point (opens file if needed)
@@ -156,6 +176,16 @@ local function goto_point(point)
   local line_count = vim.api.nvim_buf_line_count(0)
   local rendered_row, rendered_col = split_position_for_point(point)
   local target_line = math.max(1, math.min(rendered_row or point.line, line_count))
+  if rendered_row then
+    diff.set_split_semantic_target(vim.api.nvim_get_current_buf(), {
+      path = point.file and point.file.filename,
+      line = point.line,
+      side = point.side,
+      row = rendered_row,
+    })
+  else
+    diff.set_split_semantic_target(vim.api.nvim_get_current_buf(), nil)
+  end
   vim.api.nvim_win_set_cursor(0, { target_line, rendered_col or 0 })
   vim.cmd("normal! zz")
 
@@ -187,16 +217,18 @@ function M.next_point()
   end
 
   local current_file_idx = state.get_current_file_index()
-  local current_line = vim.fn.line(".")
+  local current_line, current_col = current_rendered_order()
 
   -- Find next point after current position
   for _, point in ipairs(all_points) do
     local point_line = point.line
+    local point_col = 0
     if point.file_index == current_file_idx then
-      point_line = rendered_line_for_current_point(point)
+      point_line, point_col = rendered_order_for_point(point)
     end
     if point.file_index > current_file_idx or
-       (point.file_index == current_file_idx and point_line > current_line) then
+       (point.file_index == current_file_idx
+         and (point_line > current_line or (point_line == current_line and point_col > current_col))) then
       goto_point(point)
       return
     end
@@ -220,17 +252,19 @@ function M.prev_point()
   end
 
   local current_file_idx = state.get_current_file_index()
-  local current_line = vim.fn.line(".")
+  local current_line, current_col = current_rendered_order()
 
   -- Find previous point before current position (iterate in reverse)
   for i = #all_points, 1, -1 do
     local point = all_points[i]
     local point_line = point.line
+    local point_col = 0
     if point.file_index == current_file_idx then
-      point_line = rendered_line_for_current_point(point)
+      point_line, point_col = rendered_order_for_point(point)
     end
     if point.file_index < current_file_idx or
-       (point.file_index == current_file_idx and point_line < current_line) then
+       (point.file_index == current_file_idx
+         and (point_line < current_line or (point_line == current_line and point_col < current_col))) then
       goto_point(point)
       return
     end

--- a/lua/raccoon/keymaps.lua
+++ b/lua/raccoon/keymaps.lua
@@ -38,9 +38,13 @@ local function build_thread_index()
   return index
 end
 
+local function point_key(line, side)
+  return (side or "RIGHT") .. ":" .. tostring(line)
+end
+
 --- Get all points of interest (diffs and comments) for a file
 ---@param file table File data with filename and patch
----@return table[] points Sorted list of {line, type} where type is "diff" or "comment"
+---@return table[] points Sorted list of {line, side, type} where type is "diff" or "comment"
 local function get_file_points(file)
   if not file then return {} end
 
@@ -49,45 +53,44 @@ local function get_file_points(file)
 
   -- Get diff hunks
   if file.patch then
-    local changes = diff.get_changed_lines(file.patch)
-
-    -- Group consecutive changed lines into hunks
-    local all_lines = {}
-    for _, line in ipairs(changes.added) do
-      table.insert(all_lines, line)
-    end
-    for _, del in ipairs(changes.deleted) do
-      if del.line_num then
-        table.insert(all_lines, math.max(1, del.line_num))
+    for _, target in ipairs(diff.get_change_points(file.patch)) do
+      local key = point_key(target.line, target.side)
+      if not seen[key] then
+        table.insert(points, target)
+        seen[key] = true
       end
-    end
-    table.sort(all_lines)
-
-    -- Get hunk start lines (first line of consecutive groups)
-    local prev_line = nil
-    for _, line in ipairs(all_lines) do
-      if prev_line == nil or line > prev_line + 1 then
-        if not seen[line] then
-          table.insert(points, { line = line, type = "diff" })
-          seen[line] = true
-        end
-      end
-      prev_line = line
     end
   end
 
   -- Get comments
   local index = build_thread_index()
   local line_map = index and index.line_state_by_file[file.filename] or {}
-  for line in pairs(line_map) do
-    if line and not seen[line] then
-      table.insert(points, { line = line, type = "comment" })
-      seen[line] = true
+  for line, bucket in pairs(line_map) do
+    if line then
+      local sides = {}
+      for _, thread in ipairs(bucket.threads or {}) do
+        sides[thread.side == "LEFT" and "LEFT" or "RIGHT"] = true
+      end
+      if #(bucket.issue_comments or {}) > 0 then
+        sides.RIGHT = true
+      end
+      for side in pairs(sides) do
+        local key = point_key(line, side)
+        if not seen[key] then
+          table.insert(points, { line = line, side = side, type = "comment" })
+          seen[key] = true
+        end
+      end
     end
   end
 
   -- Sort by line number
-  table.sort(points, function(a, b) return a.line < b.line end)
+  table.sort(points, function(a, b)
+    if a.line ~= b.line then
+      return a.line < b.line
+    end
+    return (a.side or "RIGHT") < (b.side or "RIGHT")
+  end)
 
   return points
 end
@@ -105,6 +108,7 @@ local function get_all_points()
         file_index = file_idx,
         file = file,
         line = point.line,
+        side = point.side,
         type = point.type,
       })
     end
@@ -113,8 +117,25 @@ local function get_all_points()
   return all_points
 end
 
+local function split_position_for_point(point)
+  local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+  if not rendered then
+    return nil
+  end
+  return diff.find_split_row(rendered, {
+    path = point.file and point.file.filename,
+    line = point.line,
+    side = point.side,
+  })
+end
+
+local function rendered_line_for_current_point(point)
+  local row = split_position_for_point(point)
+  return row or point.line
+end
+
 --- Navigate to a point (opens file if needed)
----@param point table {file_index, file, line, type}
+---@param point table {file_index, file, line, side, type}
 local function goto_point(point)
   local current_file_idx = state.get_current_file_index()
 
@@ -133,15 +154,16 @@ local function goto_point(point)
 
   -- Go to line (clamped to valid range to prevent "cursor position outside buffer" errors)
   local line_count = vim.api.nvim_buf_line_count(0)
-  local target_line = math.max(1, math.min(point.line, line_count))
-  vim.api.nvim_win_set_cursor(0, { target_line, 0 })
+  local rendered_row, rendered_col = split_position_for_point(point)
+  local target_line = math.max(1, math.min(rendered_row or point.line, line_count))
+  vim.api.nvim_win_set_cursor(0, { target_line, rendered_col or 0 })
   vim.cmd("normal! zz")
 
   -- Show what we landed on with position in file
   local file_points = get_file_points(point.file)
   local point_idx = 1
   for i, p in ipairs(file_points) do
-    if p.line == point.line then
+    if p.line == point.line and (p.side or "RIGHT") == (point.side or "RIGHT") then
       point_idx = i
       break
     end
@@ -169,8 +191,12 @@ function M.next_point()
 
   -- Find next point after current position
   for _, point in ipairs(all_points) do
+    local point_line = point.line
+    if point.file_index == current_file_idx then
+      point_line = rendered_line_for_current_point(point)
+    end
     if point.file_index > current_file_idx or
-       (point.file_index == current_file_idx and point.line > current_line) then
+       (point.file_index == current_file_idx and point_line > current_line) then
       goto_point(point)
       return
     end
@@ -199,8 +225,12 @@ function M.prev_point()
   -- Find previous point before current position (iterate in reverse)
   for i = #all_points, 1, -1 do
     local point = all_points[i]
+    local point_line = point.line
+    if point.file_index == current_file_idx then
+      point_line = rendered_line_for_current_point(point)
+    end
     if point.file_index < current_file_idx or
-       (point.file_index == current_file_idx and point.line < current_line) then
+       (point.file_index == current_file_idx and point_line < current_line) then
       goto_point(point)
       return
     end

--- a/lua/raccoon/thread_index.lua
+++ b/lua/raccoon/thread_index.lua
@@ -117,6 +117,38 @@ local function ensure_line_bucket(path_map, path, line)
   return bucket
 end
 
+local function ensure_side_line_bucket(path_map, path, side, line)
+  local file_map = path_map[path]
+  if not file_map then
+    file_map = {}
+    path_map[path] = file_map
+  end
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local side_map = file_map[side]
+  if not side_map then
+    side_map = {}
+    file_map[side] = side_map
+  end
+  local bucket = side_map[line]
+  if not bucket then
+    bucket = {
+      threads = {},
+      issue_comments = {},
+      counts = { nr = 0, u = 0, i = 0 },
+    }
+    side_map[line] = bucket
+  end
+  return bucket
+end
+
+local function increment_thread_count(bucket, thread)
+  if thread.needs_reply then
+    bucket.counts.nr = bucket.counts.nr + 1
+  else
+    bucket.counts.u = bucket.counts.u + 1
+  end
+end
+
 --- Build an exact review-thread index for the current session.
 --- Returns nil + error if any real review comment cannot be mapped to a thread.
 ---@return table|nil index, string|nil err
@@ -247,18 +279,24 @@ function M.build()
   local history_threads = {}
   local line_state_by_file = {}
   local comment_line_state_by_file = {}
+  local side_line_state_by_file = {}
+  local side_comment_line_state_by_file = {}
 
   for _, thread in ipairs(threads) do
     table.insert(history_threads, thread)
     if is_real_number(thread.line) and thread.path then
       local bucket = ensure_line_bucket(comment_line_state_by_file, thread.path, thread.line)
       table.insert(bucket.threads, thread)
+      local side_bucket = ensure_side_line_bucket(
+        side_comment_line_state_by_file,
+        thread.path,
+        thread.side,
+        thread.line
+      )
+      table.insert(side_bucket.threads, thread)
       if thread.resolved ~= true then
-        if thread.needs_reply then
-          bucket.counts.nr = bucket.counts.nr + 1
-        else
-          bucket.counts.u = bucket.counts.u + 1
-        end
+        increment_thread_count(bucket, thread)
+        increment_thread_count(side_bucket, thread)
       end
     end
     if thread.resolved ~= true then
@@ -266,11 +304,10 @@ function M.build()
       if is_real_number(thread.line) and thread.path then
         local bucket = ensure_line_bucket(line_state_by_file, thread.path, thread.line)
         table.insert(bucket.threads, thread)
-        if thread.needs_reply then
-          bucket.counts.nr = bucket.counts.nr + 1
-        else
-          bucket.counts.u = bucket.counts.u + 1
-        end
+        increment_thread_count(bucket, thread)
+        local side_bucket = ensure_side_line_bucket(side_line_state_by_file, thread.path, thread.side, thread.line)
+        table.insert(side_bucket.threads, thread)
+        increment_thread_count(side_bucket, thread)
       end
     end
   end
@@ -283,6 +320,19 @@ function M.build()
     local comment_bucket = ensure_line_bucket(comment_line_state_by_file, entry.path, entry.line)
     table.insert(comment_bucket.issue_comments, entry.comment)
     comment_bucket.counts.i = comment_bucket.counts.i + 1
+
+    local side_bucket = ensure_side_line_bucket(side_line_state_by_file, entry.path, "RIGHT", entry.line)
+    table.insert(side_bucket.issue_comments, entry.comment)
+    side_bucket.counts.i = side_bucket.counts.i + 1
+
+    local side_comment_bucket = ensure_side_line_bucket(
+      side_comment_line_state_by_file,
+      entry.path,
+      "RIGHT",
+      entry.line
+    )
+    table.insert(side_comment_bucket.issue_comments, entry.comment)
+    side_comment_bucket.counts.i = side_comment_bucket.counts.i + 1
   end
 
   table.sort(history_threads, compare_threads_for_history)
@@ -295,6 +345,8 @@ function M.build()
     thread_by_id = thread_by_id,
     line_state_by_file = line_state_by_file,
     comment_line_state_by_file = comment_line_state_by_file,
+    side_line_state_by_file = side_line_state_by_file,
+    side_comment_line_state_by_file = side_comment_line_state_by_file,
     issue_entries = issue_entries,
     review_comments = review_comments,
     review_bodies = state.get_comments("_reviews"),
@@ -306,8 +358,17 @@ end
 ---@param index table
 ---@param path string
 ---@param line number
+---@param side? string
 ---@return table|nil
-function M.get_line_state(index, path, line)
+function M.get_line_state(index, path, line, side)
+  if not index or not path or not is_real_number(line) then
+    return nil
+  end
+  if side then
+    local file_map = index.side_line_state_by_file and index.side_line_state_by_file[path]
+    local side_map = file_map and file_map[side == "LEFT" and "LEFT" or "RIGHT"]
+    return side_map and side_map[line] or nil
+  end
   local file_map = index.line_state_by_file[path]
   if not file_map then
     return nil
@@ -318,8 +379,17 @@ end
 ---@param index table
 ---@param path string
 ---@param line number
+---@param side? string
 ---@return table|nil
-function M.get_comment_line_state(index, path, line)
+function M.get_comment_line_state(index, path, line, side)
+  if not index or not path or not is_real_number(line) then
+    return nil
+  end
+  if side then
+    local file_map = index.side_comment_line_state_by_file and index.side_comment_line_state_by_file[path]
+    local side_map = file_map and file_map[side == "LEFT" and "LEFT" or "RIGHT"]
+    return side_map and side_map[line] or nil
+  end
   local file_map = index.comment_line_state_by_file[path]
   if not file_map then
     return nil

--- a/lua/raccoon/thread_index.lua
+++ b/lua/raccoon/thread_index.lua
@@ -164,6 +164,7 @@ function M.build()
               path = path,
               file_index = file_index_by_path[path] or math.huge,
               line = M.get_comment_line(comment),
+              side = "RIGHT",
               resolved = comment.resolved == true,
               root_comment_id = nil,
               is_file_level = comment.subject_type == "file",
@@ -192,6 +193,7 @@ function M.build()
 
           if normalize_nil(comment.in_reply_to_id) == nil and is_real_number(comment.id) then
             thread.root_comment_id = comment.id
+            thread.side = comment.side == "LEFT" and "LEFT" or "RIGHT"
           end
         end
       end

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -1016,7 +1016,7 @@ describe("raccoon.comments UI state restore", function()
 
     local picker_lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, 2, false)
     assert.matches("^%[R%]", picker_lines[1])
-    assert.truthy(picker_lines[2] and picker_lines[2]:match("^%[NEW%]"))
+    assert.equals("[NEW] New file comment for this file", picker_lines[2])
 
     local width = vim.api.nvim_win_get_config(0).width
     vim.o.columns = original_columns

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -43,6 +43,12 @@ local function make_file_buffer(path, line_count)
   return buf
 end
 
+local function write_checkout_file(path, lines)
+  local full_path = vim.fs.joinpath(CLONE_PATH, path)
+  vim.fn.mkdir(vim.fs.dirname(full_path), "p")
+  vim.fn.writefile(lines, full_path)
+end
+
 local function make_split_buffer(opts)
   local rendered = diff.render_split_file({
     path = opts.path or "lua/a.lua",
@@ -185,6 +191,7 @@ describe("raccoon.comments UI state restore", function()
   local baseline_buffers
 
   before_each(function()
+    vim.fn.delete(CLONE_PATH, "rf")
     baseline_buffers = {}
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       baseline_buffers[buf] = true
@@ -207,6 +214,7 @@ describe("raccoon.comments UI state restore", function()
         pcall(vim.api.nvim_buf_delete, buf, { force = true })
       end
     end
+    vim.fn.delete(CLONE_PATH, "rf")
   end)
 
   it("captures and restores unresolved-thread picker selection", function()
@@ -587,6 +595,75 @@ describe("raccoon.comments UI state restore", function()
     assert.is_true(sync_called)
   end)
 
+  it("sends split left-side tail deletion comments with old line beyond checkout bounds", function()
+    local original_notify = vim.notify
+    local original_config_load = config.load
+    local original_get_token_entry = config.get_token_entry
+    local original_api_init = api.init
+    local original_create_comment = api.create_comment
+    local original_sync = open.sync
+
+    local captured_opts
+    local sync_called = false
+
+    vim.notify = function() end
+    config.load = function()
+      return {
+        github_host = "github.com",
+        tokens = { owner = "ghp_fake" },
+      }, nil
+    end
+    config.get_token_entry = function()
+      return { token = "ghp_fake" }
+    end
+    api.init = function() end
+    api.create_comment = function(_owner, _repo, _number, opts, _token, callback)
+      captured_opts = opts
+      callback({ id = 59 }, nil)
+    end
+    open.sync = function()
+      sync_called = true
+    end
+
+    local patch = "@@ -1,5 +1,3 @@\n line 1\n line 2\n line 3\n-line 4\n-line 5"
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = patch,
+      },
+    })
+    write_checkout_file("lua/a.lua", { "line 1", "line 2", "line 3" })
+    make_split_buffer({
+      old_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" },
+      new_lines = { "line 1", "line 2", "line 3" },
+      patch = patch,
+    })
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    vim.api.nvim_win_set_cursor(0, { 5, rendered.left_range.content_start_col })
+    comments.show_comment_thread()
+
+    local editor_buf = vim.api.nvim_get_current_buf()
+    local line_count = vim.api.nvim_buf_line_count(editor_buf)
+    vim.api.nvim_buf_set_lines(editor_buf, line_count - 1, line_count, false, { "old tail body" })
+    vim.cmd("stopinsert")
+    trigger_buffer_mapping(editor_buf, "n", " s")
+    vim.wait(1000, function()
+      return sync_called
+    end, 10)
+
+    vim.notify = original_notify
+    config.load = original_config_load
+    config.get_token_entry = original_get_token_entry
+    api.init = original_api_init
+    api.create_comment = original_create_comment
+    open.sync = original_sync
+
+    assert.equals("lua/a.lua", captured_opts.path)
+    assert.equals(5, captured_opts.line)
+    assert.equals("LEFT", captured_opts.side)
+    assert.is_true(sync_called)
+  end)
+
   it("retries rejected split left-side line comments as file-level comments", function()
     local original_notify = vim.notify
     local original_config_load = config.load
@@ -724,6 +801,41 @@ describe("raccoon.comments UI state restore", function()
     assert.equals("file", captured_opts.subject_type)
     assert.is_nil(captured_opts.line)
     assert.is_true(sync_called)
+  end)
+
+  it("jumps to the left rendered row and column for LEFT threads", function()
+    local patch = "@@ -1,5 +1,5 @@\n line 1\n+inserted\n line 2\n line 3\n-old deleted\n line 5"
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = patch,
+      },
+    })
+    state.set_comments("lua/a.lua", {
+      review_comment({
+        id = 60,
+        thread_id = "thread-left",
+        line = 4,
+        side = "LEFT",
+        body = "left deleted thread",
+      }),
+    })
+    write_checkout_file("lua/a.lua", { "line 1", "inserted", "line 2", "line 3", "line 5" })
+
+    assert.is_true(comments.jump_to_thread("thread-left", {}))
+
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    local expected_row
+    for idx, row in ipairs(rendered.rows or {}) do
+      if row.path == "lua/a.lua" and row.old_line == 4 and not row.left_continuation then
+        expected_row = idx
+        break
+      end
+    end
+    local cursor = vim.api.nvim_win_get_cursor(0)
+
+    assert.equals(expected_row, cursor[1])
+    assert.equals(rendered.left_range.content_start_col, cursor[2])
   end)
 
   it("restores a thread reply draft and disables send when the thread becomes resolved", function()

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -2,6 +2,7 @@ local comments = require("raccoon.comments")
 local state = require("raccoon.state")
 local api = require("raccoon.api")
 local config = require("raccoon.config")
+local diff = require("raccoon.diff")
 local open = require("raccoon.open")
 
 local CLONE_PATH = "/tmp/raccoon-ui-state"
@@ -40,6 +41,20 @@ local function make_file_buffer(path, line_count)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.api.nvim_set_current_buf(buf)
   return buf
+end
+
+local function make_split_buffer(opts)
+  local rendered = diff.render_split_file({
+    path = opts.path or "lua/a.lua",
+    old_lines = opts.old_lines,
+    new_lines = opts.new_lines,
+    patch = opts.patch,
+    width = opts.width or 100,
+  })
+  local buf = vim.api.nvim_create_buf(false, true)
+  diff.apply_split_render(buf, rendered)
+  vim.api.nvim_set_current_buf(buf)
+  return buf, rendered
 end
 
 local function current_win_title()
@@ -502,6 +517,212 @@ describe("raccoon.comments UI state restore", function()
 
     assert.is_false(graphql_called)
     assert.is_true(rest_called)
+    assert.is_true(sync_called)
+  end)
+
+  it("sends split-buffer left-side comments with LEFT side and old line", function()
+    local original_notify = vim.notify
+    local original_config_load = config.load
+    local original_get_token_entry = config.get_token_entry
+    local original_api_init = api.init
+    local original_create_comment = api.create_comment
+    local original_sync = open.sync
+
+    local captured_opts
+    local sync_called = false
+
+    vim.notify = function() end
+    config.load = function()
+      return {
+        github_host = "github.com",
+        tokens = { owner = "ghp_fake" },
+      }, nil
+    end
+    config.get_token_entry = function()
+      return { token = "ghp_fake" }
+    end
+    api.init = function() end
+    api.create_comment = function(_owner, _repo, _number, opts, _token, callback)
+      captured_opts = opts
+      callback({ id = 56 }, nil)
+    end
+    open.sync = function()
+      sync_called = true
+    end
+
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = "@@ -1,3 +1,3 @@\n line 1\n-old value\n+new value\n line 3",
+      },
+    })
+    make_split_buffer({
+      old_lines = { "line 1", "old value", "line 3" },
+      new_lines = { "line 1", "new value", "line 3" },
+      patch = "@@ -1,3 +1,3 @@\n line 1\n-old value\n+new value\n line 3",
+    })
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    vim.api.nvim_win_set_cursor(0, { 2, rendered.left_range.content_start_col })
+    comments.show_comment_thread()
+
+    local editor_buf = vim.api.nvim_get_current_buf()
+    local line_count = vim.api.nvim_buf_line_count(editor_buf)
+    vim.api.nvim_buf_set_lines(editor_buf, line_count - 1, line_count, false, { "left body" })
+    vim.cmd("stopinsert")
+    trigger_buffer_mapping(editor_buf, "n", " s")
+    vim.wait(1000, function()
+      return sync_called
+    end, 10)
+
+    vim.notify = original_notify
+    config.load = original_config_load
+    config.get_token_entry = original_get_token_entry
+    api.init = original_api_init
+    api.create_comment = original_create_comment
+    open.sync = original_sync
+
+    assert.equals("lua/a.lua", captured_opts.path)
+    assert.equals(2, captured_opts.line)
+    assert.equals("LEFT", captured_opts.side)
+    assert.is_true(sync_called)
+  end)
+
+  it("retries rejected split left-side line comments as file-level comments", function()
+    local original_notify = vim.notify
+    local original_config_load = config.load
+    local original_get_token_entry = config.get_token_entry
+    local original_api_init = api.init
+    local original_create_comment = api.create_comment
+    local original_sync = open.sync
+
+    local calls = {}
+    local sync_called = false
+
+    vim.notify = function() end
+    config.load = function()
+      return {
+        github_host = "github.com",
+        tokens = { owner = "ghp_fake" },
+      }, nil
+    end
+    config.get_token_entry = function()
+      return { token = "ghp_fake" }
+    end
+    api.init = function() end
+    api.create_comment = function(_owner, _repo, _number, opts, _token, callback)
+      table.insert(calls, vim.deepcopy(opts))
+      if #calls == 1 then
+        callback(nil, "GitHub API error (422): Validation Failed")
+      else
+        callback({ id = 57 }, nil)
+      end
+    end
+    open.sync = function()
+      sync_called = true
+    end
+
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = "@@ -1,3 +1,3 @@\n line 1\n-old value\n+new value\n line 3",
+      },
+    })
+    make_split_buffer({
+      old_lines = { "line 1", "old value", "line 3" },
+      new_lines = { "line 1", "new value", "line 3" },
+      patch = "@@ -1,3 +1,3 @@\n line 1\n-old value\n+new value\n line 3",
+    })
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    vim.api.nvim_win_set_cursor(0, { 2, rendered.left_range.content_start_col })
+    comments.show_comment_thread()
+
+    local editor_buf = vim.api.nvim_get_current_buf()
+    local line_count = vim.api.nvim_buf_line_count(editor_buf)
+    vim.api.nvim_buf_set_lines(editor_buf, line_count - 1, line_count, false, { "retry body" })
+    vim.cmd("stopinsert")
+    trigger_buffer_mapping(editor_buf, "n", " s")
+    vim.wait(1000, function()
+      return sync_called
+    end, 10)
+
+    vim.notify = original_notify
+    config.load = original_config_load
+    config.get_token_entry = original_get_token_entry
+    api.init = original_api_init
+    api.create_comment = original_create_comment
+    open.sync = original_sync
+
+    assert.equals(2, #calls)
+    assert.equals("LEFT", calls[1].side)
+    assert.equals("file", calls[2].subject_type)
+    assert.is_nil(calls[2].line)
+    assert.is_true(sync_called)
+  end)
+
+  it("sends split out-of-hunk rows as file-level comments", function()
+    local original_notify = vim.notify
+    local original_config_load = config.load
+    local original_get_token_entry = config.get_token_entry
+    local original_api_init = api.init
+    local original_create_comment = api.create_comment
+    local original_sync = open.sync
+
+    local captured_opts
+    local sync_called = false
+
+    vim.notify = function() end
+    config.load = function()
+      return {
+        github_host = "github.com",
+        tokens = { owner = "ghp_fake" },
+      }, nil
+    end
+    config.get_token_entry = function()
+      return { token = "ghp_fake" }
+    end
+    api.init = function() end
+    api.create_comment = function(_owner, _repo, _number, opts, _token, callback)
+      captured_opts = opts
+      callback({ id = 58 }, nil)
+    end
+    open.sync = function()
+      sync_called = true
+    end
+
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = "@@ -2,1 +2,1 @@\n-old value\n+new value",
+      },
+    })
+    state.set_comments("lua/a.lua", {})
+    make_split_buffer({
+      old_lines = { "line 1", "old value", "line 3", "line 4" },
+      new_lines = { "line 1", "new value", "line 3", "line 4" },
+      patch = "@@ -2,1 +2,1 @@\n-old value\n+new value",
+    })
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    vim.api.nvim_win_set_cursor(0, { 4, rendered.right_range.content_start_col })
+    comments.show_comment_thread()
+
+    local editor_buf = vim.api.nvim_get_current_buf()
+    local line_count = vim.api.nvim_buf_line_count(editor_buf)
+    vim.api.nvim_buf_set_lines(editor_buf, line_count - 1, line_count, false, { "file body" })
+    vim.cmd("stopinsert")
+    trigger_buffer_mapping(editor_buf, "n", " s")
+    vim.wait(1000, function()
+      return sync_called
+    end, 10)
+
+    vim.notify = original_notify
+    config.load = original_config_load
+    config.get_token_entry = original_get_token_entry
+    api.init = original_api_init
+    api.create_comment = original_create_comment
+    open.sync = original_sync
+
+    assert.equals("file", captured_opts.subject_type)
+    assert.is_nil(captured_opts.line)
     assert.is_true(sync_called)
   end)
 

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -838,6 +838,106 @@ describe("raccoon.comments UI state restore", function()
     assert.equals(rendered.left_range.content_start_col, cursor[2])
   end)
 
+  it("renders split badges from side-specific line buckets", function()
+    state.set_comments("lua/a.lua", {
+      review_comment({
+        id = 61,
+        thread_id = "thread-left",
+        line = 2,
+        side = "LEFT",
+        body = "left thread",
+      }),
+      review_comment({
+        id = 62,
+        thread_id = "thread-right",
+        line = 2,
+        side = "RIGHT",
+        body = "right thread",
+      }),
+    })
+    local buf, rendered = make_split_buffer({
+      old_lines = { "before", "old value", "after" },
+      new_lines = { "before", "new value", "after" },
+      patch = "@@ -1,3 +1,3 @@\n before\n-old value\n+new value\n after",
+    })
+
+    comments.show_comments(buf, state.get_comments("lua/a.lua"))
+
+    local badges_by_col = {}
+    for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(buf, comments.get_namespace(), 0, -1, { details = true })) do
+      local details = mark[4] or {}
+      if details.virt_text_win_col == rendered.left_range.start_col
+          or details.virt_text_win_col == rendered.right_range.start_col
+      then
+        badges_by_col[details.virt_text_win_col] = details.virt_text[1][1]
+      end
+    end
+
+    assert.equals("[U1]", badges_by_col[rendered.left_range.start_col])
+    assert.equals("[U1]", badges_by_col[rendered.right_range.start_col])
+  end)
+
+  it("opens same-line picker with only the selected split side's threads", function()
+    state.set_comments("lua/a.lua", {
+      review_comment({
+        id = 63,
+        thread_id = "thread-left",
+        line = 2,
+        side = "LEFT",
+        body = "left side only",
+      }),
+      review_comment({
+        id = 64,
+        thread_id = "thread-right",
+        line = 2,
+        side = "RIGHT",
+        body = "right side only",
+      }),
+    })
+    local _buf, rendered = make_split_buffer({
+      old_lines = { "before", "old value", "after" },
+      new_lines = { "before", "new value", "after" },
+      patch = "@@ -1,3 +1,3 @@\n before\n-old value\n+new value\n after",
+    })
+    vim.api.nvim_win_set_cursor(0, { 2, rendered.right_range.content_start_col })
+
+    comments.show_comment_thread()
+
+    local snapshot = comments.capture_ui_state()
+    assert.equals("picker", snapshot.kind)
+    assert.equals("thread:thread-right", snapshot.row_key)
+    local picker_lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+    assert.truthy(table.concat(picker_lines, "\n"):match("right side only"))
+    assert.is_nil(table.concat(picker_lines, "\n"):match("left side only"))
+  end)
+
+  it("opens file-level comments from split placeholder rows without a line", function()
+    state.set_files({
+      {
+        filename = "assets/logo.png",
+        patch = "",
+      },
+    })
+    local rendered = diff.render_split_file({
+      path = "assets/logo.png",
+      binary = true,
+      width = 100,
+    })
+    local buf = vim.api.nvim_create_buf(false, true)
+    diff.apply_split_render(buf, rendered)
+    vim.api.nvim_set_current_buf(buf)
+    vim.api.nvim_win_set_cursor(0, { 1, rendered.left_range.content_start_col })
+
+    comments.show_comment_thread()
+
+    local snapshot = comments.capture_ui_state()
+    assert.equals("editor", snapshot.kind)
+    assert.equals("new_thread", snapshot.editor_kind)
+    assert.equals("assets/logo.png", snapshot.path)
+    assert.is_nil(snapshot.line)
+    assert.is_false(snapshot.in_diff_context)
+  end)
+
   it("restores a thread reply draft and disables send when the thread becomes resolved", function()
     local notifications = {}
     vim.notify = function(message)

--- a/tests/commit_ui_spec.lua
+++ b/tests/commit_ui_spec.lua
@@ -201,6 +201,39 @@ describe("raccoon.commit_ui", function()
     end)
   end)
 
+  describe("apply_diff_highlights", function()
+    it("adds inline character highlights for paired delete/add rows", function()
+      local ns = vim.api.nvim_create_namespace("raccoon_commit_ui_inline_test")
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+        "local value = 1",
+        "local value = 42",
+      })
+
+      commit_ui.apply_diff_highlights(ns, buf, {
+        { type = "del", content = "local value = 1" },
+        { type = "add", content = "local value = 42" },
+      })
+
+      local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })
+      local inline_delete = false
+      local inline_add = false
+      for _, mark in ipairs(marks) do
+        local details = mark[4] or {}
+        if details.hl_group == "RaccoonInlineDelete" then
+          inline_delete = true
+        elseif details.hl_group == "RaccoonInlineAdd" then
+          inline_add = true
+        end
+      end
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+
+      assert.is_true(inline_delete)
+      assert.is_true(inline_add)
+    end)
+  end)
+
   it("compute_grid_context matches rendered grid row height", function()
     local state = { grid_wins = {}, grid_bufs = {} }
     local saved_lines = vim.o.lines

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -45,6 +45,30 @@ describe("raccoon.diff", function()
     end)
   end)
 
+  describe("parse_hunk_ranges", function()
+    it("parses old and new hunk coordinates", function()
+      local ranges = diff.parse_hunk_ranges("@@ -10,2 +20,3 @@ function")
+
+      assert.same({
+        old_start = 10,
+        old_count = 2,
+        new_start = 20,
+        new_count = 3,
+      }, ranges)
+    end)
+
+    it("defaults omitted counts to one", function()
+      local ranges = diff.parse_hunk_ranges("@@ -7 +9 @@")
+
+      assert.same({
+        old_start = 7,
+        old_count = 1,
+        new_start = 9,
+        new_count = 1,
+      }, ranges)
+    end)
+  end)
+
   describe("parse_patch", function()
     it("returns empty array for nil patch", function()
       local hunks = diff.parse_patch(nil)
@@ -438,6 +462,207 @@ describe("raccoon.diff", function()
       assert.is_true(diff.is_line_in_review_context(patch, 3))
       assert.is_true(diff.is_line_in_review_context(patch, 4))
       assert.is_true(diff.is_line_in_review_context(patch, 5))
+    end)
+  end)
+
+  describe("render_stacked_inline_spans", function()
+    it("pairs delete and add lines by index within a contiguous change block", function()
+      local line_list = {
+        { type = "del", content = "local value = 1" },
+        { type = "del", content = "local other = true" },
+        { type = "add", content = "local value = 42" },
+        { type = "add", content = "local other = false" },
+      }
+
+      local spans = diff.render_stacked_inline_spans(line_list)
+
+      assert.equals(4, #spans)
+      assert.equals(1, spans[1].line)
+      assert.equals(2, spans[2].line)
+      assert.equals(3, spans[3].line)
+      assert.equals(4, spans[4].line)
+      assert.equals("RaccoonInlineDelete", spans[1].hl)
+      assert.equals("RaccoonInlineAdd", spans[3].hl)
+      assert.is_true(spans[1].start_col < spans[1].end_col)
+      assert.is_true(spans[3].start_col < spans[3].end_col)
+    end)
+
+    it("skips inline spans when either paired line exceeds the display cap", function()
+      local long = string.rep("x", diff.MAX_INLINE_DIFF_DISPLAY_CHARS + 1)
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = long },
+        { type = "add", content = long .. "y" },
+      })
+
+      assert.equals(0, #spans)
+    end)
+  end)
+
+  describe("render_split_file", function()
+    it("aligns full old and new file content with split row metadata", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "old", "three" },
+        new_lines = { "one", "new", "three" },
+        patch = "@@ -1,3 +1,3 @@\n one\n-old\n+new\n three",
+        width = 80,
+      })
+
+      assert.equals(3, #rendered.lines)
+      assert.matches("one", rendered.lines[1])
+      assert.matches("old", rendered.lines[2])
+      assert.matches("new", rendered.lines[2])
+      assert.same({
+        path = "lua/a.lua",
+        old_line = 2,
+        new_line = 2,
+        kind = "change",
+        in_diff_context = true,
+        left_continuation = false,
+        right_continuation = false,
+      }, {
+        path = rendered.rows[2].path,
+        old_line = rendered.rows[2].old_line,
+        new_line = rendered.rows[2].new_line,
+        kind = rendered.rows[2].kind,
+        in_diff_context = rendered.rows[2].in_diff_context,
+        left_continuation = rendered.rows[2].left_continuation,
+        right_continuation = rendered.rows[2].right_continuation,
+      })
+      assert.is_true(rendered.separator_col > rendered.left_range.start_col)
+      assert.is_true(rendered.right_range.start_col > rendered.separator_col)
+    end)
+
+    it("wraps long split-side lines into continuation rows with stable semantic line numbers", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old " .. string.rep("x", 24), "after" },
+        new_lines = { "before", "new " .. string.rep("y", 24), "after" },
+        patch = "@@ -1,3 +1,3 @@\n before\n-old xxxxxxxxxxxxxxxxxxxxxxxx\n+new yyyyyyyyyyyyyyyyyyyyyyyy\n after",
+        width = 42,
+      })
+
+      assert.is_true(#rendered.lines > 3)
+      local continuation
+      for _, row in ipairs(rendered.rows) do
+        if row.old_line == 2 and row.new_line == 2 and (row.left_continuation or row.right_continuation) then
+          continuation = row
+          break
+        end
+      end
+
+      assert.is_not_nil(continuation)
+      assert.equals("change", continuation.kind)
+      assert.is_true(continuation.in_diff_context)
+    end)
+
+    it("renders added, deleted, and renamed files", function()
+      local added = diff.render_split_file({
+        path = "lua/new.lua",
+        status = "added",
+        old_lines = {},
+        new_lines = { "new line" },
+        patch = "@@ -0,0 +1 @@\n+new line",
+        width = 80,
+      })
+      local deleted = diff.render_split_file({
+        path = "lua/old.lua",
+        status = "removed",
+        old_lines = { "old line" },
+        new_lines = {},
+        patch = "@@ -1 +0,0 @@\n-old line",
+        width = 80,
+      })
+      local renamed = diff.render_split_file({
+        path = "lua/new-name.lua",
+        previous_path = "lua/old-name.lua",
+        status = "renamed",
+        old_lines = { "same" },
+        new_lines = { "same" },
+        patch = "",
+        width = 80,
+      })
+
+      assert.is_nil(added.rows[1].old_line)
+      assert.equals(1, added.rows[1].new_line)
+      assert.equals(1, deleted.rows[1].old_line)
+      assert.is_nil(deleted.rows[1].new_line)
+      assert.matches("renamed from lua/old%-name%.lua", renamed.lines[1])
+    end)
+
+    it("renders binary or unreadable files as file-level placeholder rows", function()
+      local rendered = diff.render_split_file({
+        path = "assets/logo.png",
+        binary = true,
+        width = 80,
+      })
+
+      assert.equals(1, #rendered.lines)
+      assert.matches("Binary or unreadable file", rendered.lines[1])
+      assert.equals("file", rendered.rows[1].kind)
+      assert.equals("assets/logo.png", rendered.rows[1].path)
+      assert.is_false(rendered.rows[1].in_diff_context)
+    end)
+
+    it("skips syntax projection above documented caps", function()
+      local lines = {}
+      for i = 1, diff.MAX_SYNTAX_ROWS + 1 do
+        lines[i] = "line " .. i
+      end
+
+      local rendered = diff.render_split_file({
+        path = "lua/big.lua",
+        old_lines = lines,
+        new_lines = lines,
+        patch = "",
+        width = 80,
+      })
+
+      assert.is_false(rendered.syntax_enabled)
+      assert.equals("row cap", rendered.syntax_skip_reason)
+    end)
+  end)
+
+  describe("resolve_cursor_target", function()
+    it("uses cursor column to choose left or right side", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "old" },
+        new_lines = { "new" },
+        patch = "@@ -1 +1 @@\n-old\n+new",
+        width = 80,
+      })
+      diff.attach_split_metadata(buf, rendered)
+
+      local left = diff.resolve_cursor_target(buf, 1, rendered.left_range.start_col)
+      local right = diff.resolve_cursor_target(buf, 1, rendered.right_range.start_col)
+
+      assert.equals("LEFT", left.side)
+      assert.equals(1, left.line)
+      assert.equals("RIGHT", right.side)
+      assert.equals(1, right.line)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("falls back to right side when the cursor is ambiguous", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "old" },
+        new_lines = { "new" },
+        patch = "@@ -1 +1 @@\n-old\n+new",
+        width = 80,
+      })
+      diff.attach_split_metadata(buf, rendered)
+
+      local target = diff.resolve_cursor_target(buf, 1, rendered.separator_col)
+
+      assert.equals("RIGHT", target.side)
+      assert.equals(1, target.line)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
     end)
   end)
 

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -637,6 +637,20 @@ describe("raccoon.diff", function()
         { line = 2, start_col = 1, end_col = 5, hl = "RaccoonInlineAdd" },
       }, spans_for_hl(spans, "RaccoonInlineAdd"))
     end)
+
+    it("highlights whole changed identifier tokens", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "const color = token.textColor;" },
+        { type = "add", content = "const color = token.htmlStyle;" },
+      })
+
+      assert.same({
+        { line = 1, start_col = 20, end_col = 29, hl = "RaccoonInlineDelete" },
+      }, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({
+        { line = 2, start_col = 20, end_col = 29, hl = "RaccoonInlineAdd" },
+      }, spans_for_hl(spans, "RaccoonInlineAdd"))
+    end)
   end)
 
   describe("render_split_file", function()
@@ -798,6 +812,33 @@ describe("raccoon.diff", function()
       assert.is_number(inline_priority)
       assert.is_number(syntax_priority)
       assert.is_true(inline_priority > syntax_priority)
+    end)
+
+    it("projects inline split highlights onto wrapped continuation rows", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "prefix-1234567890 oldToken" },
+        new_lines = { "prefix-1234567890 newToken" },
+        patch = "@@ -1 +1 @@\n-prefix-1234567890 oldToken\n+prefix-1234567890 newToken",
+        width = 42,
+      })
+
+      local inline_delete
+      local inline_add
+      for _, highlight in ipairs(rendered.highlights) do
+        if highlight.hl == "RaccoonInlineDelete" then
+          inline_delete = highlight
+        elseif highlight.hl == "RaccoonInlineAdd" then
+          inline_add = highlight
+        end
+      end
+
+      assert.is_not_nil(inline_delete)
+      assert.is_not_nil(inline_add)
+      assert.equals(1, inline_delete.line)
+      assert.equals(1, inline_add.line)
+      assert.is_true(inline_delete.start_col >= rendered.left_range.content_start_col)
+      assert.is_true(inline_add.start_col >= rendered.right_range.content_start_col)
     end)
 
     it("keeps add-only and delete-only rows as full-line highlights", function()

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -192,6 +192,66 @@ describe("raccoon.diff", function()
     end)
   end)
 
+  describe("get_change_points", function()
+    it("returns the first right-side line for replacement blocks", function()
+      local patch = [[
+@@ -10,3 +10,3 @@
+ line 10
+-old value
++new value
+ line 12]]
+
+      assert.same({
+        { line = 11, side = "RIGHT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns the first right-side line for add-only blocks", function()
+      local patch = [[
+@@ -3,2 +3,4 @@
+ line 3
++line 4
++line 5
+ line 6]]
+
+      assert.same({
+        { line = 4, side = "RIGHT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns the first left-side line for delete-only blocks", function()
+      local patch = [[
+@@ -3,4 +3,2 @@
+ line 3
+-old line 4
+-old line 5
+ line 6]]
+
+      assert.same({
+        { line = 4, side = "LEFT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns each separated change block in rendered order", function()
+      local patch = [[
+@@ -1,7 +1,8 @@
+ shared one
+-old value
++new value
+ shared two
++added value
+ shared three
+-removed value
+ shared four]]
+
+      assert.same({
+        { line = 2, side = "RIGHT", type = "diff" },
+        { line = 4, side = "RIGHT", type = "diff" },
+        { line = 5, side = "LEFT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+  end)
+
   describe("navigation", function()
     local original_notify
 
@@ -620,6 +680,103 @@ describe("raccoon.diff", function()
 
       assert.is_false(rendered.syntax_enabled)
       assert.equals("row cap", rendered.syntax_skip_reason)
+    end)
+
+    it("applies inline split range highlights above syntax and line overlays", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "local value = 1" },
+        new_lines = { "local value = 42" },
+        patch = "@@ -1 +1 @@\n-local value = 1\n+local value = 42",
+        width = 80,
+      })
+      table.insert(rendered.highlights, {
+        line = 0,
+        start_col = rendered.right_range.content_start_col,
+        end_col = rendered.right_range.content_start_col + 5,
+        hl = "@keyword",
+        priority = 110,
+      })
+
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+
+      local inline_priority
+      local syntax_priority
+      for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(buf, diff.get_namespace(), 0, -1, { details = true })) do
+        local details = mark[4] or {}
+        if details.hl_group == "RaccoonInlineAdd" or details.hl_group == "RaccoonInlineDelete" then
+          inline_priority = math.max(inline_priority or 0, details.priority or 0)
+        elseif details.hl_group == "@keyword" then
+          syntax_priority = details.priority or 0
+        end
+      end
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+
+      assert.is_number(inline_priority)
+      assert.is_number(syntax_priority)
+      assert.is_true(inline_priority > syntax_priority)
+    end)
+  end)
+
+  describe("find_split_row", function()
+    it("finds LEFT old-only deletion rows", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "two", "three" },
+        new_lines = { "one", "three" },
+        patch = "@@ -1,3 +1,2 @@\n one\n-two\n three",
+        width = 80,
+      })
+
+      local row, col = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "LEFT",
+      })
+
+      assert.equals(2, row)
+      assert.equals(rendered.left_range.content_start_col, col)
+    end)
+
+    it("finds RIGHT rows after a prior deletion", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "two", "three" },
+        new_lines = { "one", "three" },
+        patch = "@@ -1,3 +1,2 @@\n one\n-two\n three",
+        width = 80,
+      })
+
+      local row, col = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "RIGHT",
+      })
+
+      assert.equals(3, row)
+      assert.equals(rendered.right_range.content_start_col, col)
+    end)
+
+    it("ignores continuation rows for wrapped split lines", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old " .. string.rep("x", 24), "after" },
+        new_lines = { "before", "new " .. string.rep("y", 24), "after" },
+        patch = "@@ -1,3 +1,3 @@\n before\n-old xxxxxxxxxxxxxxxxxxxxxxxx\n+new yyyyyyyyyyyyyyyyyyyyyyyy\n after",
+        width = 42,
+      })
+
+      local row = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "RIGHT",
+      })
+
+      assert.is_not_nil(rendered.rows[row + 1])
+      assert.is_false(rendered.rows[row].right_continuation)
+      assert.is_true(rendered.rows[row + 1].right_continuation)
     end)
   end)
 

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -526,6 +526,16 @@ describe("raccoon.diff", function()
   end)
 
   describe("render_stacked_inline_spans", function()
+    local function spans_for_hl(spans, hl)
+      local filtered = {}
+      for _, span in ipairs(spans) do
+        if span.hl == hl then
+          table.insert(filtered, span)
+        end
+      end
+      return filtered
+    end
+
     it("pairs delete and add lines by index within a contiguous change block", function()
       local line_list = {
         { type = "del", content = "local value = 1" },
@@ -555,6 +565,77 @@ describe("raccoon.diff", function()
       })
 
       assert.equals(0, #spans)
+    end)
+
+    it("highlights separated character changes without unchanged middle text", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "abc1def2ghi" },
+        { type = "add", content = "abcXdefYghi" },
+      })
+
+      local deletes = spans_for_hl(spans, "RaccoonInlineDelete")
+      local adds = spans_for_hl(spans, "RaccoonInlineAdd")
+
+      assert.same({
+        { line = 1, start_col = 3, end_col = 4, hl = "RaccoonInlineDelete" },
+        { line = 1, start_col = 7, end_col = 8, hl = "RaccoonInlineDelete" },
+      }, deletes)
+      assert.same({
+        { line = 2, start_col = 3, end_col = 4, hl = "RaccoonInlineAdd" },
+        { line = 2, start_col = 7, end_col = 8, hl = "RaccoonInlineAdd" },
+      }, adds)
+    end)
+
+    it("highlights only inserted characters inside a paired line", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "abcghi" },
+        { type = "add", content = "abcDEFghi" },
+      })
+
+      assert.same({}, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({
+        { line = 2, start_col = 3, end_col = 6, hl = "RaccoonInlineAdd" },
+      }, spans_for_hl(spans, "RaccoonInlineAdd"))
+    end)
+
+    it("highlights only deleted characters inside a paired line", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "abcDEFghi" },
+        { type = "add", content = "abcghi" },
+      })
+
+      assert.same({
+        { line = 1, start_col = 3, end_col = 6, hl = "RaccoonInlineDelete" },
+      }, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({}, spans_for_hl(spans, "RaccoonInlineAdd"))
+    end)
+
+    it("highlights full content when paired lines share no characters", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "abc" },
+        { type = "add", content = "XYZ" },
+      })
+
+      assert.same({
+        { line = 1, start_col = 0, end_col = 3, hl = "RaccoonInlineDelete" },
+      }, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({
+        { line = 2, start_col = 0, end_col = 3, hl = "RaccoonInlineAdd" },
+      }, spans_for_hl(spans, "RaccoonInlineAdd"))
+    end)
+
+    it("uses byte columns for UTF-8 character changes", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "aéb" },
+        { type = "add", content = "a💡b" },
+      })
+
+      assert.same({
+        { line = 1, start_col = 1, end_col = 3, hl = "RaccoonInlineDelete" },
+      }, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({
+        { line = 2, start_col = 1, end_col = 5, hl = "RaccoonInlineAdd" },
+      }, spans_for_hl(spans, "RaccoonInlineAdd"))
     end)
   end)
 
@@ -718,6 +799,32 @@ describe("raccoon.diff", function()
       assert.is_number(syntax_priority)
       assert.is_true(inline_priority > syntax_priority)
     end)
+
+    it("keeps add-only and delete-only rows as full-line highlights", function()
+      local added = diff.render_split_file({
+        path = "lua/new.lua",
+        old_lines = {},
+        new_lines = { "new line" },
+        patch = "@@ -0,0 +1 @@\n+new line",
+        width = 80,
+      })
+      local deleted = diff.render_split_file({
+        path = "lua/old.lua",
+        old_lines = { "old line" },
+        new_lines = {},
+        patch = "@@ -1 +0,0 @@\n-old line",
+        width = 80,
+      })
+
+      assert.equals("RaccoonAdd", added.highlights[1].line_hl_group)
+      assert.equals("RaccoonDelete", deleted.highlights[1].line_hl_group)
+      for _, rendered in ipairs({ added, deleted }) do
+        for _, highlight in ipairs(rendered.highlights) do
+          assert.is_not_equal("RaccoonInlineAdd", highlight.hl)
+          assert.is_not_equal("RaccoonInlineDelete", highlight.hl)
+        end
+      end
+    end)
   end)
 
   describe("find_split_row", function()
@@ -756,7 +863,7 @@ describe("raccoon.diff", function()
       })
 
       assert.equals(3, row)
-      assert.equals(rendered.right_range.content_start_col, col)
+      assert.equals(rendered.left_range.content_start_col, col)
     end)
 
     it("ignores continuation rows for wrapped split lines", function()
@@ -777,6 +884,31 @@ describe("raccoon.diff", function()
       assert.is_not_nil(rendered.rows[row + 1])
       assert.is_false(rendered.rows[row].right_continuation)
       assert.is_true(rendered.rows[row + 1].right_continuation)
+    end)
+
+    it("uses position_by_key before scanning rows", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "two", "three" },
+        new_lines = { "one", "three" },
+        patch = "@@ -1,3 +1,2 @@\n one\n-two\n three",
+        width = 80,
+      })
+
+      assert.same({
+        row = 3,
+        col = rendered.left_range.content_start_col,
+      }, rendered.position_by_key["lua/a.lua|RIGHT|2"])
+
+      rendered.rows = {}
+      local row, col = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "RIGHT",
+      })
+
+      assert.equals(3, row)
+      assert.equals(rendered.left_range.content_start_col, col)
     end)
   end)
 

--- a/tests/keymaps_spec.lua
+++ b/tests/keymaps_spec.lua
@@ -235,12 +235,15 @@ describe("raccoon.keymaps", function()
 
       local cursor = vim.api.nvim_win_get_cursor(0)
       assert.equals(5, cursor[1])
-      assert.equals(rendered.right_range.content_start_col, cursor[2])
+      assert.equals(rendered.left_range.content_start_col, cursor[2])
+      local target = diff.resolve_cursor_target(buf, cursor[1], cursor[2])
+      assert.equals("RIGHT", target.side)
+      assert.equals(4, target.line)
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
 
-    it("next_point lands replacement diffs on the right-side changed row", function()
+    it("next_point lands replacement diffs visibly left while preserving RIGHT semantics", function()
       local diff = require("raccoon.diff")
       local patch = "@@ -1,3 +1,3 @@\n before\n-old value\n+new value\n after"
       state.start({
@@ -273,7 +276,10 @@ describe("raccoon.keymaps", function()
 
       local cursor = vim.api.nvim_win_get_cursor(0)
       assert.equals(2, cursor[1])
-      assert.equals(rendered.right_range.content_start_col, cursor[2])
+      assert.equals(rendered.left_range.content_start_col, cursor[2])
+      local target = diff.resolve_cursor_target(buf, cursor[1], cursor[2])
+      assert.equals("RIGHT", target.side)
+      assert.equals(2, target.line)
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
@@ -324,6 +330,75 @@ describe("raccoon.keymaps", function()
       local cursor = vim.api.nvim_win_get_cursor(0)
       assert.equals(2, cursor[1])
       assert.equals(rendered.left_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("navigates same-row LEFT and RIGHT points in semantic order", function()
+      local diff = require("raccoon.diff")
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = "",
+        },
+      })
+      state.set_comments("lua/a.lua", {
+        {
+          id = 3000,
+          body = "left comment",
+          thread_id = "thread-left",
+          line = 2,
+          side = "LEFT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-01T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+        {
+          id = 3001,
+          body = "right comment",
+          thread_id = "thread-right",
+          line = 2,
+          side = "RIGHT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-02T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old value", "after" },
+        new_lines = { "before", "new value", "after" },
+        patch = "",
+        width = 90,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      keymaps.next_point()
+      local first_cursor = vim.api.nvim_win_get_cursor(0)
+      local first_target = diff.resolve_cursor_target(buf, first_cursor[1], first_cursor[2])
+      assert.equals(2, first_cursor[1])
+      assert.equals(rendered.left_range.content_start_col, first_cursor[2])
+      assert.equals("LEFT", first_target.side)
+
+      keymaps.next_point()
+      local second_cursor = vim.api.nvim_win_get_cursor(0)
+      local second_target = diff.resolve_cursor_target(buf, second_cursor[1], second_cursor[2])
+      assert.equals(2, second_cursor[1])
+      assert.equals(rendered.left_range.content_start_col, second_cursor[2])
+      assert.equals("RIGHT", second_target.side)
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)

--- a/tests/keymaps_spec.lua
+++ b/tests/keymaps_spec.lua
@@ -188,6 +188,145 @@ describe("raccoon.keymaps", function()
       -- Should not error (just warns via ui module)
       keymaps.show_description()
     end)
+
+    it("next_point resolves current-file split destinations through rendered rows", function()
+      local diff = require("raccoon.diff")
+      local patch = "@@ -1,5 +1,4 @@\n line 1\n-line 2\n line 3\n line 4\n line 5"
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = patch,
+        },
+      })
+      state.set_comments("lua/a.lua", {
+        {
+          id = 1000,
+          body = "later comment",
+          thread_id = "thread-later",
+          line = 4,
+          side = "RIGHT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-01T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" },
+        new_lines = { "line 1", "line 3", "line 4", "line 5" },
+        patch = patch,
+        width = 80,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 3, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(5, cursor[1])
+      assert.equals(rendered.right_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("next_point lands replacement diffs on the right-side changed row", function()
+      local diff = require("raccoon.diff")
+      local patch = "@@ -1,3 +1,3 @@\n before\n-old value\n+new value\n after"
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = patch,
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old value", "after" },
+        new_lines = { "before", "new value", "after" },
+        patch = patch,
+        width = 90,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(2, cursor[1])
+      assert.equals(rendered.right_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("next_point keeps left-side thread comments on the left side", function()
+      local diff = require("raccoon.diff")
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = "",
+        },
+      })
+      state.set_comments("lua/a.lua", {
+        {
+          id = 2000,
+          body = "left comment",
+          thread_id = "thread-left",
+          line = 2,
+          side = "LEFT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-01T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old value", "after" },
+        new_lines = { "before", "new value", "after" },
+        patch = "",
+        width = 90,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(2, cursor[1])
+      assert.equals(rendered.left_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
   describe("merge_picker", function()

--- a/tests/thread_index_spec.lua
+++ b/tests/thread_index_spec.lua
@@ -137,6 +137,60 @@ describe("raccoon.thread_index", function()
     assert.is_true(comment_line_state.threads[1].resolved)
   end)
 
+  it("keeps same-number LEFT and RIGHT threads in separate side buckets", function()
+    state.set_comments("lua/a.lua", {
+      review_comment({
+        id = 41,
+        thread_id = "thread-left",
+        line = 7,
+        side = "LEFT",
+        body = "left thread",
+      }),
+      review_comment({
+        id = 42,
+        thread_id = "thread-right",
+        line = 7,
+        side = "RIGHT",
+        body = "right thread",
+      }),
+    })
+
+    local index, err = thread_index.build()
+
+    assert.is_nil(err)
+    local aggregate = thread_index.get_line_state(index, "lua/a.lua", 7)
+    assert.equals(2, #aggregate.threads)
+    assert.same({ nr = 0, u = 2, i = 0 }, aggregate.counts)
+
+    local left = thread_index.get_line_state(index, "lua/a.lua", 7, "LEFT")
+    local right = thread_index.get_line_state(index, "lua/a.lua", 7, "RIGHT")
+    assert.equals(1, #left.threads)
+    assert.equals("thread-left", left.threads[1].thread_id)
+    assert.same({ nr = 0, u = 1, i = 0 }, left.counts)
+    assert.equals(1, #right.threads)
+    assert.equals("thread-right", right.threads[1].thread_id)
+    assert.same({ nr = 0, u = 1, i = 0 }, right.counts)
+
+    local left_comment = thread_index.get_comment_line_state(index, "lua/a.lua", 7, "LEFT")
+    local right_comment = thread_index.get_comment_line_state(index, "lua/a.lua", 7, "RIGHT")
+    assert.equals("thread-left", left_comment.threads[1].thread_id)
+    assert.equals("thread-right", right_comment.threads[1].thread_id)
+  end)
+
+  it("returns nil for guarded side and nil-line lookups", function()
+    local index, err = thread_index.build()
+
+    assert.is_nil(err)
+    assert.is_nil(thread_index.get_line_state(nil, "lua/a.lua", 7))
+    assert.is_nil(thread_index.get_line_state(index, nil, 7))
+    assert.is_nil(thread_index.get_line_state(index, "lua/a.lua", nil))
+    assert.is_nil(thread_index.get_line_state(index, "lua/a.lua", 7, "LEFT"))
+    assert.is_nil(thread_index.get_comment_line_state(nil, "lua/a.lua", 7))
+    assert.is_nil(thread_index.get_comment_line_state(index, nil, 7))
+    assert.is_nil(thread_index.get_comment_line_state(index, "lua/a.lua", nil))
+    assert.is_nil(thread_index.get_comment_line_state(index, "lua/a.lua", 7, "RIGHT"))
+  end)
+
   it("uses original_line and position when line is missing", function()
     local original_line_comment = review_comment({
       id = 11,


### PR DESCRIPTION
## Summary
- Render flat PR review files as read-only full-file split diff buffers with old/new side metadata, wrapping, syntax projection caps, and inline character highlights.
- Resolve comment targets from split row metadata, including LEFT-side comments, side-local badges, file-level fallback for out-of-hunk rows, and validation retry for rejected LEFT anchors.
- Reuse shared inline character diff spans in stacked commit and local commit viewers without changing their layout.
- Add ARCHITECTURE_DIFF.md with diagrams for split rendering and comment submission.

## Test Plan
- [x] make lint
- [x] make test
- [x] git diff --check HEAD~1..HEAD