### PR TITLE
[codex] Add optional Pierre diff renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Optional Pierre-backed flat diff renderer, configurable through `diff_renderer`, with fallback to the builtin Lua renderer when Node or `@pierre/diffs` is unavailable.
+- Optional Pierre-backed flat diff renderer for flat review mode, configurable through `diff_renderer`, with fallback to the built-in Lua renderer when Node or `@pierre/diffs` is unavailable.
+
+### Changed
+- Documented that the Pierre renderer is optional, how to configure it, and that raccoon works normally without Node or `@pierre/diffs`.
 
 ## [0.13.2] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- Optional Pierre-backed flat diff renderer, configurable through `diff_renderer`, with fallback to the builtin Lua renderer when Node or `@pierre/diffs` is unavailable.
+
 ## [0.13.2] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optional Pierre-backed flat diff renderer for flat review mode, configurable through `diff_renderer`, with fallback to the built-in Lua renderer when Node or `@pierre/diffs` is unavailable.
 
 ### Changed
-- Documented that the Pierre renderer is optional, how to configure it, and that raccoon works normally without Node or `@pierre/diffs`.
+- Documented that the Pierre renderer is optional, how to configure it, how to install it with `pnpm add @pierre/diffs`, and that raccoon works normally without Node or `@pierre/diffs`.
+
+### Fixed
+- Optional Pierre rendering now handles hunk-only GitHub patch strings and falls back to the built-in renderer when Pierre returns an empty render plan.
 
 ## [0.13.2] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Optional Pierre rendering now handles hunk-only GitHub patch strings and falls back to the built-in renderer when Pierre returns an empty render plan.
+- Optional Pierre inline word diffs now resolve Pierre's bundled `diff` dependency under pnpm installs.
 
 ## [0.13.2] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
 
 - Browse open PRs with a floating picker
 - Review changed files with inline diff highlighting
+- Optional Pierre-backed flat diff rendering, with automatic fallback to the built-in Lua renderer
 - Exact-thread review comments in flat diff
 - Jump between diff hunks, unresolved threads, and needs-reply threads
 - File picker and unresolved-thread picker for flat diff
@@ -53,6 +54,7 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
   - **Classic token** ([create here](https://github.com/settings/tokens)): with `repo` scope
     - Read access to metadata
     - Read and Write access to code, issues, and pull requests
+- Optional: Node.js plus `@pierre/diffs` if you want to try the Pierre-backed flat diff renderer. The plugin works without them.
 
 ## Installation
 
@@ -93,6 +95,10 @@ See [config_docs.md](config_docs.md) for a detailed reference of every config fi
 | `repos` | array | `[]` | Limit PR list to specific repos, e.g. `["my-org/backend"]`. Only PRs involving you are shown. |
 | `clone_root` | string | `<nvim data dir>/raccoon/repos` | Where PR branches are cloned for review |
 | `sync_interval` | number | `300` | How often (in seconds) to auto-sync with remote (minimum 10) *(formerly `pull_changes_interval`)* |
+| `diff_renderer.provider` | string | `"auto"` | Flat diff renderer provider: `"auto"`, `"builtin"`, or `"pierre"` |
+| `diff_renderer.timeout_ms` | number | `200` | Max time in milliseconds to wait for the optional Pierre renderer |
+| `diff_renderer.command` | array/null | `null` | Optional command override for the Pierre renderer, e.g. `["node", "/abs/path/to/pierre_render.mjs"]` |
+| `diff_renderer.inline_word_diff` | boolean | `true` | Whether the optional Pierre renderer should request inline word-diff spans |
 | `shortcuts` | object | see below | Custom keyboard shortcuts (partial overrides merged with defaults) |
 | `commit_viewer.grid.rows` | number | `2` | Rows in the commit viewer diff grid |
 | `commit_viewer.grid.cols` | number | `2` | Columns in the commit viewer diff grid |
@@ -142,6 +148,47 @@ The plugin auto-detects the correct API endpoints (`https://<host>/api/v3` for R
 
 See [shortcuts_docs.md](shortcuts_docs.md) for the full shortcut reference, mode boundaries, and abbreviation meanings.
 
+### Optional Pierre flat diff renderer
+
+Raccoon always includes its built-in Lua flat diff renderer. You do not need Node.js, `@pierre/diffs`, or any renderer config for the plugin to work.
+
+The optional Pierre renderer is used only for flat diff rendering. It still draws in Neovim using extmarks, signs, and virtual lines, so commenting, navigation, sync, and file opening keep the same workflow. Commit viewer rendering is not changed by this option.
+
+By default, `diff_renderer.provider` is `"auto"`. In auto mode, raccoon tries the Pierre renderer when its bridge command can run and returns valid JSON. If Node.js is missing, `@pierre/diffs` is not installed, the command times out, or the command returns invalid JSON, raccoon silently falls back to the built-in renderer.
+
+To force the built-in renderer and skip the optional Node process entirely:
+
+```json
+{
+  "diff_renderer": {
+    "provider": "builtin"
+  }
+}
+```
+
+To explicitly use Pierre when you have installed the optional sidecar dependency:
+
+```json
+{
+  "diff_renderer": {
+    "provider": "pierre",
+    "timeout_ms": 200,
+    "inline_word_diff": true
+  }
+}
+```
+
+If Node cannot resolve `@pierre/diffs` from your plugin install location, provide a command override that points at a wrapper script or a checked-out bridge:
+
+```json
+{
+  "diff_renderer": {
+    "provider": "pierre",
+    "command": ["node", "/absolute/path/to/pierre_render.mjs"]
+  }
+}
+```
+
 ### Full config example
 
 ```json
@@ -153,6 +200,12 @@ See [shortcuts_docs.md](shortcuts_docs.md) for the full shortcut reference, mode
   "repos": ["your-username/project", "work-org/api"],
   "clone_root": "~/code/pr-reviews",
   "sync_interval": 120,
+  "diff_renderer": {
+    "provider": "auto",
+    "timeout_ms": 200,
+    "command": null,
+    "inline_word_diff": true
+  },
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
     "base_commits_count": 30

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Review GitHub pull requests directly in Neovim. Browse changed files with diff h
   - **Classic token** ([create here](https://github.com/settings/tokens)): with `repo` scope
     - Read access to metadata
     - Read and Write access to code, issues, and pull requests
-- Optional: Node.js plus `@pierre/diffs` if you want to try the Pierre-backed flat diff renderer. The plugin works without them.
+- Optional: Node.js plus `@pierre/diffs` if you want to try the Pierre-backed flat diff renderer. The plugin works without them. To enable this optional path, run `pnpm add @pierre/diffs` in the plugin checkout that contains `scripts/pierre_render.mjs`.
 
 ## Installation
 
@@ -153,6 +153,14 @@ See [shortcuts_docs.md](shortcuts_docs.md) for the full shortcut reference, mode
 Raccoon always includes its built-in Lua flat diff renderer. You do not need Node.js, `@pierre/diffs`, or any renderer config for the plugin to work.
 
 The optional Pierre renderer is used only for flat diff rendering. It still draws in Neovim using extmarks, signs, and virtual lines, so commenting, navigation, sync, and file opening keep the same workflow. Commit viewer rendering is not changed by this option.
+
+To install the optional Pierre parser dependency, run this from the `nvim-raccoon` plugin checkout:
+
+```sh
+pnpm add @pierre/diffs
+```
+
+For lazy.nvim, the checkout is commonly under `~/.local/share/nvim/lazy/nvim-raccoon`, but use the path where your plugin manager installed `bajor/nvim-raccoon`. If you do not install this dependency, raccoon keeps using the built-in Lua renderer.
 
 By default, `diff_renderer.provider` is `"auto"`. In auto mode, raccoon tries the Pierre renderer when its bridge command can run and returns valid JSON. If Node.js is missing, `@pierre/diffs` is not installed, the command times out, or the command returns invalid JSON, raccoon silently falls back to the built-in renderer.
 

--- a/config_docs.md
+++ b/config_docs.md
@@ -15,6 +15,8 @@ Validation rules:
 - Unknown fields are silently ignored (e.g. legacy `github_username`)
 - Renamed keys are migrated transparently by `lua/raccoon/config_compat.lua` — see the [Migrating from older config keys](#migrating-from-older-config-keys) section at the bottom
 
+`diff_renderer` is optional. If it is omitted, raccoon still works and uses its built-in Lua renderer unless the optional Pierre renderer is available and succeeds in auto mode.
+
 ## Minimal config
 
 The smallest valid config needs just a token:
@@ -160,6 +162,94 @@ How often (in seconds) the plugin checks for new commits pushed to the PR branch
 
 The sync check compares the HEAD SHA — if nothing changed, no further API calls are made. Auto-sync is paused while commit/local viewer mode is active and resumes when you exit. In flat diff, auto-sync also skips cycles while a reply/new-thread composer contains unsent text. You can manually sync at any time with `:Raccoon sync` or the configured `shortcuts.sync` binding. Toggling between flat diff and PR commit mode preserves the last flat-diff file/thread/composer state and the last commit-viewer selection for the current PR.
 
+### `diff_renderer`
+
+Optional object controlling how raccoon renders flat diff highlights.
+
+Raccoon always includes the built-in Lua renderer. You do not need Node.js, `@pierre/diffs`, or a `diff_renderer` block for the plugin to work.
+
+The Pierre renderer is optional and affects only flat diff rendering. It still draws inside Neovim using extmarks, signs, and virtual lines. Comment creation, thread navigation, file navigation, sync, and commit viewer mode keep the same workflow.
+
+#### `diff_renderer.provider`
+
+| Type | Default |
+|------|---------|
+| string | `"auto"` |
+
+Valid values:
+
+- `"auto"`: Try the optional Pierre renderer and fall back to the built-in renderer on any failure.
+- `"builtin"`: Always use the built-in Lua renderer. This skips the optional Node process entirely.
+- `"pierre"`: Try the Pierre renderer first and fall back to the built-in renderer if Pierre fails.
+
+```json
+{
+  "diff_renderer": {
+    "provider": "builtin"
+  }
+}
+```
+
+Use `"builtin"` if you do not want raccoon to spawn Node for diff rendering.
+
+#### `diff_renderer.timeout_ms`
+
+| Type | Default |
+|------|---------|
+| number | `200` |
+
+Maximum time in milliseconds to wait for the optional Pierre renderer. If the timeout is reached, raccoon falls back to the built-in renderer for that patch.
+
+```json
+{
+  "diff_renderer": {
+    "timeout_ms": 100
+  }
+}
+```
+
+#### `diff_renderer.command`
+
+| Type | Default |
+|------|---------|
+| array or null | `null` |
+
+Command used to run the optional Pierre bridge. When unset, raccoon looks up its bundled `scripts/pierre_render.mjs` file on Neovim's runtime path and runs:
+
+```json
+["node", "<runtime path>/scripts/pierre_render.mjs"]
+```
+
+Set this only when Node cannot resolve `@pierre/diffs` from your plugin install location or when you want to run a wrapper script:
+
+```json
+{
+  "diff_renderer": {
+    "provider": "pierre",
+    "command": ["node", "/absolute/path/to/pierre_render.mjs"]
+  }
+}
+```
+
+The command must read JSON from stdin and write a render-plan JSON object to stdout. Invalid JSON, non-zero exit codes, missing executables, and missing dependencies all trigger fallback to the built-in renderer.
+
+#### `diff_renderer.inline_word_diff`
+
+| Type | Default |
+|------|---------|
+| boolean | `true` |
+
+Whether the optional Pierre bridge should request inline word-diff spans for changed lines. This setting only affects the Pierre renderer. The built-in renderer ignores it.
+
+```json
+{
+  "diff_renderer": {
+    "provider": "pierre",
+    "inline_word_diff": false
+  }
+}
+```
+
 ### `commit_viewer`
 
 Nested object controlling the commit viewer grid layout.
@@ -285,6 +375,12 @@ Partial overrides are merged with defaults — you only need to specify keys you
   "repos": ["your-username/project", "work-org/api"],
   "clone_root": "~/code/pr-reviews",
   "sync_interval": 120,
+  "diff_renderer": {
+    "provider": "auto",
+    "timeout_ms": 200,
+    "command": null,
+    "inline_word_diff": true
+  },
   "commit_viewer": {
     "grid": { "rows": 3, "cols": 2 },
     "base_commits_count": 30

--- a/config_docs.md
+++ b/config_docs.md
@@ -170,6 +170,14 @@ Raccoon always includes the built-in Lua renderer. You do not need Node.js, `@pi
 
 The Pierre renderer is optional and affects only flat diff rendering. It still draws inside Neovim using extmarks, signs, and virtual lines. Comment creation, thread navigation, file navigation, sync, and commit viewer mode keep the same workflow.
 
+To install the optional Pierre parser dependency, run this command in the `nvim-raccoon` plugin checkout that contains `scripts/pierre_render.mjs`:
+
+```sh
+pnpm add @pierre/diffs
+```
+
+For lazy.nvim, the checkout is commonly under `~/.local/share/nvim/lazy/nvim-raccoon`. If your plugin manager installed `bajor/nvim-raccoon` somewhere else, run the command in that installed directory. If you do not install this dependency, raccoon keeps using the built-in Lua renderer.
+
 #### `diff_renderer.provider`
 
 | Type | Default |

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -3,9 +3,56 @@
 local M = {}
 
 local state = require("raccoon.state")
+local has_pierre, pierre = pcall(require, "raccoon.pierre")
 
 --- Namespace for diff highlights
 local ns_id = vim.api.nvim_create_namespace("raccoon_diff")
+local pierre_plans = {}
+
+local function pierre_key(patch, filename)
+  return (filename or "") .. "\0" .. patch
+end
+
+local function remember_pierre_plan(patch, filename, plan)
+  if type(patch) ~= "string" or type(plan) ~= "table" then
+    return
+  end
+  pierre_plans[patch] = plan
+  pierre_plans[pierre_key(patch, filename)] = plan
+end
+
+local function pierre_enabled()
+  if not has_pierre or type(pierre) ~= "table" or type(pierre.is_enabled) ~= "function" then
+    return false
+  end
+  local ok, enabled = pcall(pierre.is_enabled)
+  return ok and enabled == true
+end
+
+local function get_pierre_plan(patch, filename)
+  if type(patch) ~= "string" or patch == "" or not pierre_enabled() then
+    return nil
+  end
+
+  local key = pierre_key(patch, filename)
+  if pierre_plans[key] then
+    return pierre_plans[key]
+  end
+  if pierre_plans[patch] then
+    return pierre_plans[patch]
+  end
+  if type(pierre.render_patch) ~= "function" then
+    return nil
+  end
+
+  local ok, plan = pcall(pierre.render_patch, patch, filename)
+  if ok and type(plan) == "table" then
+    remember_pierre_plan(patch, filename, plan)
+    return plan
+  end
+
+  return nil
+end
 
 --- Parse a unified diff hunk header
 --- Returns start_line, count for the new file (right side)
@@ -109,9 +156,14 @@ end
 ---@param patch string|nil
 ---@param target_line number|nil
 ---@return boolean
-function M.is_line_in_review_context(patch, target_line)
+function M.is_line_in_review_context(patch, target_line, filename)
   if type(target_line) ~= "number" or target_line < 1 then
     return false
+  end
+
+  local plan = get_pierre_plan(patch, filename)
+  if plan and type(plan.reviewable) == "table" then
+    return plan.reviewable[target_line] == true
   end
 
   local hunks = M.parse_patch(patch)
@@ -126,10 +178,71 @@ function M.is_line_in_review_context(patch, target_line)
   return false
 end
 
+--- Apply a Pierre render plan to a buffer
+---@param buf number Buffer ID
+---@param plan table Pierre render plan
+function M.apply_render_plan(buf, plan)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
+
+  if type(plan) ~= "table" then
+    return
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(buf)
+
+  for _, line_num in ipairs(plan.added or {}) do
+    local row = line_num - 1
+    if row >= 0 and row < line_count then
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+        line_hl_group = "RaccoonAdd",
+        sign_text = "+",
+        sign_hl_group = "RaccoonAddSign",
+      })
+    end
+  end
+
+  for _, deleted in ipairs(plan.deleted or {}) do
+    local target = math.max(0, math.min((deleted.line_num or 1) - 1, line_count - 1))
+    local virt_lines = {}
+    for _, row in ipairs(deleted.rows or {}) do
+      local chunks = {}
+      for _, chunk in ipairs(row) do
+        table.insert(chunks, { chunk.text or "", chunk.hl or "RaccoonDelete" })
+      end
+      table.insert(virt_lines, chunks)
+    end
+
+    if #virt_lines > 0 then
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, target, 0, {
+        virt_lines = virt_lines,
+        virt_lines_above = true,
+        sign_text = "-",
+        sign_hl_group = "RaccoonDeleteSign",
+      })
+    end
+  end
+
+  for _, span in ipairs(plan.inline_add or {}) do
+    local row = (span.line_num or 0) - 1
+    if row >= 0 and row < line_count then
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, span.start_col or 0, {
+        end_col = span.end_col,
+        hl_group = "RaccoonAddInline",
+        priority = 250,
+      })
+    end
+  end
+end
+
 --- Apply diff highlights to a buffer
 ---@param buf number Buffer ID
 ---@param patch string|nil The patch content
-function M.apply_highlights(buf, patch)
+---@param opts? table Optional renderer context
+function M.apply_highlights(buf, patch, opts)
   if not buf or not vim.api.nvim_buf_is_valid(buf) then
     return
   end
@@ -139,6 +252,11 @@ function M.apply_highlights(buf, patch)
 
   if not patch or patch == "" then
     return
+  end
+
+  local plan = get_pierre_plan(patch, opts and opts.filename or nil)
+  if plan then
+    return M.apply_render_plan(buf, plan)
   end
 
   local changes = M.get_changed_lines(patch)
@@ -249,7 +367,7 @@ function M.open_file(file)
   if file.patch then
     -- Defer to allow buffer to fully load
     vim.schedule(function()
-      M.apply_highlights(buf, file.patch)
+      M.apply_highlights(buf, file.patch, { filename = file.filename })
     end)
   end
 
@@ -347,6 +465,18 @@ local function get_current_file_diff_hunks()
   local file = state.get_current_file()
   if not file or not file.patch then
     return {}
+  end
+
+  local plan = get_pierre_plan(file.patch, file.filename)
+  if plan and type(plan.hunks) == "table" then
+    local lines = {}
+    for _, hunk in ipairs(plan.hunks) do
+      if type(hunk.start_line) == "number" then
+        table.insert(lines, hunk.start_line)
+      end
+    end
+    table.sort(lines)
+    return lines
   end
 
   local changes = M.get_changed_lines(file.patch)

--- a/lua/raccoon/diff.lua
+++ b/lua/raccoon/diff.lua
@@ -54,6 +54,17 @@ local function get_pierre_plan(patch, filename)
   return nil
 end
 
+local function has_plan_visual_marks(plan)
+  if type(plan) ~= "table" then
+    return false
+  end
+  return #(plan.added or {}) > 0 or #(plan.deleted or {}) > 0 or #(plan.inline_add or {}) > 0
+end
+
+local function has_plan_reviewable_lines(plan)
+  return type(plan) == "table" and type(plan.reviewable) == "table" and next(plan.reviewable) ~= nil
+end
+
 --- Parse a unified diff hunk header
 --- Returns start_line, count for the new file (right side)
 ---@param header string Hunk header like "@@ -1,4 +1,5 @@"
@@ -162,7 +173,7 @@ function M.is_line_in_review_context(patch, target_line, filename)
   end
 
   local plan = get_pierre_plan(patch, filename)
-  if plan and type(plan.reviewable) == "table" then
+  if has_plan_reviewable_lines(plan) then
     return plan.reviewable[target_line] == true
   end
 
@@ -255,7 +266,7 @@ function M.apply_highlights(buf, patch, opts)
   end
 
   local plan = get_pierre_plan(patch, opts and opts.filename or nil)
-  if plan then
+  if has_plan_visual_marks(plan) then
     return M.apply_render_plan(buf, plan)
   end
 
@@ -475,8 +486,10 @@ local function get_current_file_diff_hunks()
         table.insert(lines, hunk.start_line)
       end
     end
-    table.sort(lines)
-    return lines
+    if #lines > 0 then
+      table.sort(lines)
+      return lines
+    end
   end
 
   local changes = M.get_changed_lines(file.patch)

--- a/lua/raccoon/init.lua
+++ b/lua/raccoon/init.lua
@@ -5,7 +5,12 @@ local M = {}
 
 --- Default configuration
 M.config = {
-  -- Config will be loaded from ~/.config/raccoon/config.json
+  diff_renderer = {
+    provider = "auto", -- auto | builtin | pierre
+    timeout_ms = 200,
+    command = nil,
+    inline_word_diff = true,
+  },
 }
 
 --- Setup highlight groups for diff display
@@ -32,6 +37,16 @@ local function setup_highlights()
 
   vim.api.nvim_set_hl(0, "RaccoonDeleteSign", {
     fg = "#e06c75", -- Red
+    default = true,
+  })
+
+  vim.api.nvim_set_hl(0, "RaccoonAddInline", {
+    underline = true,
+    default = true,
+  })
+
+  vim.api.nvim_set_hl(0, "RaccoonDeleteInline", {
+    undercurl = true,
     default = true,
   })
 

--- a/lua/raccoon/pierre.lua
+++ b/lua/raccoon/pierre.lua
@@ -1,0 +1,117 @@
+local M = {}
+
+local cache = {}
+
+local defaults = {
+  provider = "auto",
+  timeout_ms = 200,
+  command = nil,
+  inline_word_diff = true,
+}
+
+local function cfg()
+  local core = require("raccoon")
+  return vim.tbl_deep_extend("force", defaults, (core.config or {}).diff_renderer or {})
+end
+
+function M.is_enabled()
+  local provider = cfg().provider
+  return provider == "auto" or provider == "pierre"
+end
+
+local function default_command()
+  local script = vim.api.nvim_get_runtime_file("scripts/pierre_render.mjs", false)[1]
+  if not script then
+    return nil
+  end
+  return { "node", script }
+end
+
+local function normalize_reviewable(plan)
+  local reviewable = {}
+  if type(plan.reviewable) == "table" then
+    for key, line in pairs(plan.reviewable) do
+      if type(line) == "number" then
+        reviewable[line] = true
+      elseif type(key) == "number" and line == true then
+        reviewable[key] = true
+      end
+    end
+  end
+  plan.reviewable = reviewable
+end
+
+local function validate_plan(plan)
+  if type(plan) ~= "table" or plan.version ~= 1 then
+    return false
+  end
+
+  for _, key in ipairs({ "hunks", "added", "deleted", "reviewable" }) do
+    if plan[key] ~= nil and type(plan[key]) ~= "table" then
+      return false
+    end
+    plan[key] = plan[key] or {}
+  end
+  if plan.inline_add ~= nil and type(plan.inline_add) ~= "table" then
+    return false
+  end
+  plan.inline_add = plan.inline_add or {}
+
+  normalize_reviewable(plan)
+  return true
+end
+
+function M.render_patch(patch, filename)
+  if not M.is_enabled() or type(patch) ~= "string" or patch == "" then
+    return nil, "disabled"
+  end
+
+  local key = (filename or "") .. "\0" .. patch
+  if cache[key] then
+    return cache[key], nil
+  end
+
+  local c = cfg()
+  local cmd = c.command or default_command()
+  if type(cmd) ~= "table" or not cmd[1] then
+    return nil, "missing command"
+  end
+  if type(vim.system) ~= "function" then
+    return nil, "missing vim.system"
+  end
+
+  local payload = vim.json.encode({
+    patch = patch,
+    filename = filename,
+    inline_word_diff = c.inline_word_diff ~= false,
+  })
+
+  local ok, job_or_err = pcall(vim.system, cmd, { text = true, stdin = payload })
+  if not ok then
+    return nil, tostring(job_or_err)
+  end
+
+  local wait_ok, result = pcall(function()
+    return job_or_err:wait(c.timeout_ms)
+  end)
+  if not wait_ok then
+    return nil, tostring(result)
+  end
+  if result == nil then
+    return nil, "timeout"
+  end
+  if result.code ~= 0 then
+    local stderr = result.stderr or ""
+    return nil, stderr ~= "" and stderr or ("exit " .. tostring(result.code))
+  end
+
+  local decode_ok, decoded = pcall(vim.json.decode, result.stdout or "")
+  if not decode_ok or not validate_plan(decoded) then
+    return nil, "invalid json"
+  end
+
+  cache[key] = decoded
+  return decoded, nil
+end
+
+return M

--- a/scripts/pierre_render.mjs
+++ b/scripts/pierre_render.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { stdin, stdout, stderr, exit } from "node:process";
+import { Buffer } from "node:buffer";
+
+function cleanLine(value) {
+  return String(value ?? "").replace(/\r?\n$/, "");
+}
+
+function byteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function deletedChunks(oldText, newText, diffWordsWithSpace) {
+  if (typeof diffWordsWithSpace !== "function") {
+    return [{ text: `- ${oldText}`, hl: "RaccoonDelete" }];
+  }
+
+  const chunks = [{ text: "- ", hl: "RaccoonDelete" }];
+  for (const part of diffWordsWithSpace(oldText, newText)) {
+    if (part.added) {
+      continue;
+    }
+    chunks.push({
+      text: part.value,
+      hl: part.removed ? "RaccoonDeleteInline" : "RaccoonDelete",
+    });
+  }
+  return chunks;
+}
+
+function addedSpans(oldText, newText, lineNum, diffWordsWithSpace) {
+  if (typeof diffWordsWithSpace !== "function") {
+    return [];
+  }
+
+  const spans = [];
+  let col = 0;
+  for (const part of diffWordsWithSpace(oldText, newText)) {
+    if (part.removed) {
+      continue;
+    }
+
+    const width = byteLength(part.value);
+    if (part.added && width > 0) {
+      spans.push({
+        line_num: lineNum,
+        start_col: col,
+        end_col: col + width,
+      });
+    }
+    col += width;
+  }
+  return spans;
+}
+
+async function readStdin() {
+  let body = "";
+  for await (const chunk of stdin) {
+    body += chunk;
+  }
+  return body;
+}
+
+async function main() {
+  let input;
+  try {
+    input = JSON.parse((await readStdin()) || "{}");
+  } catch {
+    stderr.write("invalid input json\n");
+    exit(1);
+  }
+
+  let parsePatchFiles;
+  try {
+    ({ parsePatchFiles } = await import("@pierre/diffs"));
+  } catch {
+    stderr.write("missing @pierre/diffs\n");
+    exit(1);
+  }
+
+  let diffWordsWithSpace;
+  if (input.inline_word_diff !== false) {
+    try {
+      ({ diffWordsWithSpace } = await import("diff"));
+    } catch {
+      diffWordsWithSpace = undefined;
+    }
+  }
+
+  let patches;
+  try {
+    patches = parsePatchFiles(String(input.patch || ""));
+  } catch {
+    stderr.write("failed to parse patch\n");
+    exit(1);
+  }
+
+  const fileDiff = patches?.[0]?.files?.[0];
+  if (!fileDiff) {
+    stdout.write(
+      JSON.stringify({
+        version: 1,
+        hunks: [],
+        added: [],
+        deleted: [],
+        reviewable: [],
+        inline_add: [],
+      })
+    );
+    return;
+  }
+
+  const added = [];
+  const deleted = [];
+  const reviewable = new Set();
+  const inlineAdd = [];
+  const hunks = [];
+
+  for (const hunk of fileDiff.hunks || []) {
+    const hunkStart = Math.max(hunk.additionStart || 1, 1);
+    hunks.push({
+      start_line: hunkStart,
+      end_line: hunkStart + Math.max(hunk.additionCount || 0, 1) - 1,
+    });
+
+    let addIdx = hunk.additionLineIndex || 0;
+    let delIdx = hunk.deletionLineIndex || 0;
+    let anchor = hunkStart;
+
+    for (const part of hunk.hunkContent || []) {
+      if (part.type === "context") {
+        for (let i = 0; i < part.lines; i++) {
+          reviewable.add(anchor + i);
+        }
+        addIdx += part.lines;
+        delIdx += part.lines;
+        anchor += part.lines;
+        continue;
+      }
+
+      const rows = [];
+      const pairedRows = Math.min(part.deletions, part.additions);
+      for (let i = 0; i < part.deletions; i++) {
+        const oldText = cleanLine(fileDiff.deletionLines?.[delIdx + i]);
+        const newText =
+          i < pairedRows ? cleanLine(fileDiff.additionLines?.[addIdx + i]) : "";
+        rows.push(deletedChunks(oldText, newText, diffWordsWithSpace));
+      }
+      if (rows.length > 0) {
+        deleted.push({ line_num: Math.max(anchor, 1), rows });
+      }
+
+      for (let i = 0; i < part.additions; i++) {
+        const lineNum = anchor + i;
+        added.push(lineNum);
+        reviewable.add(lineNum);
+        if (i < pairedRows) {
+          inlineAdd.push(
+            ...addedSpans(
+              cleanLine(fileDiff.deletionLines?.[delIdx + i]),
+              cleanLine(fileDiff.additionLines?.[addIdx + i]),
+              lineNum,
+              diffWordsWithSpace
+            )
+          );
+        }
+      }
+
+      addIdx += part.additions;
+      delIdx += part.deletions;
+      anchor += part.additions;
+    }
+  }
+
+  stdout.write(
+    JSON.stringify({
+      version: 1,
+      hunks,
+      added,
+      deleted,
+      reviewable: Array.from(reviewable).sort((a, b) => a - b),
+      inline_add: inlineAdd,
+    })
+  );
+}
+
+main().catch((err) => {
+  stderr.write(`${String(err)}\n`);
+  exit(1);
+});

--- a/scripts/pierre_render.mjs
+++ b/scripts/pierre_render.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { stdin, stdout, stderr, exit } from "node:process";
 import { Buffer } from "node:buffer";
+import { createRequire } from "node:module";
 
 function cleanLine(value) {
   return String(value ?? "").replace(/\r?\n$/, "");
@@ -62,6 +63,25 @@ function normalizePatch(patch, filename) {
   return `diff --git a/${safeName} b/${safeName}\n--- a/${safeName}\n+++ b/${safeName}\n${patch}`;
 }
 
+async function loadDiffWordsWithSpace() {
+  try {
+    return (await import("diff")).diffWordsWithSpace;
+  } catch {
+    // pnpm keeps transitive dependencies nested, so resolve diff from Pierre's package root.
+  }
+
+  try {
+    if (typeof import.meta.resolve !== "function") {
+      return undefined;
+    }
+
+    const pierreRequire = createRequire(import.meta.resolve("@pierre/diffs"));
+    return (await import(pierreRequire.resolve("diff"))).diffWordsWithSpace;
+  } catch {
+    return undefined;
+  }
+}
+
 async function readStdin() {
   let body = "";
   for await (const chunk of stdin) {
@@ -89,11 +109,7 @@ async function main() {
 
   let diffWordsWithSpace;
   if (input.inline_word_diff !== false) {
-    try {
-      ({ diffWordsWithSpace } = await import("diff"));
-    } catch {
-      diffWordsWithSpace = undefined;
-    }
+    diffWordsWithSpace = await loadDiffWordsWithSpace();
   }
 
   let patches;

--- a/scripts/pierre_render.mjs
+++ b/scripts/pierre_render.mjs
@@ -53,6 +53,15 @@ function addedSpans(oldText, newText, lineNum, diffWordsWithSpace) {
   return spans;
 }
 
+function normalizePatch(patch, filename) {
+  if (!patch || /^diff --git /m.test(patch) || /^--- /m.test(patch) || /^\+\+\+ /m.test(patch)) {
+    return patch;
+  }
+
+  const safeName = String(filename || "file").replace(/[\r\n]/g, " ");
+  return `diff --git a/${safeName} b/${safeName}\n--- a/${safeName}\n+++ b/${safeName}\n${patch}`;
+}
+
 async function readStdin() {
   let body = "";
   for await (const chunk of stdin) {
@@ -89,7 +98,7 @@ async function main() {
 
   let patches;
   try {
-    patches = parsePatchFiles(String(input.patch || ""));
+    patches = parsePatchFiles(normalizePatch(String(input.patch || ""), input.filename));
   } catch {
     stderr.write("failed to parse patch\n");
     exit(1);

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -1,11 +1,17 @@
 local diff = require("raccoon.diff")
+local raccoon = require("raccoon")
 local state = require("raccoon.state")
 
 describe("raccoon.diff", function()
+  local original_config = vim.deepcopy(raccoon.config)
+
   before_each(function()
     state.reset()
   end)
 
+  after_each(function()
+    raccoon.config = vim.deepcopy(original_config)
+  end)
 
   describe("parse_hunk_header", function()
     it("parses standard hunk header", function()
@@ -469,6 +475,219 @@ describe("raccoon.diff", function()
       -- Verify namespace was used
       local ns = diff.get_namespace()
       assert.is_number(ns)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+  end)
+
+  describe("pierre render plans", function()
+    local original_system
+    local original_pierre
+
+    local function reload_diff_with_pierre(fake_pierre)
+      package.loaded["raccoon.diff"] = nil
+      package.loaded["raccoon.pierre"] = fake_pierre
+      diff = require("raccoon.diff")
+      return diff
+    end
+
+    local function reload_diff_with_real_pierre()
+      package.loaded["raccoon.diff"] = nil
+      package.loaded["raccoon.pierre"] = nil
+      diff = require("raccoon.diff")
+      return diff
+    end
+
+    local function get_extmarks(buf)
+      return vim.api.nvim_buf_get_extmarks(buf, diff.get_namespace(), 0, -1, { details = true })
+    end
+
+    local function has_extmark_with(buf, predicate)
+      for _, mark in ipairs(get_extmarks(buf)) do
+        if predicate(mark[4] or {}) then
+          return true
+        end
+      end
+      return false
+    end
+
+    local function create_buf(lines)
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      return buf
+    end
+
+    local function assert_builtin_fallback_marks_addition(buf)
+      assert.is_true(has_extmark_with(buf, function(details)
+        return type(details.sign_text) == "string"
+          and details.sign_text:match("^%+")
+          and details.line_hl_group == "RaccoonAdd"
+      end))
+    end
+
+    before_each(function()
+      original_system = vim.system
+      original_pierre = package.loaded["raccoon.pierre"]
+      raccoon.config.diff_renderer = {
+        provider = "pierre",
+        timeout_ms = 25,
+        command = { "node", "stub" },
+        inline_word_diff = true,
+      }
+    end)
+
+    after_each(function()
+      vim.system = original_system
+      package.loaded["raccoon.diff"] = nil
+      package.loaded["raccoon.pierre"] = original_pierre
+      diff = require("raccoon.diff")
+    end)
+
+    it("applies extmarks from a Pierre render plan", function()
+      local plan = {
+        version = 1,
+        added = { 2 },
+        deleted = {
+          {
+            line_num = 3,
+            rows = {
+              {
+                { text = "- old value", hl = "RaccoonDelete" },
+              },
+            },
+          },
+        },
+        reviewable = { [2] = true },
+        hunks = { { start_line = 2, end_line = 3 } },
+        inline_add = {
+          { line_num = 2, start_col = 4, end_col = 9 },
+        },
+      }
+
+      reload_diff_with_pierre({
+        is_enabled = function()
+          return true
+        end,
+        render_patch = function()
+          return plan
+        end,
+      })
+
+      local buf = create_buf({ "line 1", "new value", "line 3" })
+      diff.apply_highlights(buf, "@@ -1,2 +1,3 @@\n line 1\n+new value\n line 3", { filename = "x.lua" })
+
+      assert.is_true(has_extmark_with(buf, function(details)
+        return type(details.sign_text) == "string"
+          and details.sign_text:match("^%+")
+          and details.line_hl_group == "RaccoonAdd"
+      end))
+      assert.is_true(has_extmark_with(buf, function(details)
+        return type(details.sign_text) == "string" and details.sign_text:match("^%-") and details.virt_lines ~= nil
+      end))
+      assert.is_true(has_extmark_with(buf, function(details)
+        return details.hl_group == "RaccoonAddInline"
+      end))
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("falls back to builtin highlights when Pierre returns invalid JSON", function()
+      local calls = 0
+      vim.system = function()
+        calls = calls + 1
+        return {
+          wait = function()
+            return { code = 0, stdout = "not json", stderr = "" }
+          end,
+        }
+      end
+
+      reload_diff_with_real_pierre()
+
+      local buf = create_buf({ "line 1", "new value", "line 2" })
+      diff.apply_highlights(buf, "@@ -1,2 +1,3 @@\n line 1\n+new value\n line 2", { filename = "x.lua" })
+
+      assert.equals(1, calls)
+      assert_builtin_fallback_marks_addition(buf)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("falls back to builtin highlights when the Pierre process fails", function()
+      local calls = 0
+      vim.system = function()
+        calls = calls + 1
+        return {
+          wait = function()
+            return { code = 1, stdout = "", stderr = "boom" }
+          end,
+        }
+      end
+
+      reload_diff_with_real_pierre()
+
+      local buf = create_buf({ "line 1", "new value", "line 2" })
+      diff.apply_highlights(buf, "@@ -1,2 +1,3 @@\n line 1\n+new value\n line 2", { filename = "x.lua" })
+
+      assert.equals(1, calls)
+      assert_builtin_fallback_marks_addition(buf)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
+    it("uses plan reviewable lines when present", function()
+      reload_diff_with_pierre({
+        is_enabled = function()
+          return true
+        end,
+        render_patch = function()
+          return {
+            version = 1,
+            reviewable = { [50] = true },
+            hunks = {},
+            added = {},
+            deleted = {},
+          }
+        end,
+      })
+
+      assert.is_true(diff.is_line_in_review_context("@@ -1,1 +1,1 @@\n line 1", 50))
+      assert.is_false(diff.is_line_in_review_context("@@ -1,1 +1,1 @@\n line 1", 1))
+    end)
+
+    it("uses plan hunk starts for diff navigation when present", function()
+      reload_diff_with_pierre({
+        is_enabled = function()
+          return true
+        end,
+        render_patch = function()
+          return {
+            version = 1,
+            reviewable = {},
+            hunks = {
+              { start_line = 40, end_line = 41 },
+            },
+            added = {},
+            deleted = {},
+          }
+        end,
+      })
+
+      local lines = {}
+      for i = 1, 50 do
+        table.insert(lines, "line " .. i)
+      end
+      local buf = create_buf(lines)
+      vim.api.nvim_set_current_buf(buf)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      state.start({ owner = "o", repo = "r", number = 1, clone_path = "/tmp/raccoon-test" })
+      state.set_files({
+        { filename = "x.lua", patch = "@@ -1,1 +2,1 @@\n+new value" },
+      })
+
+      assert.is_true(diff.next_diff())
+      assert.equals(40, vim.api.nvim_win_get_cursor(0)[1])
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -613,6 +613,31 @@ describe("raccoon.diff", function()
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
 
+    it("falls back to builtin highlights when Pierre returns an empty render plan", function()
+      reload_diff_with_pierre({
+        is_enabled = function()
+          return true
+        end,
+        render_patch = function()
+          return {
+            version = 1,
+            reviewable = {},
+            hunks = {},
+            added = {},
+            deleted = {},
+            inline_add = {},
+          }
+        end,
+      })
+
+      local buf = create_buf({ "line 1", "new value", "line 2" })
+      diff.apply_highlights(buf, "@@ -1,2 +1,3 @@\n line 1\n+new value\n line 2", { filename = "x.lua" })
+
+      assert_builtin_fallback_marks_addition(buf)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
     it("falls back to builtin highlights when the Pierre process fails", function()
       local calls = 0
       vim.system = function()

--- a/tests/pierre_spec.lua
+++ b/tests/pierre_spec.lua
@@ -1,0 +1,127 @@
+local raccoon = require("raccoon")
+
+describe("raccoon.pierre", function()
+  local original_config = vim.deepcopy(raccoon.config)
+  local original_system
+
+  local function reload_pierre()
+    package.loaded["raccoon.pierre"] = nil
+    return require("raccoon.pierre")
+  end
+
+  before_each(function()
+    original_system = vim.system
+    raccoon.config.diff_renderer = {
+      provider = "auto",
+      timeout_ms = 25,
+      command = { "node", "stub" },
+      inline_word_diff = true,
+    }
+  end)
+
+  after_each(function()
+    vim.system = original_system
+    raccoon.config = vim.deepcopy(original_config)
+    package.loaded["raccoon.pierre"] = nil
+  end)
+
+  it("is disabled in builtin mode", function()
+    raccoon.config.diff_renderer.provider = "builtin"
+    vim.system = function()
+      error("vim.system should not be called when Pierre is disabled")
+    end
+
+    local pierre = reload_pierre()
+    local plan, err = pierre.render_patch("@@ -1,1 +1,1 @@\n line", "x.lua")
+
+    assert.is_nil(plan)
+    assert.equals("disabled", err)
+  end)
+
+  it("runs the configured command, decodes JSON, and caches successful plans", function()
+    local calls = {}
+    vim.system = function(cmd, opts)
+      table.insert(calls, { cmd = cmd, opts = opts })
+      return {
+        wait = function(_, timeout)
+          calls[#calls].timeout = timeout
+          return {
+            code = 0,
+            stdout = vim.json.encode({
+              version = 1,
+              hunks = { { start_line = 10, end_line = 12 } },
+              added = { 11 },
+              deleted = {},
+              reviewable = { 10, 11, 12 },
+              inline_add = {},
+            }),
+            stderr = "",
+          }
+        end,
+      }
+    end
+
+    local pierre = reload_pierre()
+    local plan, err = pierre.render_patch("@@ -10,2 +10,3 @@\n line\n+new\n line", "x.lua")
+    local cached = pierre.render_patch("@@ -10,2 +10,3 @@\n line\n+new\n line", "x.lua")
+
+    assert.is_nil(err)
+    assert.equals(1, #calls)
+    assert.same({ "node", "stub" }, calls[1].cmd)
+    assert.equals(25, calls[1].timeout)
+    assert.equals("x.lua", vim.json.decode(calls[1].opts.stdin).filename)
+    assert.is_true(vim.json.decode(calls[1].opts.stdin).inline_word_diff)
+    assert.is_true(plan.reviewable[10])
+    assert.is_true(plan.reviewable[11])
+    assert.is_true(plan.reviewable[12])
+    assert.same(plan, cached)
+  end)
+
+  it("returns an error when the process exits non-zero", function()
+    vim.system = function()
+      return {
+        wait = function()
+          return { code = 1, stdout = "", stderr = "missing @pierre/diffs" }
+        end,
+      }
+    end
+
+    local pierre = reload_pierre()
+    local plan, err = pierre.render_patch("@@ -1,1 +1,1 @@\n line", "x.lua")
+
+    assert.is_nil(plan)
+    assert.equals("missing @pierre/diffs", err)
+  end)
+
+  it("returns an error when the process times out", function()
+    vim.system = function()
+      return {
+        wait = function()
+          return nil
+        end,
+      }
+    end
+
+    local pierre = reload_pierre()
+    local plan, err = pierre.render_patch("@@ -1,1 +1,1 @@\n line", "x.lua")
+
+    assert.is_nil(plan)
+    assert.equals("timeout", err)
+  end)
+
+  it("returns an error for invalid JSON", function()
+    vim.system = function()
+      return {
+        wait = function()
+          return { code = 0, stdout = "{", stderr = "" }
+        end,
+      }
+    end
+
+    local pierre = reload_pierre()
+    local plan, err = pierre.render_patch("@@ -1,1 +1,1 @@\n line", "x.lua")
+
+    assert.is_nil(plan)
+    assert.equals("invalid json", err)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Add optional `diff_renderer` config with `auto`, `builtin`, and `pierre` provider modes.
- Add a Lua Pierre adapter plus Node bridge that parses patches with `@pierre/diffs` when available.
- Keep flat review rendering in Neovim with extmarks, signs, virtual lines, and builtin fallback on adapter failure.
- Add Plenary coverage for adapter errors, fallback behavior, render-plan extmarks, reviewable lines, and hunk navigation.

## Notes
- This PR intentionally keeps the change in one branch/PR per request.
- `@pierre/diffs` and Node remain optional; missing or failing sidecar execution falls back to the current Lua renderer.
- Commit viewer behavior is unchanged.

## Test Plan
- `make test`
- `make lint`
