### PR TITLE
[codex] Fix commit viewer page keymaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Commit viewer file-tree browsing now highlights the previewed file when the grid is collapsed to a 1x1 preview.
-- Commit and local commit viewer page navigation keep their `<leader>j` and `<leader>k` bindings on diff grids without hijacking left-side file or commit panels.
+- Commit and local commit viewer page navigation keep their `<leader>j` and `<leader>k` bindings on commit lists and diff grids without hijacking file browsing panels.
 
 ## [0.13.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Commit viewer file-tree browsing now highlights the previewed file when the grid is collapsed to a 1x1 preview.
-- Commit and local commit viewer page navigation keep their `<leader>j` and `<leader>k` bindings when review keymaps are active.
+- Commit and local commit viewer page navigation keep their `<leader>j` and `<leader>k` bindings on diff grids without hijacking left-side file or commit panels.
 
 ## [0.13.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.2] - 2026-07-01
+
+### Fixed
+- Commit viewer file-tree browsing now highlights the previewed file when the grid is collapsed to a 1x1 preview.
+- Commit and local commit viewer page navigation keep their `<leader>j` and `<leader>k` bindings when review keymaps are active.
+
 ## [0.13.1] - 2026-06-29
 
 ### Added

--- a/lua/raccoon/commit_ui.lua
+++ b/lua/raccoon/commit_ui.lua
@@ -1410,12 +1410,16 @@ function M.render_filetree(s)
 
   -- Build lookup: files visible on current grid page
   local visible_files = {}
-  local cells = s.grid_rows * s.grid_cols
-  local start_idx = (s.current_page - 1) * cells + 1
-  for i = start_idx, math.min(start_idx + cells - 1, #s.all_hunks) do
-    local hunk_data = s.all_hunks[i]
-    if hunk_data then
-      visible_files[hunk_data.filename] = true
+  if s.focus_target == "filetree" and s.filetree_preview_path then
+    visible_files[s.filetree_preview_path] = true
+  else
+    local cells = s.grid_rows * s.grid_cols
+    local start_idx = (s.current_page - 1) * cells + 1
+    for i = start_idx, math.min(start_idx + cells - 1, #s.all_hunks) do
+      local hunk_data = s.all_hunks[i]
+      if hunk_data then
+        visible_files[hunk_data.filename] = true
+      end
     end
   end
 
@@ -1786,6 +1790,7 @@ function M.toggle_filetree_focus(s, opts)
   if s.focus_target == "filetree" then
     -- Switching back to sidebar: restore original grid
     s.focus_target = "sidebar"
+    s.filetree_preview_path = nil
     if s.filetree_win and vim.api.nvim_win_is_valid(s.filetree_win) then
       vim.wo[s.filetree_win].cursorline = false
     end
@@ -1803,6 +1808,7 @@ function M.toggle_filetree_focus(s, opts)
   else
     -- Switching to filetree: collapse grid to 1x1 with file preview
     s.focus_target = "filetree"
+    s.filetree_preview_path = nil
     s.orig_grid_rows = s.grid_rows
     s.orig_grid_cols = s.grid_cols
     M.rebuild_grid(s, 1, 1, opts.apply_keymaps)
@@ -1846,6 +1852,8 @@ function M._preview_file_at_cursor(s, opts)
 
   -- Clear stale preview content when no file is found
   if not path then
+    s.filetree_preview_path = nil
+    M.render_filetree(s)
     local buf = s.grid_bufs and s.grid_bufs[1]
     if buf and vim.api.nvim_buf_is_valid(buf) then
       M._set_preview_empty(buf, s.grid_wins and s.grid_wins[1], "(no file)", "  No file at cursor")
@@ -1855,6 +1863,8 @@ function M._preview_file_at_cursor(s, opts)
   local repo_path = opts.get_repo_path and opts.get_repo_path()
   if not repo_path then return end
   local sha = opts.get_sha and opts.get_sha()
+  s.filetree_preview_path = path
+  M.render_filetree(s)
   M.render_file_preview(s, {
     ns_id = opts.ns_id,
     repo_path = repo_path,

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -653,8 +653,40 @@ local function setup_keymaps()
   end
 
   -- Apply keymaps buffer-locally
-  local commit_bufs = ui.collect_bufs(commit_state)
-  ui.apply_keymaps_to_bufs(commit_mode_keymaps, commit_bufs)
+  local page_keys = {}
+  for _, lhs in ipairs({
+    shortcuts.commit_viewer.next_page,
+    shortcuts.commit_viewer.prev_page,
+    shortcuts.commit_viewer.next_page_alt,
+  }) do
+    if config.is_enabled(lhs) then
+      page_keys[lhs] = true
+    end
+  end
+  local noop = function() end
+  local panel_keymaps = {}
+  for _, km in ipairs(commit_mode_keymaps) do
+    if page_keys[km.lhs] then
+      table.insert(panel_keymaps, vim.tbl_extend("force", km, { rhs = noop }))
+    else
+      table.insert(panel_keymaps, km)
+    end
+  end
+
+  local grid_bufs = {}
+  for _, buf in ipairs(commit_state.grid_bufs or {}) do
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      table.insert(grid_bufs, buf)
+    end
+  end
+  ui.apply_keymaps_to_bufs(commit_mode_keymaps, grid_bufs)
+  local panel_bufs = {}
+  for _, buf in ipairs({ commit_state.sidebar_buf, commit_state.header_buf, commit_state.filetree_buf }) do
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      table.insert(panel_bufs, buf)
+    end
+  end
+  ui.apply_keymaps_to_bufs(panel_keymaps, panel_bufs)
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(commit_state.sidebar_buf, {

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -664,24 +664,29 @@ local function setup_keymaps()
     end
   end
   local noop = function() end
+  local page_keymaps = {}
   local panel_keymaps = {}
   for _, km in ipairs(commit_mode_keymaps) do
     if page_keys[km.lhs] then
+      table.insert(page_keymaps, km)
       table.insert(panel_keymaps, vim.tbl_extend("force", km, { rhs = noop }))
     else
       table.insert(panel_keymaps, km)
     end
   end
 
-  local grid_bufs = {}
+  local page_bufs = {}
   for _, buf in ipairs(commit_state.grid_bufs or {}) do
     if buf and vim.api.nvim_buf_is_valid(buf) then
-      table.insert(grid_bufs, buf)
+      table.insert(page_bufs, buf)
     end
   end
-  ui.apply_keymaps_to_bufs(commit_mode_keymaps, grid_bufs)
+  if commit_state.sidebar_buf and vim.api.nvim_buf_is_valid(commit_state.sidebar_buf) then
+    table.insert(page_bufs, commit_state.sidebar_buf)
+  end
+  ui.apply_keymaps_to_bufs(commit_mode_keymaps, page_bufs)
   local panel_bufs = {}
-  for _, buf in ipairs({ commit_state.sidebar_buf, commit_state.header_buf, commit_state.filetree_buf }) do
+  for _, buf in ipairs({ commit_state.header_buf, commit_state.filetree_buf }) do
     if buf and vim.api.nvim_buf_is_valid(buf) then
       table.insert(panel_bufs, buf)
     end
@@ -696,6 +701,9 @@ local function setup_keymaps()
     move_to_bottom = move_to_bottom,
     select_at_cursor = select_at_cursor,
   })
+  if commit_state.sidebar_buf and vim.api.nvim_buf_is_valid(commit_state.sidebar_buf) then
+    ui.apply_keymaps_to_bufs(page_keymaps, { commit_state.sidebar_buf })
+  end
 
   -- Filetree navigation keymaps
   ui.setup_filetree_nav(commit_state, filetree_opts)

--- a/lua/raccoon/commits.lua
+++ b/lua/raccoon/commits.lua
@@ -55,6 +55,7 @@ local commit_state = {
   cached_stat_lines = nil,
   cached_file_count = nil,
   focus_target = "sidebar",
+  filetree_preview_path = nil,
   orig_grid_rows = nil,
   orig_grid_cols = nil,
   preview_generation = 0,
@@ -99,6 +100,7 @@ local function reset_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    filetree_preview_path = nil,
     orig_grid_rows = nil,
     orig_grid_cols = nil,
     preview_generation = 0,
@@ -454,6 +456,7 @@ local function select_commit(index)
 
   commit_state.selected_index = index
   commit_state.current_page = 1
+  commit_state.filetree_preview_path = nil
   commit_state.select_generation = commit_state.select_generation + 1
   local generation = commit_state.select_generation
 
@@ -652,9 +655,6 @@ local function setup_keymaps()
   -- Apply keymaps buffer-locally
   local commit_bufs = ui.collect_bufs(commit_state)
   ui.apply_keymaps_to_bufs(commit_mode_keymaps, commit_bufs)
-  for _, buf in ipairs(commit_bufs) do
-    keymaps.setup_buffer(buf)
-  end
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(commit_state.sidebar_buf, {

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -503,16 +503,30 @@ local function setup_keymaps()
       page_keys[lhs] = true
     end
   end
+  local noop = function() end
+  local page_keymaps = {}
   local panel_keymaps = {}
   for _, km in ipairs(local_mode_keymaps) do
-    if not page_keys[km.lhs] then
+    if page_keys[km.lhs] then
+      table.insert(page_keymaps, km)
+      table.insert(panel_keymaps, vim.tbl_extend("force", km, { rhs = noop }))
+    else
       table.insert(panel_keymaps, km)
     end
   end
 
-  ui.apply_keymaps_to_bufs(local_mode_keymaps, local_state.grid_bufs or {})
+  local page_bufs = {}
+  for _, buf in ipairs(local_state.grid_bufs or {}) do
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      table.insert(page_bufs, buf)
+    end
+  end
+  if local_state.sidebar_buf and vim.api.nvim_buf_is_valid(local_state.sidebar_buf) then
+    table.insert(page_bufs, local_state.sidebar_buf)
+  end
+  ui.apply_keymaps_to_bufs(local_mode_keymaps, page_bufs)
   local panel_bufs = {}
-  for _, buf in ipairs({ local_state.sidebar_buf, local_state.header_buf, local_state.filetree_buf }) do
+  for _, buf in ipairs({ local_state.header_buf, local_state.filetree_buf }) do
     if buf and vim.api.nvim_buf_is_valid(buf) then
       table.insert(panel_bufs, buf)
     end
@@ -527,6 +541,9 @@ local function setup_keymaps()
     move_to_bottom = move_to_bottom,
     select_at_cursor = select_at_cursor,
   })
+  if local_state.sidebar_buf and vim.api.nvim_buf_is_valid(local_state.sidebar_buf) then
+    ui.apply_keymaps_to_bufs(page_keymaps, { local_state.sidebar_buf })
+  end
 
   -- Filetree navigation keymaps
   ui.setup_filetree_nav(local_state, filetree_opts)

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -493,8 +493,31 @@ local function setup_keymaps()
   end
 
   -- Apply keymaps buffer-locally
-  local commit_bufs = ui.collect_bufs(local_state)
-  ui.apply_keymaps_to_bufs(local_mode_keymaps, commit_bufs)
+  local page_keys = {}
+  for _, lhs in ipairs({
+    shortcuts.commit_viewer.next_page,
+    shortcuts.commit_viewer.prev_page,
+    shortcuts.commit_viewer.next_page_alt,
+  }) do
+    if config.is_enabled(lhs) then
+      page_keys[lhs] = true
+    end
+  end
+  local panel_keymaps = {}
+  for _, km in ipairs(local_mode_keymaps) do
+    if not page_keys[km.lhs] then
+      table.insert(panel_keymaps, km)
+    end
+  end
+
+  ui.apply_keymaps_to_bufs(local_mode_keymaps, local_state.grid_bufs or {})
+  local panel_bufs = {}
+  for _, buf in ipairs({ local_state.sidebar_buf, local_state.header_buf, local_state.filetree_buf }) do
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      table.insert(panel_bufs, buf)
+    end
+  end
+  ui.apply_keymaps_to_bufs(panel_keymaps, panel_bufs)
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(local_state.sidebar_buf, {
@@ -932,5 +955,6 @@ end
 -- Exposed for testing
 M._get_state = function() return local_state end
 M._select_commit = select_commit
+M._setup_keymaps = setup_keymaps
 
 return M

--- a/lua/raccoon/localcommits.lua
+++ b/lua/raccoon/localcommits.lua
@@ -63,6 +63,7 @@ local function make_initial_state()
     cached_stat_lines = nil,
     cached_file_count = nil,
     focus_target = "sidebar",
+    filetree_preview_path = nil,
     orig_grid_rows = nil,
     orig_grid_cols = nil,
     preview_generation = 0,
@@ -151,6 +152,7 @@ local function select_commit(index)
 
   local_state.selected_index = index
   local_state.current_page = 1
+  local_state.filetree_preview_path = nil
   local_state.select_generation = local_state.select_generation + 1
   local generation = local_state.select_generation
 
@@ -493,11 +495,6 @@ local function setup_keymaps()
   -- Apply keymaps buffer-locally
   local commit_bufs = ui.collect_bufs(local_state)
   ui.apply_keymaps_to_bufs(local_mode_keymaps, commit_bufs)
-  if state.is_active() then
-    for _, buf in ipairs(commit_bufs) do
-      keymaps.setup_buffer(buf)
-    end
-  end
 
   -- Sidebar-local keymaps
   ui.setup_sidebar_nav(local_state.sidebar_buf, {

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -969,6 +969,16 @@ describe("raccoon.commits buffer-local keymaps", function()
     return false
   end
 
+  local function get_buf_keymap(buf, mode, lhs)
+    local maps = vim.api.nvim_buf_get_keymap(buf, mode)
+    for _, map in ipairs(maps) do
+      if map.lhs == lhs then
+        return map
+      end
+    end
+    return nil
+  end
+
   local function has_global_keymap(mode, lhs)
     local maps = vim.api.nvim_get_keymap(mode)
     for _, map in ipairs(maps) do
@@ -999,9 +1009,11 @@ describe("raccoon.commits buffer-local keymaps", function()
     for _, buf in ipairs(cs.grid_bufs) do
       table.insert(bufs_to_clean, buf)
     end
+    require("raccoon.keymaps").clear()
   end)
 
   after_each(function()
+    require("raccoon.keymaps").clear()
     for _, buf in ipairs(bufs_to_clean) do
       if vim.api.nvim_buf_is_valid(buf) then
         vim.api.nvim_buf_delete(buf, { force = true })
@@ -1038,6 +1050,32 @@ describe("raccoon.commits buffer-local keymaps", function()
             "expected " .. key .. " on grid buf")
         end
       end
+    end)
+
+    it("keeps leader j/k bound to commit page navigation when review keymaps exist", function()
+      require("raccoon.keymaps").setup()
+      cs.current_page = 1
+      cs.all_hunks = {}
+      for idx = 1, 5 do
+        table.insert(cs.all_hunks, {
+          filename = "file" .. idx .. ".lua",
+          hunk = { lines = { { type = "context", content = "line " .. idx } } },
+        })
+      end
+
+      commits._setup_keymaps()
+
+      local next_map = get_buf_keymap(cs.grid_bufs[1], "n", " j")
+      assert.is_table(next_map)
+      assert.is_function(next_map.callback)
+      next_map.callback()
+      assert.equals(2, cs.current_page)
+
+      local prev_map = get_buf_keymap(cs.grid_bufs[1], "n", " k")
+      assert.is_table(prev_map)
+      assert.is_function(prev_map.callback)
+      prev_map.callback()
+      assert.equals(1, cs.current_page)
     end)
 
     it("applies <C-w> blocks buffer-locally", function()
@@ -1446,6 +1484,8 @@ describe("raccoon.commits render_filetree three-tier highlighting", function()
     cs.grid_rows = 2
     cs.grid_cols = 2
     cs.current_page = 1
+    cs.focus_target = "sidebar"
+    cs.filetree_preview_path = nil
   end)
 
   after_each(function()
@@ -1493,6 +1533,32 @@ describe("raccoon.commits render_filetree three-tier highlighting", function()
     local hl = get_filetree_highlights(filetree_buf)
     assert.equals("RaccoonFileVisible", hl[0])
     assert.equals("RaccoonFileInCommit", hl[1])
+    assert.equals("RaccoonFileInCommit", hl[2])
+  end)
+
+  it("highlights only the previewed file as visible while browsing files", function()
+    cs.grid_rows = 1
+    cs.grid_cols = 1
+    cs.focus_target = "filetree"
+    cs.filetree_preview_path = "file2.lua"
+
+    cs.cached_sha = "test-preview"
+    cs.cached_tree_lines = { "├ file1.lua", "├ file2.lua", "└ file3.lua" }
+    cs.cached_line_paths = { [0] = "file1.lua", [1] = "file2.lua", [2] = "file3.lua" }
+    cs.cached_file_count = 3
+
+    cs.all_hunks = {
+      { filename = "file1.lua", hunk = {} },
+      { filename = "file2.lua", hunk = {} },
+      { filename = "file3.lua", hunk = {} },
+    }
+    cs.commit_files = { ["file1.lua"] = true, ["file2.lua"] = true, ["file3.lua"] = true }
+
+    commits._render_filetree()
+
+    local hl = get_filetree_highlights(filetree_buf)
+    assert.equals("RaccoonFileInCommit", hl[0])
+    assert.equals("RaccoonFileVisible", hl[1])
     assert.equals("RaccoonFileInCommit", hl[2])
   end)
 

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -979,6 +979,13 @@ describe("raccoon.commits buffer-local keymaps", function()
     return nil
   end
 
+  local function invoke_buf_keymap(buf, lhs)
+    local map = get_buf_keymap(buf, "n", lhs)
+    if map and map.callback then
+      map.callback()
+    end
+  end
+
   local function has_global_keymap(mode, lhs)
     local maps = vim.api.nvim_get_keymap(mode)
     for _, map in ipairs(maps) do
@@ -1040,11 +1047,9 @@ describe("raccoon.commits buffer-local keymaps", function()
       end
     end)
 
-    it("applies navigation keymaps buffer-locally", function()
+    it("applies page navigation keymaps to grid buffers", function()
       commits._setup_keymaps()
       for _, key in ipairs({ " j", " k", " l" }) do
-        assert.is_true(has_buf_keymap(cs.sidebar_buf, "n", key),
-          "expected " .. key .. " on sidebar")
         for _, buf in ipairs(cs.grid_bufs) do
           assert.is_true(has_buf_keymap(buf, "n", key),
             "expected " .. key .. " on grid buf")
@@ -1076,6 +1081,33 @@ describe("raccoon.commits buffer-local keymaps", function()
       assert.is_function(prev_map.callback)
       prev_map.callback()
       assert.equals(1, cs.current_page)
+    end)
+
+    it("does not page from non-grid buffers", function()
+      cs.current_page = 1
+      cs.all_hunks = {}
+      for idx = 1, 5 do
+        table.insert(cs.all_hunks, {
+          filename = "file" .. idx .. ".lua",
+          hunk = { lines = { { type = "context", content = "line " .. idx } } },
+        })
+      end
+
+      commits._setup_keymaps()
+
+      for _, buf in ipairs({ cs.sidebar_buf, cs.header_buf, cs.filetree_buf }) do
+        cs.current_page = 1
+        invoke_buf_keymap(buf, " j")
+        assert.equals(1, cs.current_page)
+
+        cs.current_page = 2
+        invoke_buf_keymap(buf, " k")
+        assert.equals(2, cs.current_page)
+
+        cs.current_page = 1
+        invoke_buf_keymap(buf, " l")
+        assert.equals(1, cs.current_page)
+      end
     end)
 
     it("applies <C-w> blocks buffer-locally", function()
@@ -1113,10 +1145,8 @@ describe("raccoon.commits buffer-local keymaps", function()
       commits._setup_keymaps()
       assert.is_true(has_buf_keymap(cs.filetree_buf, "n", " cm"),
         "expected <leader>cm on filetree_buf")
-      for _, key in ipairs({ " j", " k", " l" }) do
-        assert.is_true(has_buf_keymap(cs.filetree_buf, "n", key),
-          "expected " .. key .. " on filetree_buf")
-      end
+      assert.is_true(has_buf_keymap(cs.filetree_buf, "n", " f"),
+        "expected <leader>f on filetree_buf")
     end)
 
     it("handles invalid buffers gracefully", function()

--- a/tests/commits_spec.lua
+++ b/tests/commits_spec.lua
@@ -1047,9 +1047,11 @@ describe("raccoon.commits buffer-local keymaps", function()
       end
     end)
 
-    it("applies page navigation keymaps to grid buffers", function()
+    it("applies page navigation keymaps to commit-list and grid buffers", function()
       commits._setup_keymaps()
       for _, key in ipairs({ " j", " k", " l" }) do
+        assert.is_true(has_buf_keymap(cs.sidebar_buf, "n", key),
+          "expected " .. key .. " on sidebar")
         for _, buf in ipairs(cs.grid_bufs) do
           assert.is_true(has_buf_keymap(buf, "n", key),
             "expected " .. key .. " on grid buf")
@@ -1081,9 +1083,15 @@ describe("raccoon.commits buffer-local keymaps", function()
       assert.is_function(prev_map.callback)
       prev_map.callback()
       assert.equals(1, cs.current_page)
+
+      local sidebar_next_map = get_buf_keymap(cs.sidebar_buf, "n", " j")
+      assert.is_table(sidebar_next_map)
+      assert.is_function(sidebar_next_map.callback)
+      sidebar_next_map.callback()
+      assert.equals(2, cs.current_page)
     end)
 
-    it("does not page from non-grid buffers", function()
+    it("does not page from file/header buffers", function()
       cs.current_page = 1
       cs.all_hunks = {}
       for idx = 1, 5 do
@@ -1095,7 +1103,7 @@ describe("raccoon.commits buffer-local keymaps", function()
 
       commits._setup_keymaps()
 
-      for _, buf in ipairs({ cs.sidebar_buf, cs.header_buf, cs.filetree_buf }) do
+      for _, buf in ipairs({ cs.header_buf, cs.filetree_buf }) do
         cs.current_page = 1
         invoke_buf_keymap(buf, " j")
         assert.equals(1, cs.current_page)

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -89,7 +89,10 @@ describe("raccoon.git", function()
     end)
 
     it("returns false for non-git directory", function()
-      assert.is_false(git.is_git_repo("/tmp"))
+      local dir = vim.fn.tempname()
+      vim.fn.mkdir(dir, "p")
+      assert.is_false(git.is_git_repo(dir))
+      vim.fn.delete(dir, "rf")
     end)
 
     it("returns false for non-existent directory", function()
@@ -553,4 +556,3 @@ describe("raccoon.git path edge cases", function()
 
   end)
 end)
-

--- a/tests/localcommits_spec.lua
+++ b/tests/localcommits_spec.lua
@@ -134,7 +134,7 @@ describe("raccoon.localcommits", function()
       ls.current_page = 1
     end)
 
-    it("keeps leader j/k as page navigation only on grid buffers", function()
+    it("keeps leader j/k as page navigation on commit-list and grid buffers only", function()
       local ls = localcommits._get_state()
       localcommits._setup_keymaps()
 
@@ -144,7 +144,13 @@ describe("raccoon.localcommits", function()
       invoke_map(ls.grid_bufs[1], " k")
       assert.equals(1, ls.current_page)
 
-      for _, buf in ipairs({ ls.sidebar_buf, ls.header_buf, ls.filetree_buf }) do
+      invoke_map(ls.sidebar_buf, " j")
+      assert.equals(2, ls.current_page)
+
+      invoke_map(ls.sidebar_buf, " k")
+      assert.equals(1, ls.current_page)
+
+      for _, buf in ipairs({ ls.header_buf, ls.filetree_buf }) do
         ls.current_page = 1
         invoke_map(buf, " j")
         assert.equals(1, ls.current_page)

--- a/tests/localcommits_spec.lua
+++ b/tests/localcommits_spec.lua
@@ -67,6 +67,95 @@ describe("raccoon.localcommits", function()
     end)
   end)
 
+  describe("buffer-local keymaps", function()
+    local bufs_to_clean = {}
+
+    local function get_buf_keymap(buf, mode, lhs)
+      local maps = vim.api.nvim_buf_get_keymap(buf, mode)
+      for _, map in ipairs(maps) do
+        if map.lhs == lhs then
+          return map
+        end
+      end
+      return nil
+    end
+
+    local function invoke_map(buf, lhs)
+      local map = get_buf_keymap(buf, "n", lhs)
+      if map and map.callback then
+        map.callback()
+      end
+    end
+
+    before_each(function()
+      require("raccoon.keymaps").clear()
+      local ls = localcommits._get_state()
+      ls.sidebar_buf = commit_ui.create_scratch_buf()
+      ls.header_buf = commit_ui.create_scratch_buf()
+      ls.filetree_buf = commit_ui.create_scratch_buf()
+      ls.grid_bufs = {
+        commit_ui.create_scratch_buf(),
+        commit_ui.create_scratch_buf(),
+        commit_ui.create_scratch_buf(),
+        commit_ui.create_scratch_buf(),
+      }
+      ls.grid_rows = 2
+      ls.grid_cols = 2
+      ls.current_page = 1
+      ls.all_hunks = {}
+      for idx = 1, 5 do
+        table.insert(ls.all_hunks, {
+          filename = "file" .. idx .. ".lua",
+          hunk = { lines = { { type = "context", content = "line " .. idx } } },
+        })
+      end
+
+      bufs_to_clean = { ls.sidebar_buf, ls.header_buf, ls.filetree_buf }
+      for _, buf in ipairs(ls.grid_bufs) do
+        table.insert(bufs_to_clean, buf)
+      end
+    end)
+
+    after_each(function()
+      require("raccoon.keymaps").clear()
+      local ls = localcommits._get_state()
+      for _, buf in ipairs(bufs_to_clean) do
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+      bufs_to_clean = {}
+      ls.sidebar_buf = nil
+      ls.header_buf = nil
+      ls.filetree_buf = nil
+      ls.grid_bufs = {}
+      ls.grid_wins = {}
+      ls.all_hunks = {}
+      ls.current_page = 1
+    end)
+
+    it("keeps leader j/k as page navigation only on grid buffers", function()
+      local ls = localcommits._get_state()
+      localcommits._setup_keymaps()
+
+      invoke_map(ls.grid_bufs[1], " j")
+      assert.equals(2, ls.current_page)
+
+      invoke_map(ls.grid_bufs[1], " k")
+      assert.equals(1, ls.current_page)
+
+      for _, buf in ipairs({ ls.sidebar_buf, ls.header_buf, ls.filetree_buf }) do
+        ls.current_page = 1
+        invoke_map(buf, " j")
+        assert.equals(1, ls.current_page)
+
+        ls.current_page = 2
+        invoke_map(buf, " k")
+        assert.equals(2, ls.current_page)
+      end
+    end)
+  end)
+
   describe("exit_local_mode", function()
     it("falls back to a normal buffer when the saved buffer was wiped", function()
       local ls = localcommits._get_state()


### PR DESCRIPTION
## Summary

- Keep commit-viewer `<leader>j` / `<leader>k` bound to next/previous grid page when normal review keymaps have been initialized.
- Track the previewed file while browsing files so the file tree highlights only the file currently shown in the center preview.
- Make the git repo test create an isolated non-git temp directory instead of assuming `/tmp` has no `.git` directory.

## Root Cause

Commit mode applied commit viewer keymaps, then reapplied flat-review buffer keymaps. The flat-review `<leader>j` / `<leader>k` mappings overwrote the commit viewer page mappings, so the keys ran review navigation instead of paging the commit grid.

## Validation

- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/commits_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/localcommits_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/commit_ui_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/git_spec.lua"`
- `make test`
- `make lint`