### PR TITLE
fix: align split comment targets and inline spans

### DIFF
--- a/ARCHITECTURE_DIFF.md
+++ b/ARCHITECTURE_DIFF.md
@@ -1,65 +1,43 @@
 # Architecture Diff
 
 ## Summary
-Split diff rendering now uses exact character inline decorations, stable left-column cursor placement, and side-aware comment thread buckets.
+Split diff comments now use one target classification, and inline diff highlights are token-stable and projected onto wrapped rows.
 
 ## Diagram(s)
 
 ```mermaid
 flowchart TD
-    A[Paired delete/add line] --> B[Split into UTF-8 chars with byte columns]
-    B --> C[Trim common prefix and suffix]
-    C --> D[LCS over changed middle]
-    D --> E[Coalesce changed char runs]
-    E --> F[Inline delete spans]
-    E --> G[Inline add spans]
-    F --> H[apply_split_render priority 200]
-    G --> H
-    I[Syntax projection priority 110] --> H
-    J[Full-line diff priority 90] --> H
-```
-
-```mermaid
-sequenceDiagram
-    participant Nav as Navigation
-    participant Diff as diff metadata
-    participant UI as Split buffer cursor
-    participant Comments as Comment action
-
-    Nav->>Diff: find_split_row(path, side, line)
-    Diff-->>Nav: rendered row plus left content column
-    Nav->>Diff: set_split_semantic_target(path, side, line, row)
-    Nav->>UI: place cursor at left content column
-    Comments->>Diff: resolve_cursor_target(row, col)
-    Diff-->>Comments: stored semantic side when cursor is still on row
+    A[Cursor target] --> B[resolve_new_thread_target]
+    B --> C{Target kind}
+    C -->|line| D[New Thread title and line REST comment]
+    C -->|file| E[New File Comment title and file REST comment]
+    C -->|disabled| F[Warn and disable send]
+    D --> G[Picker label]
+    E --> G
+    F --> G
 ```
 
 ```mermaid
 flowchart LR
-    A[GitHub comments] --> B[thread_index.build]
-    B --> C[line_state_by_file aggregate]
-    B --> D[side_line_state_by_file]
-    B --> E[side_comment_line_state_by_file]
-    D --> F[Split badges LEFT old line]
-    D --> G[Split badges RIGHT new line]
-    E --> H[Same-line picker for selected side]
-    I[Line nil placeholder] --> J[File-level new thread editor]
+    A[Paired delete/add row] --> B[UTF-8 char diff]
+    B --> C[Expand heavily changed identifier fragments]
+    C --> D[Inline byte spans]
+    D --> E[Split rendered chunks with byte ranges]
+    E --> F[Project spans onto visible row chunks]
+    F --> G[Neovim extmarks]
 ```
 
 ## Changes
 
 ### Added
-- `diff.left_cursor_col(rendered)` for split cursor placement.
-- `rendered.position_by_key[path|side|line]` for O(1) split row lookup before scan fallback.
-- `diff.set_split_semantic_target()` so right-side navigation can display left while preserving right-side comment semantics.
-- Side-aware thread index maps for split badges and same-line thread pickers.
+- `comments.lua` now resolves new comment targets as `line`, `file`, or `disabled` before labeling, restoring, or sending.
+- Split inline rendering now tracks byte ranges for each wrapped visual chunk.
 
 ### Modified
-- Inline changed-line highlighting now computes exact UTF-8 character add/delete runs with byte columns for Neovim extmarks.
-- Split navigation, thread jumps, file jumps, diff-only jumps, and resize restore now use the left content column.
-- Split comment badge rendering reads LEFT buckets from `old_line` and RIGHT buckets from `new_line`.
-- Same-line thread lookup passes the resolved target side.
+- Out-of-hunk changed-file targets remain allowed, but are consistently labeled and sent as file comments.
+- Identifier replacements with noisy character matches are highlighted as whole changed tokens.
+- Inline split highlights are projected onto continuation rows instead of disappearing when a changed line wraps.
 
 ### Removed
-- One-span prefix/suffix inline diff highlighting for paired changed lines.
-- Side-insensitive split badge and same-line picker lookup.
+- Independent picker/editor/send decisions that could label a file comment as a line thread.
+- The single-row-only guard that skipped inline highlights for wrapped split rows.

--- a/lua/raccoon/comments.lua
+++ b/lua/raccoon/comments.lua
@@ -648,19 +648,6 @@ end
 
 ---@param path string
 ---@param line number
----@return boolean
-local function can_start_new_thread(path, line)
-  if line == nil then
-    return find_pr_file(path) ~= nil
-  end
-  if type(line) ~= "number" or line < 1 then
-    return false
-  end
-  return find_pr_file(path) ~= nil
-end
-
----@param path string
----@param line number
 ---@param side? string
 ---@return string|nil
 local function new_thread_disable_reason(path, line, side)
@@ -689,6 +676,30 @@ local function new_thread_disable_reason(path, line, side)
   return nil
 end
 
+local function resolve_new_thread_target(path, line, side, in_diff_context)
+  side = side == "LEFT" and "LEFT" or "RIGHT"
+  local disable_reason = new_thread_disable_reason(path, line, side)
+  if disable_reason then
+    return {
+      kind = "disabled",
+      side = side,
+      line_commentable = false,
+      disable_reason = disable_reason,
+    }
+  end
+
+  local line_commentable = in_diff_context
+  if line_commentable == nil then
+    line_commentable = is_line_commentable(path, line, side)
+  end
+
+  return {
+    kind = line_commentable and "line" or "file",
+    side = side,
+    line_commentable = line_commentable == true,
+  }
+end
+
 local function is_anchor_validation_error(err)
   if not err then
     return false
@@ -713,14 +724,10 @@ local function send_new_thread(path, line, side, in_diff_context)
     return
   end
   side = side == "LEFT" and "LEFT" or "RIGHT"
-  local disable_reason = new_thread_disable_reason(path, line, side)
-  if disable_reason then
-    vim.notify(disable_reason, vim.log.levels.WARN)
+  local target = resolve_new_thread_target(path, line, side, in_diff_context)
+  if target.kind == "disabled" then
+    vim.notify(target.disable_reason, vim.log.levels.WARN)
     return
-  end
-  local line_commentable = in_diff_context
-  if line_commentable == nil then
-    line_commentable = is_line_commentable(path, line, side)
   end
 
   local function on_send_success()
@@ -762,7 +769,7 @@ local function send_new_thread(path, line, side, in_diff_context)
     end)
   end
 
-  if not line_commentable then
+  if target.kind == "file" then
     send_via_rest(nil, { subject_type = "file" })
     return
   end
@@ -775,14 +782,14 @@ end
 ---@return boolean
 local function open_new_thread_from_line(path, line, prefill_lines, target)
   local side = target and target.side == "LEFT" and "LEFT" or "RIGHT"
-  local disable_reason = new_thread_disable_reason(path, line, side)
-  if disable_reason then
-    vim.notify(disable_reason, vim.log.levels.WARN)
+  local resolved = resolve_new_thread_target(path, line, side, target and target.in_diff_context)
+  if resolved.kind == "disabled" then
+    vim.notify(resolved.disable_reason, vim.log.levels.WARN)
     return false
   end
   open_new_thread_editor(path, line, prefill_lines or {}, {
-    side = side,
-    in_diff_context = target and target.in_diff_context,
+    side = resolved.side,
+    in_diff_context = resolved.line_commentable,
   })
   return true
 end
@@ -791,12 +798,10 @@ open_new_thread_editor = function(path, line, prefill_lines, opts)
   opts = opts or {}
   local shortcuts = config.load_shortcuts()
   local side = opts.side == "LEFT" and "LEFT" or "RIGHT"
-  local line_commentable = opts.in_diff_context
-  if line_commentable == nil then
-    line_commentable = is_line_commentable(path, line, side)
-  end
-  local title_prefix = line_commentable and "New Thread" or "New File Comment"
-  local intro_line = line_commentable
+  local target = resolve_new_thread_target(path, line, side, opts.in_diff_context)
+  local line_commentable = target.line_commentable
+  local title_prefix = target.kind == "line" and "New Thread" or "New File Comment"
+  local intro_line = target.kind == "line"
     and "New thread on this line"
     or "New file comment (GitHub shows it at the top of the file)"
   local lines = { intro_line, "" }
@@ -817,12 +822,12 @@ open_new_thread_editor = function(path, line, prefill_lines, opts)
     kind = "new_thread",
     path = path,
     line = line,
-    side = side,
+    side = target.side,
     in_diff_context = line_commentable,
     prefill_lines = prefill_lines,
     initial_input_lines = opts.initial_input_lines,
     on_send = opts.disable_send_reason and nil or function()
-      send_new_thread(path, line, side, line_commentable)
+      send_new_thread(path, line, target.side, line_commentable)
     end,
   })
   if opts.disable_send_reason then
@@ -1234,7 +1239,8 @@ end
 
 local function restore_new_thread_snapshot(snapshot)
   local disable_reason = nil
-  if new_thread_disable_reason(snapshot.path, snapshot.line, snapshot.side) then
+  local target = resolve_new_thread_target(snapshot.path, snapshot.line, snapshot.side, snapshot.in_diff_context)
+  if target.kind == "disabled" then
     disable_reason = "Thread is no longer commentable on this line; clear the text or close it"
   end
   open_new_thread_editor(
@@ -1244,8 +1250,8 @@ local function restore_new_thread_snapshot(snapshot)
     {
       initial_input_lines = snapshot.input_lines,
       disable_send_reason = disable_reason,
-      side = snapshot.side,
-      in_diff_context = snapshot.in_diff_context,
+      side = target.side,
+      in_diff_context = target.line_commentable,
     }
   )
 end
@@ -1615,10 +1621,13 @@ local function open_same_line_picker(path, line, line_state, target)
       end,
     })
   end
-  if can_start_new_thread(path, line) then
+  local new_target = resolve_new_thread_target(path, line, target and target.side, target and target.in_diff_context)
+  if new_target.kind ~= "disabled" then
     table.insert(thread_rows, {
       key = "new_thread:" .. path .. ":" .. tostring(line),
-      text = "[NEW] New thread on this line",
+      text = new_target.kind == "line"
+          and "[NEW] New thread on this line"
+        or "[NEW] New file comment for this file",
       on_select = function()
         open_new_thread_from_line(path, line, {}, target)
       end,

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -303,6 +303,70 @@ local function append_changed_char_spans(spans, chars, changed)
   end
 end
 
+local function span_overlaps_token(span, token_start_col, token_end_col)
+  return span.start_col < token_end_col and span.end_col > token_start_col
+end
+
+local function expand_fragmented_identifier_spans(text, spans)
+  if #spans < 2 then
+    return spans
+  end
+
+  local remove = {}
+  local additions = {}
+  for token_start, token in (text or ""):gmatch("()([%w_]+)") do
+    local token_start_col = token_start - 1
+    local token_end_col = token_start_col + #token
+    local token_span_indices = {}
+    local changed_cols = {}
+    for span_idx, span in ipairs(spans) do
+      if span_overlaps_token(span, token_start_col, token_end_col) then
+        table.insert(token_span_indices, span_idx)
+        local start_col = math.max(span.start_col, token_start_col)
+        local end_col = math.min(span.end_col, token_end_col)
+        for col = start_col, end_col - 1 do
+          changed_cols[col] = true
+        end
+      end
+    end
+
+    local changed_count = 0
+    for _ in pairs(changed_cols) do
+      changed_count = changed_count + 1
+    end
+    if #token_span_indices > 1 and changed_count >= math.ceil(#token / 2) then
+      for _, span_idx in ipairs(token_span_indices) do
+        remove[span_idx] = true
+      end
+      table.insert(additions, {
+        start_col = token_start_col,
+        end_col = token_end_col,
+      })
+    end
+  end
+
+  if #additions == 0 then
+    return spans
+  end
+
+  local expanded = {}
+  for span_idx, span in ipairs(spans) do
+    if not remove[span_idx] then
+      table.insert(expanded, span)
+    end
+  end
+  for _, span in ipairs(additions) do
+    table.insert(expanded, span)
+  end
+  table.sort(expanded, function(left, right)
+    if left.start_col ~= right.start_col then
+      return left.start_col < right.start_col
+    end
+    return left.end_col < right.end_col
+  end)
+  return expanded
+end
+
 local function mark_lcs_matches(
   left_chars,
   left_start,
@@ -399,7 +463,7 @@ local function compute_inline_char_spans(left, right)
   local new_spans = {}
   append_changed_char_spans(old_spans, left_chars, left_changed)
   append_changed_char_spans(new_spans, right_chars, right_changed)
-  return old_spans, new_spans
+  return expand_fragmented_identifier_spans(left, old_spans), expand_fragmented_identifier_spans(right, new_spans)
 end
 
 local function append_pair_spans(spans, left_line, right_line, left_content, right_content, left_hl, right_hl)
@@ -590,25 +654,45 @@ local function split_to_display_width(text, width)
   width = math.max(1, width)
   text = text or ""
   if text == "" then
-    return { "" }
+    return {
+      {
+        text = "",
+        start_col = 0,
+        end_col = 0,
+      },
+    }
   end
   local chunks = {}
   local current = ""
   local current_width = 0
-  local char_count = vim.fn.strchars(text)
-  for idx = 0, char_count - 1 do
-    local char = vim.fn.strcharpart(text, idx, 1)
-    local char_width = math.max(1, vim.fn.strdisplaywidth(char))
+  local current_start_col = 0
+  local current_end_col = 0
+  for _, char in ipairs(split_utf8_chars(text)) do
+    local char_width = math.max(1, vim.fn.strdisplaywidth(char.value))
     if current ~= "" and current_width + char_width > width then
-      table.insert(chunks, current)
-      current = char
+      table.insert(chunks, {
+        text = current,
+        start_col = current_start_col,
+        end_col = current_end_col,
+      })
+      current = char.value
       current_width = char_width
+      current_start_col = char.start_col
+      current_end_col = char.end_col
     else
-      current = current .. char
+      if current == "" then
+        current_start_col = char.start_col
+      end
+      current = current .. char.value
       current_width = current_width + char_width
+      current_end_col = char.end_col
     end
   end
-  table.insert(chunks, current)
+  table.insert(chunks, {
+    text = current,
+    start_col = current_start_col,
+    end_col = current_end_col,
+  })
   return chunks
 end
 
@@ -625,6 +709,24 @@ local function format_side(line_num, chunk, line_num_width, content_width)
   local label = line_num and tostring(line_num) or ""
   label = string.rep(" ", math.max(0, line_num_width - #label)) .. label
   return label .. " " .. pad_to_display_width(chunk or "", content_width)
+end
+
+local function append_projected_inline_highlights(highlights, first_line, chunks, spans, range, hl)
+  for _, span in ipairs(spans) do
+    for chunk_idx, chunk in ipairs(chunks) do
+      local start_col = math.max(span.start_col, chunk.start_col)
+      local end_col = math.min(span.end_col, chunk.end_col)
+      if end_col > start_col then
+        table.insert(highlights, {
+          line = first_line + chunk_idx - 2,
+          start_col = range.content_start_col + start_col - chunk.start_col,
+          end_col = range.content_start_col + end_col - chunk.start_col,
+          hl = hl,
+          priority = INLINE_HIGHLIGHT_PRIORITY,
+        })
+      end
+    end
+  end
 end
 
 local function split_layout(width, max_line)
@@ -830,17 +932,19 @@ function M.render_split_file(opts)
     local chunk_count = math.max(#left_chunks, #right_chunks)
     local first_line = #lines + 1
     for chunk_idx = 1, chunk_count do
+      local left_chunk = left_chunks[chunk_idx] or { text = "", start_col = 0, end_col = 0 }
+      local right_chunk = right_chunks[chunk_idx] or { text = "", start_col = 0, end_col = 0 }
       local left_num = chunk_idx == 1 and row.old_line or nil
       local right_num = chunk_idx == 1 and row.new_line or nil
       local left_side = format_side(
         left_num,
-        left_chunks[chunk_idx] or "",
+        left_chunk.text,
         layout.line_num_width,
         layout.content_width
       )
       local right_side = format_side(
         right_num,
-        right_chunks[chunk_idx] or "",
+        right_chunk.text,
         layout.line_num_width,
         layout.content_width
       )
@@ -870,26 +974,24 @@ function M.render_split_file(opts)
       end
     end
 
-    if row.kind == "change" and first_line == #lines then
+    if row.kind == "change" then
       local old_spans, new_spans = compute_inline_char_spans(row.old_content or "", row.new_content or "")
-      for _, old_span in ipairs(old_spans) do
-        table.insert(inline_highlights, {
-          line = first_line - 1,
-          start_col = layout.left_range.content_start_col + old_span.start_col,
-          end_col = layout.left_range.content_start_col + old_span.end_col,
-          hl = "RaccoonInlineDelete",
-          priority = INLINE_HIGHLIGHT_PRIORITY,
-        })
-      end
-      for _, new_span in ipairs(new_spans) do
-        table.insert(inline_highlights, {
-          line = first_line - 1,
-          start_col = layout.right_range.content_start_col + new_span.start_col,
-          end_col = layout.right_range.content_start_col + new_span.end_col,
-          hl = "RaccoonInlineAdd",
-          priority = INLINE_HIGHLIGHT_PRIORITY,
-        })
-      end
+      append_projected_inline_highlights(
+        inline_highlights,
+        first_line,
+        left_chunks,
+        old_spans,
+        layout.left_range,
+        "RaccoonInlineDelete"
+      )
+      append_projected_inline_highlights(
+        inline_highlights,
+        first_line,
+        right_chunks,
+        new_spans,
+        layout.right_range,
+        "RaccoonInlineAdd"
+      )
     end
   end
 

--- a/tests/comments_ui_state_spec.lua
+++ b/tests/comments_ui_state_spec.lua
@@ -1016,7 +1016,7 @@ describe("raccoon.comments UI state restore", function()
 
     local picker_lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, 2, false)
     assert.matches("^%[R%]", picker_lines[1])
-    assert.truthy(picker_lines[2] and picker_lines[2]:match("^%[NEW%]"))
+    assert.equals("[NEW] New file comment for this file", picker_lines[2])
 
     local width = vim.api.nvim_win_get_config(0).width
     vim.o.columns = original_columns

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -637,6 +637,20 @@ describe("raccoon.diff", function()
         { line = 2, start_col = 1, end_col = 5, hl = "RaccoonInlineAdd" },
       }, spans_for_hl(spans, "RaccoonInlineAdd"))
     end)
+
+    it("highlights whole changed identifier tokens", function()
+      local spans = diff.render_stacked_inline_spans({
+        { type = "del", content = "const color = token.textColor;" },
+        { type = "add", content = "const color = token.htmlStyle;" },
+      })
+
+      assert.same({
+        { line = 1, start_col = 20, end_col = 29, hl = "RaccoonInlineDelete" },
+      }, spans_for_hl(spans, "RaccoonInlineDelete"))
+      assert.same({
+        { line = 2, start_col = 20, end_col = 29, hl = "RaccoonInlineAdd" },
+      }, spans_for_hl(spans, "RaccoonInlineAdd"))
+    end)
   end)
 
   describe("render_split_file", function()
@@ -798,6 +812,33 @@ describe("raccoon.diff", function()
       assert.is_number(inline_priority)
       assert.is_number(syntax_priority)
       assert.is_true(inline_priority > syntax_priority)
+    end)
+
+    it("projects inline split highlights onto wrapped continuation rows", function()
+      local rendered = diff.render_split_file({
+        path = "lua/a.lua",
+        old_lines = { "prefix-1234567890 oldToken" },
+        new_lines = { "prefix-1234567890 newToken" },
+        patch = "@@ -1 +1 @@\n-prefix-1234567890 oldToken\n+prefix-1234567890 newToken",
+        width = 42,
+      })
+
+      local inline_delete
+      local inline_add
+      for _, highlight in ipairs(rendered.highlights) do
+        if highlight.hl == "RaccoonInlineDelete" then
+          inline_delete = highlight
+        elseif highlight.hl == "RaccoonInlineAdd" then
+          inline_add = highlight
+        end
+      end
+
+      assert.is_not_nil(inline_delete)
+      assert.is_not_nil(inline_add)
+      assert.equals(1, inline_delete.line)
+      assert.equals(1, inline_add.line)
+      assert.is_true(inline_delete.start_col >= rendered.left_range.content_start_col)
+      assert.is_true(inline_add.start_col >= rendered.right_range.content_start_col)
     end)
 
     it("keeps add-only and delete-only rows as full-line highlights", function()


### PR DESCRIPTION
## Summary
- centralize new-comment target classification so line, file, and disabled states drive picker labels, editor titles, restore, and send behavior
- keep out-of-hunk changed-file comments as file-level comments, but stop labeling them as line threads
- project inline diff spans onto wrapped split rows and expand noisy identifier fragments to token-sized highlights

## Root Cause
- comment UI paths independently checked file membership and diff context, so an out-of-hunk target could be allowed as a file comment while still being labeled as a new line thread
- inline split spans were computed against full source lines but only applied to single-row rendered lines, so wrapped changed lines lost their inline highlights

## Validation
- make test
- make lint