### PR TITLE
Fix split-buffer side-aware comments and navigation

### DIFF
--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,53 +1,33 @@
 # Architecture Diff
 
 ## Summary
-Flat PR review now renders a read-only full-file split diff buffer with side-aware row metadata for comments and navigation.
+Split diff comments and navigation now resolve semantic targets by path, line, and side before moving the cursor or validating a new thread.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    A[PR file metadata] --> B[diff.parse_patch]
-    C[PR checkout file] --> D[new-side lines]
-    B --> E[old-side reconstruction]
-    D --> E
-    E --> F[split semantic rows]
-    D --> F
-    F --> G[wrapped display rows]
-    G --> H[split scratch buffer]
-    G --> I[row metadata]
-    I --> J[cursor target resolver]
-    J --> K[comment editor]
-```
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Buffer as Split Diff Buffer
-    participant Comments
-    participant Diff as diff.resolve_cursor_target
-    participant GitHub
-
-    User->>Buffer: Place cursor on old or new side
-    User->>Comments: Start comment
-    Comments->>Diff: Resolve path, line, side, context
-    Diff-->>Comments: Target metadata
-    Comments->>GitHub: Create review comment
-    alt LEFT line rejected by GitHub validation
-        Comments->>GitHub: Retry as file-level comment
-    end
+    A[Review target<br/>{path, line, side}] --> B[diff.find_split_row]
+    C[Rendered split rows<br/>old_line/new_line + continuation flags] --> B
+    B --> D[Rendered row]
+    B --> E[Side content column]
+    D --> F[Cursor jump]
+    E --> F
+    A --> G[New-thread validation]
+    G --> H{side}
+    H -->|RIGHT| I[Check checkout line bounds]
+    H -->|LEFT| J[Skip checkout bounds]
 ```
 
 ## Changes
 
 ### Added
-- `lua/raccoon/diff.lua`: split diff model, full-file row alignment, wrapping, metadata attachment, cursor target resolution, inline span helper, and Tree-sitter projection caps.
-- `ARCHITECTURE_DIFF.md`: documents the rendering and comment submission flow.
+- `diff.find_split_row(rendered, target)`: shared semantic-to-rendered split row lookup for `LEFT` old-side and `RIGHT` new-side targets.
 
 ### Modified
-- `lua/raccoon/comments.lua`: resolves comment targets from split row metadata, renders side-local badges, submits `LEFT` comments, and falls back to file-level comments on GitHub validation failures.
-- `lua/raccoon/commit_ui.lua`: reuses shared inline character spans for stacked commit and local commit diff buffers.
-- `lua/raccoon/init.lua`: adds split change and inline highlight groups.
+- `comments`: validates new threads with side-aware bounds, stores/restores draft side, and jumps to review threads using `thread.side`.
+- `thread_index`: persists each review thread's root-comment side, defaulting to `RIGHT`.
+- `keymaps`: carries side on diff/comment points and resolves current split-buffer destinations through rendered metadata.
 
 ### Removed
-- The flat review path no longer opens the PR checkout file directly as the primary review surface.
+- Duplicate private split-row lookup logic from comment navigation.

--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,33 +1,45 @@
 # Architecture Diff
 
 ## Summary
-Split diff comments and navigation now resolve semantic targets by path, line, and side before moving the cursor or validating a new thread.
+Combined diff/comment navigation now uses side-aware diff change points, and split inline range highlights are layered above syntax and full-line diff highlights.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    A[Review target<br/>{path, line, side}] --> B[diff.find_split_row]
-    C[Rendered split rows<br/>old_line/new_line + continuation flags] --> B
-    B --> D[Rendered row]
-    B --> E[Side content column]
-    D --> F[Cursor jump]
-    E --> F
-    A --> G[New-thread validation]
-    G --> H{side}
-    H -->|RIGHT| I[Check checkout line bounds]
-    H -->|LEFT| J[Skip checkout bounds]
+    subgraph Navigation
+        A[Unified patch] --> B[diff.parse_patch]
+        B --> C[diff.get_change_points]
+        C --> D{Change block}
+        D -->|Add or replacement| E[RIGHT new line]
+        D -->|Delete only| F[LEFT old line]
+        E --> G[keymaps get_file_points]
+        F --> G
+        H[Thread index comments] --> G
+        G --> I[Sorted combined points]
+        I --> J[diff.find_split_row]
+        J --> K[Rendered row and side column]
+    end
+
+    subgraph HighlightLayering
+        L[Split rows] --> M[Full-line diff extmarks priority 90]
+        L --> N[Syntax projection priority 110]
+        L --> O[Inline add/delete ranges priority 200]
+        M --> P[apply_split_render]
+        N --> P
+        O --> P
+    end
 ```
 
 ## Changes
 
 ### Added
-- `diff.find_split_row(rendered, target)`: shared semantic-to-rendered split row lookup for `LEFT` old-side and `RIGHT` new-side targets.
+- `diff.get_change_points(patch)`: returns one `{ line, side, type = "diff" }` point per contiguous add/delete block.
+- Split range highlight priorities for syntax and inline diff entries.
 
 ### Modified
-- `comments`: validates new threads with side-aware bounds, stores/restores draft side, and jumps to review threads using `thread.side`.
-- `thread_index`: persists each review thread's root-comment side, defaulting to `RIGHT`.
-- `keymaps`: carries side on diff/comment points and resolves current split-buffer destinations through rendered metadata.
+- `keymaps`: uses `diff.get_change_points()` for diff navigation while preserving side-aware comment navigation.
+- `diff.apply_split_render()`: applies range highlights with extmarks so priority is explicit.
 
 ### Removed
-- Duplicate private split-row lookup logic from comment navigation.
+- Mixed old/new changed-line grouping from combined point navigation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.14.0] - 2026-06-10
+
+### Fixed
+- Combined diff/comment navigation now lands replacement hunks on the right-side changed row instead of the paired left-side deletion row.
+- Split diff inline add/delete character highlights now use higher-priority range extmarks so they remain visible over syntax and full-line diff highlights.
+
+### Added
+- Internal `diff.get_change_points(patch)` helper for side-aware first-change navigation points per contiguous diff block.
+
 ## [0.13.0] - 2026-05-23
 
 ### Added

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -688,8 +688,10 @@ end
 
 ---@param path string
 ---@param line number
+---@param side? string
 ---@return string|nil
-local function new_thread_disable_reason(path, line)
+local function new_thread_disable_reason(path, line, side)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
   if line == nil then
     return find_pr_file(path) and nil or file_outside_pr_changes_message()
   end
@@ -701,9 +703,11 @@ local function new_thread_disable_reason(path, line)
     return file_outside_pr_changes_message()
   end
 
-  local line_count = checkout_line_count(path)
-  if line_count and line > line_count then
-    return line_outside_file_bounds_message()
+  if side == "RIGHT" then
+    local line_count = checkout_line_count(path)
+    if line_count and line > line_count then
+      return line_outside_file_bounds_message()
+    end
   end
 
   return nil
@@ -732,12 +736,12 @@ local function send_new_thread(path, line, side, in_diff_context)
     vim.notify("Empty thread", vim.log.levels.WARN)
     return
   end
-  local disable_reason = new_thread_disable_reason(path, line)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
   if disable_reason then
     vim.notify(disable_reason, vim.log.levels.WARN)
     return
   end
-  side = side == "LEFT" and "LEFT" or "RIGHT"
   local line_commentable = in_diff_context
   if line_commentable == nil then
     line_commentable = is_line_commentable(path, line, side)
@@ -794,13 +798,14 @@ end
 ---@param prefill_lines string[]
 ---@return boolean
 local function open_new_thread_from_line(path, line, prefill_lines, target)
-  local disable_reason = new_thread_disable_reason(path, line)
+  local side = target and target.side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
   if disable_reason then
     vim.notify(disable_reason, vim.log.levels.WARN)
     return false
   end
   open_new_thread_editor(path, line, prefill_lines or {}, {
-    side = target and target.side,
+    side = side,
     in_diff_context = target and target.in_diff_context,
   })
   return true
@@ -978,24 +983,10 @@ end
 
 local function split_row_for_line(buf, path, line, side)
   local rendered = diff.get_split_metadata(buf)
-  if not rendered then
-    return nil
-  end
-  side = side == "LEFT" and "LEFT" or "RIGHT"
-  for idx, row in ipairs(rendered.rows or {}) do
-    if row.path == path then
-      if side == "LEFT" and row.old_line == line and not row.left_continuation then
-        return idx, rendered.left_range.content_start_col
-      end
-      if side == "RIGHT" and row.new_line == line and not row.right_continuation then
-        return idx, rendered.right_range.content_start_col
-      end
-    end
-  end
-  return nil
+  return diff.find_split_row(rendered, { path = path, line = line, side = side })
 end
 
-local function jump_to_path_and_line(path, line)
+local function jump_to_path_and_line(path, line, side)
   local files = state.get_files()
   local target_file = nil
   local target_index = nil
@@ -1015,7 +1006,7 @@ local function jump_to_path_and_line(path, line)
     M.show_comments(buf, state.get_comments(path))
   end
   if line then
-    local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, "RIGHT")
+    local rendered_row, rendered_col = split_row_for_line(vim.api.nvim_get_current_buf(), path, line, side)
     local line_count = vim.api.nvim_buf_line_count(0)
     vim.api.nvim_win_set_cursor(0, { math.max(1, math.min(rendered_row or line, line_count)), rendered_col or 0 })
     vim.cmd("normal! zz")
@@ -1033,7 +1024,7 @@ function M.jump_to_thread(thread_id, opts)
     return false
   end
   state.set_selected_thread_id(thread.thread_id)
-  if not jump_to_path_and_line(thread.path, thread.line) then
+  if not jump_to_path_and_line(thread.path, thread.line, thread.side) then
     return false
   end
   if opts and opts.open_window then
@@ -1084,7 +1075,7 @@ local function jump_to_file_target(path)
     end
   end
   if first_issue_line then
-    return jump_to_path_and_line(path, first_issue_line)
+    return jump_to_path_and_line(path, first_issue_line, "RIGHT")
   end
   local file = nil
   for _, entry in ipairs(state.get_files()) do
@@ -1094,7 +1085,7 @@ local function jump_to_file_target(path)
     end
   end
   local changed_line = first_changed_line(file)
-  return jump_to_path_and_line(path, changed_line or 1)
+  return jump_to_path_and_line(path, changed_line or 1, "RIGHT")
 end
 
 function M.jump_to_file(path)
@@ -1257,13 +1248,8 @@ end
 
 local function restore_new_thread_snapshot(snapshot)
   local disable_reason = nil
-  if not find_pr_file(snapshot.path) then
+  if new_thread_disable_reason(snapshot.path, snapshot.line, snapshot.side) then
     disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
-  else
-    local line_count = checkout_line_count(snapshot.path)
-    if line_count and snapshot.line and snapshot.line > line_count then
-      disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
-    end
   end
   open_new_thread_editor(
     snapshot.path,
@@ -1611,7 +1597,7 @@ local function issue_prefill_lines(issue_comments)
   return lines
 end
 
-local function open_same_line_picker(path, line, line_state)
+local function open_same_line_picker(path, line, line_state, target)
   local thread_rows = {}
   local selected_thread_id = state.get_selected_thread_id()
   local selected = 1
@@ -1648,7 +1634,7 @@ local function open_same_line_picker(path, line, line_state)
       key = "new_thread:" .. path .. ":" .. tostring(line),
       text = "[NEW] New thread on this line",
       on_select = function()
-        open_new_thread_editor(path, line, {})
+        open_new_thread_from_line(path, line, {}, target)
       end,
     })
   end
@@ -1683,7 +1669,7 @@ function M.show_comment_thread()
     return
   end
   if #line_state.threads > 0 then
-    open_same_line_picker(path, line, line_state)
+    open_same_line_picker(path, line, line_state, target)
     return
   end
   open_new_thread_from_line(path, line, issue_prefill_lines(line_state.issue_comments), target)

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -110,7 +110,12 @@ function M.parse_patch(patch)
           line_num = line_num,
           old_line = old_line_num,
         })
-        table.insert(current_hunk.changes, { type = "del", line_num = line_num, content = line:sub(2) })
+        table.insert(current_hunk.changes, {
+          type = "del",
+          line_num = line_num,
+          old_line = old_line_num,
+          content = line:sub(2),
+        })
         old_line_num = old_line_num + 1
       elseif not line:match("^\\ No newline at end of file$") and (line:match("^%s") or line == "") then
         -- Context line
@@ -148,7 +153,11 @@ function M.get_changed_lines(patch)
         table.insert(changes.added, change.line_num)
       elseif change.type == "del" then
         -- For deleted lines, we track the line after which they were deleted + content
-        table.insert(changes.deleted, { line_num = change.line_num, content = change.content })
+        table.insert(changes.deleted, {
+          line_num = change.line_num,
+          old_line = change.old_line,
+          content = change.content,
+        })
       end
     end
   end
@@ -881,17 +890,23 @@ local function resolve_active_target(buf)
   return M.resolve_cursor_target(buf, cursor[1], cursor[2])
 end
 
-local function find_rendered_row(rendered, target)
+--- Resolve a semantic split target to its rendered row and side content column.
+---@param rendered table|nil rendered split metadata
+---@param target table|nil {path:string, line:number, side:string}
+---@return number|nil row 1-based rendered row
+---@return number|nil col 0-based side content column
+function M.find_split_row(rendered, target)
   if not rendered or not target then
     return nil
   end
+  local side = target.side == "LEFT" and "LEFT" or "RIGHT"
   for idx, row in ipairs(rendered.rows or {}) do
     if row.path == target.path then
-      if target.side == "LEFT" and row.old_line == target.line and not row.left_continuation then
-        return idx
+      if side == "LEFT" and row.old_line == target.line and not row.left_continuation then
+        return idx, rendered.left_range and rendered.left_range.content_start_col or 0
       end
-      if target.side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
-        return idx
+      if side == "RIGHT" and row.new_line == target.line and not row.right_continuation then
+        return idx, rendered.right_range and rendered.right_range.content_start_col or 0
       end
     end
   end
@@ -903,11 +918,10 @@ local function restore_target_cursor(buf, rendered, target)
   if win == -1 or not target then
     return
   end
-  local row = find_rendered_row(rendered, target)
+  local row, col = M.find_split_row(rendered, target)
   if not row then
     return
   end
-  local col = target.side == "LEFT" and rendered.left_range.content_start_col or rendered.right_range.content_start_col
   pcall(vim.api.nvim_win_set_cursor, win, { row, col })
 end
 

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -11,6 +11,9 @@ M.MAX_SYNTAX_ROWS = 5000
 M.MAX_SYNTAX_SIDE_BYTES = 500 * 1024
 M.MAX_INLINE_DIFF_DISPLAY_CHARS = 1000
 
+local LINE_HIGHLIGHT_PRIORITY = 90
+local SYNTAX_HIGHLIGHT_PRIORITY = 110
+local INLINE_HIGHLIGHT_PRIORITY = 200
 local SPLIT_SEPARATOR = " │ "
 local split_metadata_by_buf = {}
 
@@ -163,6 +166,51 @@ function M.get_changed_lines(patch)
   end
 
   return changes
+end
+
+--- Get first navigable changed point for each contiguous add/delete block.
+---@param patch string The patch content
+---@return table[] points Array of {line, side, type = "diff"}
+function M.get_change_points(patch)
+  local points = {}
+  local hunks = M.parse_patch(patch)
+
+  for _, hunk in ipairs(hunks) do
+    local idx = 1
+    while idx <= #hunk.lines do
+      local line_data = hunk.lines[idx]
+      if line_data.type == "add" or line_data.type == "del" then
+        local first_add = nil
+        local first_del = nil
+        while idx <= #hunk.lines and (hunk.lines[idx].type == "add" or hunk.lines[idx].type == "del") do
+          if hunk.lines[idx].type == "add" and not first_add then
+            first_add = hunk.lines[idx]
+          elseif hunk.lines[idx].type == "del" and not first_del then
+            first_del = hunk.lines[idx]
+          end
+          idx = idx + 1
+        end
+
+        if first_add and (first_add.new_line or first_add.line_num) then
+          table.insert(points, {
+            line = first_add.new_line or first_add.line_num,
+            side = "RIGHT",
+            type = "diff",
+          })
+        elseif first_del and (first_del.old_line or first_del.line_num) then
+          table.insert(points, {
+            line = first_del.old_line or math.max(1, first_del.line_num),
+            side = "LEFT",
+            type = "diff",
+          })
+        end
+      else
+        idx = idx + 1
+      end
+    end
+  end
+
+  return points
 end
 
 --- Check whether a file line is in GitHub PR review diff context.
@@ -558,6 +606,7 @@ local function collect_syntax_highlights_for_side(lang, source_lines, line_map, 
             start_col = content_start_col + start_col,
             end_col = content_start_col + math.min(end_col, content_width),
             hl = "@" .. capture,
+            priority = SYNTAX_HIGHLIGHT_PRIORITY,
           })
         end
       end
@@ -635,6 +684,7 @@ function M.render_split_file(opts)
   local lines = {}
   local rows = {}
   local highlights = {}
+  local inline_highlights = {}
 
   local function append_rendered_row(row)
     local left_chunks = split_to_display_width(row.old_content or "", layout.content_width)
@@ -670,26 +720,32 @@ function M.render_split_file(opts)
       table.insert(rows, rendered_row)
       local hl = line_highlight(row.kind)
       if hl then
-        table.insert(highlights, { line = #lines - 1, line_hl_group = hl })
+        table.insert(highlights, {
+          line = #lines - 1,
+          line_hl_group = hl,
+          priority = LINE_HIGHLIGHT_PRIORITY,
+        })
       end
     end
 
     if row.kind == "change" and first_line == #lines then
       local old_span, new_span = changed_span(row.old_content or "", row.new_content or "")
       if old_span then
-        table.insert(highlights, {
+        table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.left_range.content_start_col + old_span.start_col,
           end_col = layout.left_range.content_start_col + old_span.end_col,
           hl = "RaccoonInlineDelete",
+          priority = INLINE_HIGHLIGHT_PRIORITY,
         })
       end
       if new_span then
-        table.insert(highlights, {
+        table.insert(inline_highlights, {
           line = first_line - 1,
           start_col = layout.right_range.content_start_col + new_span.start_col,
           end_col = layout.right_range.content_start_col + new_span.end_col,
           hl = "RaccoonInlineAdd",
+          priority = INLINE_HIGHLIGHT_PRIORITY,
         })
       end
     end
@@ -751,6 +807,9 @@ function M.render_split_file(opts)
       rendered.syntax_enabled = false
       rendered.syntax_skip_reason = "no parser"
     end
+  end
+  for _, hl in ipairs(inline_highlights) do
+    table.insert(rendered.highlights, hl)
   end
   return rendered
 end
@@ -829,9 +888,14 @@ function M.apply_split_render(buf, rendered)
     if hl.line_hl_group then
       pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, hl.line, 0, {
         line_hl_group = hl.line_hl_group,
+        priority = hl.priority or LINE_HIGHLIGHT_PRIORITY,
       })
     elseif hl.start_col and hl.end_col and hl.end_col > hl.start_col then
-      pcall(vim.api.nvim_buf_add_highlight, buf, ns_id, hl.hl, hl.line, hl.start_col, hl.end_col)
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, hl.line, hl.start_col, {
+        end_col = hl.end_col,
+        hl_group = hl.hl,
+        priority = hl.priority or SYNTAX_HIGHLIGHT_PRIORITY,
+      })
     end
   end
   M.attach_split_metadata(buf, rendered)

--- a/lua/raccoon/keymaps.lua
+++ b/lua/raccoon/keymaps.lua
@@ -38,9 +38,13 @@ local function build_thread_index()
   return index
 end
 
+local function point_key(line, side)
+  return (side or "RIGHT") .. ":" .. tostring(line)
+end
+
 --- Get all points of interest (diffs and comments) for a file
 ---@param file table File data with filename and patch
----@return table[] points Sorted list of {line, type} where type is "diff" or "comment"
+---@return table[] points Sorted list of {line, side, type} where type is "diff" or "comment"
 local function get_file_points(file)
   if not file then return {} end
 
@@ -54,40 +58,64 @@ local function get_file_points(file)
     -- Group consecutive changed lines into hunks
     local all_lines = {}
     for _, line in ipairs(changes.added) do
-      table.insert(all_lines, line)
+      table.insert(all_lines, { line = line, side = "RIGHT" })
     end
     for _, del in ipairs(changes.deleted) do
-      if del.line_num then
-        table.insert(all_lines, math.max(1, del.line_num))
+      local line = del.old_line or del.line_num
+      if line then
+        table.insert(all_lines, { line = math.max(1, line), side = "LEFT" })
       end
     end
-    table.sort(all_lines)
+    table.sort(all_lines, function(a, b)
+      if a.line ~= b.line then
+        return a.line < b.line
+      end
+      return a.side < b.side
+    end)
 
     -- Get hunk start lines (first line of consecutive groups)
     local prev_line = nil
-    for _, line in ipairs(all_lines) do
-      if prev_line == nil or line > prev_line + 1 then
-        if not seen[line] then
-          table.insert(points, { line = line, type = "diff" })
-          seen[line] = true
+    for _, target in ipairs(all_lines) do
+      if prev_line == nil or target.line > prev_line + 1 then
+        local key = point_key(target.line, target.side)
+        if not seen[key] then
+          table.insert(points, { line = target.line, side = target.side, type = "diff" })
+          seen[key] = true
         end
       end
-      prev_line = line
+      prev_line = target.line
     end
   end
 
   -- Get comments
   local index = build_thread_index()
   local line_map = index and index.line_state_by_file[file.filename] or {}
-  for line in pairs(line_map) do
-    if line and not seen[line] then
-      table.insert(points, { line = line, type = "comment" })
-      seen[line] = true
+  for line, bucket in pairs(line_map) do
+    if line then
+      local sides = {}
+      for _, thread in ipairs(bucket.threads or {}) do
+        sides[thread.side == "LEFT" and "LEFT" or "RIGHT"] = true
+      end
+      if #(bucket.issue_comments or {}) > 0 then
+        sides.RIGHT = true
+      end
+      for side in pairs(sides) do
+        local key = point_key(line, side)
+        if not seen[key] then
+          table.insert(points, { line = line, side = side, type = "comment" })
+          seen[key] = true
+        end
+      end
     end
   end
 
   -- Sort by line number
-  table.sort(points, function(a, b) return a.line < b.line end)
+  table.sort(points, function(a, b)
+    if a.line ~= b.line then
+      return a.line < b.line
+    end
+    return (a.side or "RIGHT") < (b.side or "RIGHT")
+  end)
 
   return points
 end
@@ -105,6 +133,7 @@ local function get_all_points()
         file_index = file_idx,
         file = file,
         line = point.line,
+        side = point.side,
         type = point.type,
       })
     end
@@ -113,8 +142,25 @@ local function get_all_points()
   return all_points
 end
 
+local function split_position_for_point(point)
+  local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+  if not rendered then
+    return nil
+  end
+  return diff.find_split_row(rendered, {
+    path = point.file and point.file.filename,
+    line = point.line,
+    side = point.side,
+  })
+end
+
+local function rendered_line_for_current_point(point)
+  local row = split_position_for_point(point)
+  return row or point.line
+end
+
 --- Navigate to a point (opens file if needed)
----@param point table {file_index, file, line, type}
+---@param point table {file_index, file, line, side, type}
 local function goto_point(point)
   local current_file_idx = state.get_current_file_index()
 
@@ -133,15 +179,16 @@ local function goto_point(point)
 
   -- Go to line (clamped to valid range to prevent "cursor position outside buffer" errors)
   local line_count = vim.api.nvim_buf_line_count(0)
-  local target_line = math.max(1, math.min(point.line, line_count))
-  vim.api.nvim_win_set_cursor(0, { target_line, 0 })
+  local rendered_row, rendered_col = split_position_for_point(point)
+  local target_line = math.max(1, math.min(rendered_row or point.line, line_count))
+  vim.api.nvim_win_set_cursor(0, { target_line, rendered_col or 0 })
   vim.cmd("normal! zz")
 
   -- Show what we landed on with position in file
   local file_points = get_file_points(point.file)
   local point_idx = 1
   for i, p in ipairs(file_points) do
-    if p.line == point.line then
+    if p.line == point.line and (p.side or "RIGHT") == (point.side or "RIGHT") then
       point_idx = i
       break
     end
@@ -169,8 +216,12 @@ function M.next_point()
 
   -- Find next point after current position
   for _, point in ipairs(all_points) do
+    local point_line = point.line
+    if point.file_index == current_file_idx then
+      point_line = rendered_line_for_current_point(point)
+    end
     if point.file_index > current_file_idx or
-       (point.file_index == current_file_idx and point.line > current_line) then
+       (point.file_index == current_file_idx and point_line > current_line) then
       goto_point(point)
       return
     end
@@ -199,8 +250,12 @@ function M.prev_point()
   -- Find previous point before current position (iterate in reverse)
   for i = #all_points, 1, -1 do
     local point = all_points[i]
+    local point_line = point.line
+    if point.file_index == current_file_idx then
+      point_line = rendered_line_for_current_point(point)
+    end
     if point.file_index < current_file_idx or
-       (point.file_index == current_file_idx and point.line < current_line) then
+       (point.file_index == current_file_idx and point_line < current_line) then
       goto_point(point)
       return
     end

--- a/lua/raccoon/keymaps.lua
+++ b/lua/raccoon/keymaps.lua
@@ -53,37 +53,12 @@ local function get_file_points(file)
 
   -- Get diff hunks
   if file.patch then
-    local changes = diff.get_changed_lines(file.patch)
-
-    -- Group consecutive changed lines into hunks
-    local all_lines = {}
-    for _, line in ipairs(changes.added) do
-      table.insert(all_lines, { line = line, side = "RIGHT" })
-    end
-    for _, del in ipairs(changes.deleted) do
-      local line = del.old_line or del.line_num
-      if line then
-        table.insert(all_lines, { line = math.max(1, line), side = "LEFT" })
+    for _, target in ipairs(diff.get_change_points(file.patch)) do
+      local key = point_key(target.line, target.side)
+      if not seen[key] then
+        table.insert(points, target)
+        seen[key] = true
       end
-    end
-    table.sort(all_lines, function(a, b)
-      if a.line ~= b.line then
-        return a.line < b.line
-      end
-      return a.side < b.side
-    end)
-
-    -- Get hunk start lines (first line of consecutive groups)
-    local prev_line = nil
-    for _, target in ipairs(all_lines) do
-      if prev_line == nil or target.line > prev_line + 1 then
-        local key = point_key(target.line, target.side)
-        if not seen[key] then
-          table.insert(points, { line = target.line, side = target.side, type = "diff" })
-          seen[key] = true
-        end
-      end
-      prev_line = target.line
     end
   end
 

--- a/lua/raccoon/thread_index.lua
+++ b/lua/raccoon/thread_index.lua
@@ -164,6 +164,7 @@ function M.build()
               path = path,
               file_index = file_index_by_path[path] or math.huge,
               line = M.get_comment_line(comment),
+              side = "RIGHT",
               resolved = comment.resolved == true,
               root_comment_id = nil,
               is_file_level = comment.subject_type == "file",
@@ -192,6 +193,7 @@ function M.build()
 
           if normalize_nil(comment.in_reply_to_id) == nil and is_real_number(comment.id) then
             thread.root_comment_id = comment.id
+            thread.side = comment.side == "LEFT" and "LEFT" or "RIGHT"
           end
         end
       end

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -43,6 +43,12 @@ local function make_file_buffer(path, line_count)
   return buf
 end
 
+local function write_checkout_file(path, lines)
+  local full_path = vim.fs.joinpath(CLONE_PATH, path)
+  vim.fn.mkdir(vim.fs.dirname(full_path), "p")
+  vim.fn.writefile(lines, full_path)
+end
+
 local function make_split_buffer(opts)
   local rendered = diff.render_split_file({
     path = opts.path or "lua/a.lua",
@@ -185,6 +191,7 @@ describe("raccoon.comments UI state restore", function()
   local baseline_buffers
 
   before_each(function()
+    vim.fn.delete(CLONE_PATH, "rf")
     baseline_buffers = {}
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       baseline_buffers[buf] = true
@@ -207,6 +214,7 @@ describe("raccoon.comments UI state restore", function()
         pcall(vim.api.nvim_buf_delete, buf, { force = true })
       end
     end
+    vim.fn.delete(CLONE_PATH, "rf")
   end)
 
   it("captures and restores unresolved-thread picker selection", function()
@@ -587,6 +595,75 @@ describe("raccoon.comments UI state restore", function()
     assert.is_true(sync_called)
   end)
 
+  it("sends split left-side tail deletion comments with old line beyond checkout bounds", function()
+    local original_notify = vim.notify
+    local original_config_load = config.load
+    local original_get_token_entry = config.get_token_entry
+    local original_api_init = api.init
+    local original_create_comment = api.create_comment
+    local original_sync = open.sync
+
+    local captured_opts
+    local sync_called = false
+
+    vim.notify = function() end
+    config.load = function()
+      return {
+        github_host = "github.com",
+        tokens = { owner = "ghp_fake" },
+      }, nil
+    end
+    config.get_token_entry = function()
+      return { token = "ghp_fake" }
+    end
+    api.init = function() end
+    api.create_comment = function(_owner, _repo, _number, opts, _token, callback)
+      captured_opts = opts
+      callback({ id = 59 }, nil)
+    end
+    open.sync = function()
+      sync_called = true
+    end
+
+    local patch = "@@ -1,5 +1,3 @@\n line 1\n line 2\n line 3\n-line 4\n-line 5"
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = patch,
+      },
+    })
+    write_checkout_file("lua/a.lua", { "line 1", "line 2", "line 3" })
+    make_split_buffer({
+      old_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" },
+      new_lines = { "line 1", "line 2", "line 3" },
+      patch = patch,
+    })
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    vim.api.nvim_win_set_cursor(0, { 5, rendered.left_range.content_start_col })
+    comments.show_comment_thread()
+
+    local editor_buf = vim.api.nvim_get_current_buf()
+    local line_count = vim.api.nvim_buf_line_count(editor_buf)
+    vim.api.nvim_buf_set_lines(editor_buf, line_count - 1, line_count, false, { "old tail body" })
+    vim.cmd("stopinsert")
+    trigger_buffer_mapping(editor_buf, "n", " s")
+    vim.wait(1000, function()
+      return sync_called
+    end, 10)
+
+    vim.notify = original_notify
+    config.load = original_config_load
+    config.get_token_entry = original_get_token_entry
+    api.init = original_api_init
+    api.create_comment = original_create_comment
+    open.sync = original_sync
+
+    assert.equals("lua/a.lua", captured_opts.path)
+    assert.equals(5, captured_opts.line)
+    assert.equals("LEFT", captured_opts.side)
+    assert.is_true(sync_called)
+  end)
+
   it("retries rejected split left-side line comments as file-level comments", function()
     local original_notify = vim.notify
     local original_config_load = config.load
@@ -724,6 +801,41 @@ describe("raccoon.comments UI state restore", function()
     assert.equals("file", captured_opts.subject_type)
     assert.is_nil(captured_opts.line)
     assert.is_true(sync_called)
+  end)
+
+  it("jumps to the left rendered row and column for LEFT threads", function()
+    local patch = "@@ -1,5 +1,5 @@\n line 1\n+inserted\n line 2\n line 3\n-old deleted\n line 5"
+    state.set_files({
+      {
+        filename = "lua/a.lua",
+        patch = patch,
+      },
+    })
+    state.set_comments("lua/a.lua", {
+      review_comment({
+        id = 60,
+        thread_id = "thread-left",
+        line = 4,
+        side = "LEFT",
+        body = "left deleted thread",
+      }),
+    })
+    write_checkout_file("lua/a.lua", { "line 1", "inserted", "line 2", "line 3", "line 5" })
+
+    assert.is_true(comments.jump_to_thread("thread-left", {}))
+
+    local rendered = diff.get_split_metadata(vim.api.nvim_get_current_buf())
+    local expected_row
+    for idx, row in ipairs(rendered.rows or {}) do
+      if row.path == "lua/a.lua" and row.old_line == 4 and not row.left_continuation then
+        expected_row = idx
+        break
+      end
+    end
+    local cursor = vim.api.nvim_win_get_cursor(0)
+
+    assert.equals(expected_row, cursor[1])
+    assert.equals(rendered.left_range.content_start_col, cursor[2])
   end)
 
   it("restores a thread reply draft and disables send when the thread becomes resolved", function()

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -623,6 +623,66 @@ describe("raccoon.diff", function()
     end)
   end)
 
+  describe("find_split_row", function()
+    it("finds LEFT old-only deletion rows", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "two", "three" },
+        new_lines = { "one", "three" },
+        patch = "@@ -1,3 +1,2 @@\n one\n-two\n three",
+        width = 80,
+      })
+
+      local row, col = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "LEFT",
+      })
+
+      assert.equals(2, row)
+      assert.equals(rendered.left_range.content_start_col, col)
+    end)
+
+    it("finds RIGHT rows after a prior deletion", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "one", "two", "three" },
+        new_lines = { "one", "three" },
+        patch = "@@ -1,3 +1,2 @@\n one\n-two\n three",
+        width = 80,
+      })
+
+      local row, col = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "RIGHT",
+      })
+
+      assert.equals(3, row)
+      assert.equals(rendered.right_range.content_start_col, col)
+    end)
+
+    it("ignores continuation rows for wrapped split lines", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old " .. string.rep("x", 24), "after" },
+        new_lines = { "before", "new " .. string.rep("y", 24), "after" },
+        patch = "@@ -1,3 +1,3 @@\n before\n-old xxxxxxxxxxxxxxxxxxxxxxxx\n+new yyyyyyyyyyyyyyyyyyyyyyyy\n after",
+        width = 42,
+      })
+
+      local row = diff.find_split_row(rendered, {
+        path = "lua/a.lua",
+        line = 2,
+        side = "RIGHT",
+      })
+
+      assert.is_not_nil(rendered.rows[row + 1])
+      assert.is_false(rendered.rows[row].right_continuation)
+      assert.is_true(rendered.rows[row + 1].right_continuation)
+    end)
+  end)
+
   describe("resolve_cursor_target", function()
     it("uses cursor column to choose left or right side", function()
       local buf = vim.api.nvim_create_buf(false, true)

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -192,6 +192,66 @@ describe("raccoon.diff", function()
     end)
   end)
 
+  describe("get_change_points", function()
+    it("returns the first right-side line for replacement blocks", function()
+      local patch = [[
+@@ -10,3 +10,3 @@
+ line 10
+-old value
++new value
+ line 12]]
+
+      assert.same({
+        { line = 11, side = "RIGHT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns the first right-side line for add-only blocks", function()
+      local patch = [[
+@@ -3,2 +3,4 @@
+ line 3
++line 4
++line 5
+ line 6]]
+
+      assert.same({
+        { line = 4, side = "RIGHT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns the first left-side line for delete-only blocks", function()
+      local patch = [[
+@@ -3,4 +3,2 @@
+ line 3
+-old line 4
+-old line 5
+ line 6]]
+
+      assert.same({
+        { line = 4, side = "LEFT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+
+    it("returns each separated change block in rendered order", function()
+      local patch = [[
+@@ -1,7 +1,8 @@
+ shared one
+-old value
++new value
+ shared two
++added value
+ shared three
+-removed value
+ shared four]]
+
+      assert.same({
+        { line = 2, side = "RIGHT", type = "diff" },
+        { line = 4, side = "RIGHT", type = "diff" },
+        { line = 5, side = "LEFT", type = "diff" },
+      }, diff.get_change_points(patch))
+    end)
+  end)
+
   describe("navigation", function()
     local original_notify
 
@@ -620,6 +680,43 @@ describe("raccoon.diff", function()
 
       assert.is_false(rendered.syntax_enabled)
       assert.equals("row cap", rendered.syntax_skip_reason)
+    end)
+
+    it("applies inline split range highlights above syntax and line overlays", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "local value = 1" },
+        new_lines = { "local value = 42" },
+        patch = "@@ -1 +1 @@\n-local value = 1\n+local value = 42",
+        width = 80,
+      })
+      table.insert(rendered.highlights, {
+        line = 0,
+        start_col = rendered.right_range.content_start_col,
+        end_col = rendered.right_range.content_start_col + 5,
+        hl = "@keyword",
+        priority = 110,
+      })
+
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+
+      local inline_priority
+      local syntax_priority
+      for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(buf, diff.get_namespace(), 0, -1, { details = true })) do
+        local details = mark[4] or {}
+        if details.hl_group == "RaccoonInlineAdd" or details.hl_group == "RaccoonInlineDelete" then
+          inline_priority = math.max(inline_priority or 0, details.priority or 0)
+        elseif details.hl_group == "@keyword" then
+          syntax_priority = details.priority or 0
+        end
+      end
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+
+      assert.is_number(inline_priority)
+      assert.is_number(syntax_priority)
+      assert.is_true(inline_priority > syntax_priority)
     end)
   end)
 

--- a/tests/keymaps_spec.lua
+++ b/tests/keymaps_spec.lua
@@ -188,6 +188,57 @@ describe("raccoon.keymaps", function()
       -- Should not error (just warns via ui module)
       keymaps.show_description()
     end)
+
+    it("next_point resolves current-file split destinations through rendered rows", function()
+      local diff = require("raccoon.diff")
+      local patch = "@@ -1,5 +1,4 @@\n line 1\n-line 2\n line 3\n line 4\n line 5"
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = patch,
+        },
+      })
+      state.set_comments("lua/a.lua", {
+        {
+          id = 1000,
+          body = "later comment",
+          thread_id = "thread-later",
+          line = 4,
+          side = "RIGHT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-01T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" },
+        new_lines = { "line 1", "line 3", "line 4", "line 5" },
+        patch = patch,
+        width = 80,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 3, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(5, cursor[1])
+      assert.equals(rendered.right_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
   describe("merge_picker", function()

--- a/tests/keymaps_spec.lua
+++ b/tests/keymaps_spec.lua
@@ -239,6 +239,94 @@ describe("raccoon.keymaps", function()
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
+
+    it("next_point lands replacement diffs on the right-side changed row", function()
+      local diff = require("raccoon.diff")
+      local patch = "@@ -1,3 +1,3 @@\n before\n-old value\n+new value\n after"
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = patch,
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old value", "after" },
+        new_lines = { "before", "new value", "after" },
+        patch = patch,
+        width = 90,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(2, cursor[1])
+      assert.equals(rendered.right_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("next_point keeps left-side thread comments on the left side", function()
+      local diff = require("raccoon.diff")
+      state.start({
+        owner = "owner",
+        repo = "repo",
+        number = 1,
+        url = "https://github.com/owner/repo/pull/1",
+        clone_path = "/tmp/raccoon-keymaps",
+      })
+      state.set_files({
+        {
+          filename = "lua/a.lua",
+          patch = "",
+        },
+      })
+      state.set_comments("lua/a.lua", {
+        {
+          id = 2000,
+          body = "left comment",
+          thread_id = "thread-left",
+          line = 2,
+          side = "LEFT",
+          resolved = false,
+          in_reply_to_id = vim.NIL,
+          created_at = "2026-01-01T00:00:00Z",
+          user = { login = "reviewer" },
+        },
+      })
+
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "before", "old value", "after" },
+        new_lines = { "before", "new value", "after" },
+        patch = "",
+        width = 90,
+      })
+      local buf = vim.api.nvim_create_buf(false, true)
+      diff.apply_split_render(buf, rendered)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      keymaps.next_point()
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(2, cursor[1])
+      assert.equals(rendered.left_range.content_start_col, cursor[2])
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
   describe("merge_picker", function()


### PR DESCRIPTION
## Summary
- Add shared split-row lookup from semantic `{path, line, side}` targets to rendered row/column positions.
- Preserve review-thread side for jumps and make new-thread validation skip checkout bounds for LEFT old-side lines.
- Carry side through diff/comment points so keymap navigation lands on rendered split rows.

## Test Plan
- [x] `make test`
- [x] `make lint`