### PR TITLE
docs: document nvim-raccoon-diffs extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- Documented the optional [nvim-raccoon-diffs](https://github.com/bajor/nvim-raccoon-diffs) extension for stronger word-level inline diff highlighting in supported Raccoon views.
+
 ## [0.13.2] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.13.3] - 2026-07-18
 
 ### Added
 - Documented the optional [nvim-raccoon-diffs](https://github.com/bajor/nvim-raccoon-diffs) extension for stronger word-level inline diff highlighting in supported Raccoon views.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 }
 ```
 
+## Inline Diff Extension (Optional)
+
+For stronger word-level highlighting inside changed lines, install
+[nvim-raccoon-diffs](https://github.com/bajor/nvim-raccoon-diffs) after
+raccoon.nvim.
+
+`nvim-raccoon-diffs` is a separate extension plugin. It observes supported
+Raccoon diff views and adds extension-owned highlights for the words or text
+fragments that changed inside paired lines. Raccoon still owns PR opening,
+comments, commit viewer mode, local commit viewing, sync, and merge actions.
+No extra command or keymap is required after the extension is configured.
+
+```lua
+{
+  "bajor/nvim-raccoon-diffs",
+  main = "raccoon_inline_diff",
+  dependencies = { "bajor/nvim-raccoon" },
+  opts = {},
+}
+```
+
+See the
+[nvim-raccoon-diffs README](https://github.com/bajor/nvim-raccoon-diffs) for
+compatibility details and optional diagnostics settings.
+
 ## Configuration
 
 Run `:Raccoon config` to create and open the config file at `~/.config/raccoon/config.json`. A minimal config looks like this:


### PR DESCRIPTION
## Summary

- Add a visible optional README section for the `nvim-raccoon-diffs` extension.
- Link to https://github.com/bajor/nvim-raccoon-diffs and describe it as a separate plugin that adds stronger word/text-fragment highlights inside supported Raccoon diff views.
- Add an Unreleased changelog entry for the documentation update.

## Validation

- `make test`
- `make lint`
- `git diff --check`

## Review notes

This is documentation-only. There is no architecture, workflow, data-flow, storage-layout, or API-contract change, so no visual explanation SVG is included.